### PR TITLE
[feature] pattern matching | improvement to demand-propagation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
     - name: Build
       run: cargo build --verbose --workspace
     - name: Run tests (release)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: "1.95"
+        components: rustfmt, clippy
     - name: Build
       run: cargo build --verbose --workspace
     - name: Run tests (release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 0.5.2 — unreleased
+
+### Pattern Matching
+
+- New `match scrutinee with { pat -> body, ... }` expression with first-match
+  semantics, optional `when` guards, and full composition with `.map`,
+  `.filter`, pipelines, and postfix navigation.
+- Pattern forms: wildcard `_`, scalar literal, identifier bind, kind-bind
+  `s: string`, kind-only `string`, object pattern `{k: pat}`, array pattern
+  `[a, b]`, array head/tail `[head, ...tail]`, or-pattern `a | b | c`,
+  numeric range `1..10` / `0..=100` (negative and float bounds supported),
+  and parenthesised sub-patterns.
+- Object rest binding `{k: pat, ...*rest}` captures every unlisted key as a
+  freshly built `Val::Obj`; the `...*expr` sigil is also accepted in object
+  body position as a shallow-spread synonym.
+- Deep search variants: `$..match { arms }` walks every descendant in DFS
+  pre-order and collects truthy arm-body results; `$..match! { arms }`
+  is the early-stop variant returning the first truthy result.
+- Compile-time analyses: or-pattern linearity check at parse, optional
+  exhaustiveness lint via `JETRO_STRICT_MATCH=1`, shape summary
+  (`ObjAnyOfKeys` / `KindOnly` / `NumericRange`) for runtime pre-filter and
+  structural dispatch.
+- Runtime: flat `MatchOp` decision-machine VM with cross-arm shared-prefix
+  hoisting (single-key, multi-key, array-length, kind variants) and partial
+  prefix sharing for mixed-suffix arm lists; or-of-literals lowers to a flat
+  `LitEq + Jump` cascade; or-with-binders falls back to a tree-walk helper.
+- View-domain runtime `exec_match_view<V: ValueView>` runs pattern tests
+  against borrowed views; pipeline `MatchFilter` / `MatchMap` stages dispatch
+  through it directly to skip per-row VM opcode dispatch.
+- Bitmap-backed `..match` via `jetro-experimental`: when every arm shares an
+  object key prefix, the planner emits `StructuralPlan::DeepMatch` and
+  enumerates candidates from the structural index instead of walking the
+  full document tree.
+- Demand model integration: `ChainOp::Match { Predicate, Transform, Multi }`
+  classifies match-bodied stages so `Take`, `find`, and `count` correctly cut
+  upstream demand through `.filter(match @ ...)` chains.
+- Bench harness: `cargo bench -p jetro-core --bench match_bench` exercises
+  `match_filter_take`, `match_dispatch_5_arms`, `match_range_scan`. Reference
+  baseline saved as `match-v0.6`.
+
+### Reserved keywords added
+
+- `match`, `with`
+
 ## 0.5.1 — 2026-05-06
 
 ### Architecture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,12 +114,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -122,6 +226,12 @@ checksum = "f34e9ee8e65c0d46c9d0fe55ce80b477d0bfae4c786c6694687b9c70e8267027"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -148,6 +258,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -200,6 +316,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "halfbrown"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hifijson"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +372,26 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -306,6 +459,7 @@ dependencies = [
 name = "jetro-core"
 version = "0.5.1"
 dependencies = [
+ "criterion",
  "indexmap",
  "itoa",
  "jaq-core",
@@ -500,6 +654,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "pest"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +804,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "self_cell"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +936,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +992,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -863,6 +1052,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "jetro"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "jetro-core",
  "serde_json",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "jetro-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["jetro-core/fuzz"]
 
 [package]
 name = "jetro"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Milad (Mike) Taghavi <mitghi.at.me.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ $.cart.items.filter(qty == 0).delete()
 patch $ { .user.active: true }
 ```
 
+### Pattern Match
+
+```text
+match $.user with {
+    {role: "admin"}                    -> "full",
+    {role: "user", verified: true}     -> "limited",
+    {role: r, ...*rest}                -> {...*rest, role: r},
+    _                                  -> "denied"
+}
+
+$..match {
+    {tag: "click", id: i} -> i,
+    _                     -> false
+}
+```
+
 Full syntax reference: [jetro-core/src/SYNTAX.md](jetro-core/src/SYNTAX.md)
 
 ## Examples
@@ -252,6 +268,19 @@ let result = jetro.collect("$..price")?;
 
 ```rust
 let result = jetro.collect("$.user.name.set('Ada')")?;
+```
+
+### Pattern match
+
+```rust
+let result = jetro.collect(r#"
+$.events.map(match @ with {
+    {tag: "view",  path: p}  -> {sort: "view",  v: p},
+    {tag: "click", id: i}    -> {sort: "click", v: i},
+    {tag: "error", code: c}  -> {sort: "error", v: c},
+    _                        -> {sort: "other"}
+})
+"#)?;
 ```
 
 ## Execution Model

--- a/jetro-core/Cargo.toml
+++ b/jetro-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jetro-core"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Milad (Mike) Taghavi <mitghi.at.me.com>"]
 license = "MIT"

--- a/jetro-core/Cargo.toml
+++ b/jetro-core/Cargo.toml
@@ -39,3 +39,8 @@ fuzz_internal = []
 jaq-core = "3.0"
 jaq-std = "3.0"
 jaq-json = "2.0"
+criterion = { version = "0.5", default-features = false }
+
+[[bench]]
+name = "match_bench"
+harness = false

--- a/jetro-core/benches/README.md
+++ b/jetro-core/benches/README.md
@@ -1,0 +1,45 @@
+# jetro-core benches
+
+Microbenchmarks for the query engine. Driven by [criterion].
+
+## Layout
+
+- `match_bench.rs` — pattern-match runtime workloads.
+
+Run with:
+
+```
+cargo bench -p jetro-core --bench match_bench
+```
+
+To compare against a saved baseline:
+
+```
+cargo bench -p jetro-core --bench match_bench -- --baseline match-v0.6
+```
+
+To save a new baseline:
+
+```
+cargo bench -p jetro-core --bench match_bench -- --save-baseline <name>
+```
+
+## Baselines
+
+Baselines live under `target/criterion/<bench>/<baseline>/` and are not
+committed (the `target/` directory is gitignored). Each benchmark
+target prints its current sample mean to stdout; recorded reference
+numbers below are from a Mac M-series host running on macOS.
+
+| Baseline name | Workload | Mean (mid) | Notes |
+|---------------|----------|------------|-------|
+| `match-v0.6` | `match_filter_take` | ~64 µs | `.filter(match @ ...).take(3)` over a 1024-row int array. |
+| `match-v0.6` | `match_dispatch_5_arms` | ~1.04 ms | Tagged-union dispatch over 1024 events with 5 arms (cross-arm prefix sharing active). |
+| `match-v0.6` | `match_range_scan` | ~148 µs | Range-pattern dispatch over a 1024-row int array. |
+
+Numbers are end-to-end (parse + compile + execute per iteration). To
+benchmark steady-state hot-path execution, build a `JetroEngine` once
+and reuse the cached plan across iterations — see `lib.rs::JetroEngine`
+for the API.
+
+[criterion]: https://docs.rs/criterion

--- a/jetro-core/benches/match_bench.rs
+++ b/jetro-core/benches/match_bench.rs
@@ -1,0 +1,112 @@
+//! Microbenchmarks for the `match` runtime.
+//!
+//! Workloads:
+//! - `match_filter_take`: Take the first three rows that satisfy a
+//!   single-arm match predicate, exercising the demand cutoff path.
+//! - `match_dispatch_5_arms`: Tagged-union dispatch across five arms
+//!   over a thousand-row array, exercising the cross-arm shared-prefix
+//!   optimisation.
+//! - `match_range_scan`: Range-pattern dispatch over an integer array,
+//!   exercising the `RangeCheck` opcode and `val_to_f64` widening.
+//!
+//! Run with `cargo bench -p jetro-core --bench match_bench`. Each
+//! benchmark builds a fresh `Jetro` document per iteration so the
+//! reported numbers are end-to-end (parse + compile + execute), not
+//! steady-state. Add a baseline with
+//! `cargo bench -p jetro-core --bench match_bench -- --save-baseline current`
+//! to compare future runs.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use jetro_core::Jetro;
+
+fn make_filter_doc() -> Vec<u8> {
+    let mut buf = String::from(r#"{"xs":["#);
+    for i in 0..1024 {
+        if i > 0 {
+            buf.push(',');
+        }
+        buf.push_str(&i.to_string());
+    }
+    buf.push_str("]}");
+    buf.into_bytes()
+}
+
+fn make_dispatch_doc() -> Vec<u8> {
+    let mut buf = String::from(r#"{"events":["#);
+    let tags = ["view", "click", "submit", "error", "drop"];
+    for i in 0..1024 {
+        if i > 0 {
+            buf.push(',');
+        }
+        let tag = tags[i % tags.len()];
+        buf.push_str(&format!(r#"{{"tag":"{tag}","id":{i}}}"#));
+    }
+    buf.push_str("]}");
+    buf.into_bytes()
+}
+
+fn match_filter_take(c: &mut Criterion) {
+    let doc = make_filter_doc();
+    c.bench_function("match_filter_take", |b| {
+        b.iter(|| {
+            let j = Jetro::from_bytes(doc.clone()).expect("parse");
+            black_box(
+                j.collect(
+                    r#"$.xs.filter(match @ with {
+                        n when n > 100 -> true,
+                        _              -> false
+                    }).take(3)"#,
+                )
+                .expect("eval"),
+            )
+        })
+    });
+}
+
+fn match_dispatch_5_arms(c: &mut Criterion) {
+    let doc = make_dispatch_doc();
+    c.bench_function("match_dispatch_5_arms", |b| {
+        b.iter(|| {
+            let j = Jetro::from_bytes(doc.clone()).expect("parse");
+            black_box(
+                j.collect(
+                    r#"$.events.map(match @ with {
+                        {tag: "view",   id: i} -> {sort: 0, n: i},
+                        {tag: "click",  id: i} -> {sort: 1, n: i},
+                        {tag: "submit", id: i} -> {sort: 2, n: i},
+                        {tag: "error",  id: i} -> {sort: 3, n: i},
+                        _                      -> {sort: 4, n: 0}
+                    })"#,
+                )
+                .expect("eval"),
+            )
+        })
+    });
+}
+
+fn match_range_scan(c: &mut Criterion) {
+    let doc = make_filter_doc();
+    c.bench_function("match_range_scan", |b| {
+        b.iter(|| {
+            let j = Jetro::from_bytes(doc.clone()).expect("parse");
+            black_box(
+                j.collect(
+                    r#"$.xs.map(match @ with {
+                        0..=100      -> "small",
+                        101..=500    -> "medium",
+                        _            -> "large"
+                    })"#,
+                )
+                .expect("eval"),
+            )
+        })
+    });
+}
+
+criterion_group!(
+    match_benches,
+    match_filter_take,
+    match_dispatch_5_arms,
+    match_range_scan
+);
+criterion_main!(match_benches);

--- a/jetro-core/src/SYNTAX.md
+++ b/jetro-core/src/SYNTAX.md
@@ -635,6 +635,162 @@ to_tsv    // TAB-separated variant
 
 ---
 
+## 21. Pattern Matching
+
+`match scrutinee with { pat -> body, ... }` evaluates the scrutinee and runs
+each arm's pattern in order. The first arm whose pattern (and optional `when`
+guard) matches has its body evaluated and returned. A non-exhaustive match
+that misses every arm raises a runtime error.
+
+### Basic shape
+
+```
+match $.user with {
+    {role: "admin"}                    -> "full access",
+    {role: "user", verified: true}     -> "limited",
+    {role: "guest"}                    -> "readonly",
+    _                                  -> "denied"
+}
+```
+
+The `with` separator is required; it disambiguates the arm block from the
+postfix inline-filter syntax (`expr { pred }`).
+
+### Pattern forms
+
+| Form | Meaning |
+|------|---------|
+| `_` | Wildcard — always matches, no binding |
+| `null`, `true`, `42`, `3.14`, `"x"` | Literal — matches by structural equality |
+| `name` | Bind — captures the whole value into `name` |
+| `name@pat` *(reserved)* | As-pattern — bind whole value AND match sub-pattern |
+| `{k: pat, ...}` | Object — listed keys must be present and match; extras allowed |
+| `{k: pat, ...*rest}` | Object with rest binding — captures unlisted keys to `rest` |
+| `{k: pat, ...*}` | Object with anonymous rest — informational; same as no marker |
+| `[a, b]` | Array — exact length, element-wise match |
+| `[head, ...tail]` | Array head/tail — captures remainder to `tail` |
+| `[a, ...]` | Array with anonymous rest — accepts any length `>= prefix` |
+| `s: string`, `n: number` | Kind-bind — matches scalar kind, binds the value |
+| `string`, `number` | Kind-only — matches scalar kind, no binding |
+| `1..10`, `0..=100` | Numeric range — exclusive `..` or inclusive `..=`, ints or floats |
+| `a \| b \| c` | Or — first alt that matches wins; alts must bind same names |
+
+### Guards
+
+```
+match $.x with {
+    n when n > 100  -> "big",
+    n when n > 10   -> "medium",
+    _               -> "small"
+}
+```
+
+Guards run after the pattern binds; full expression syntax is allowed.
+Builtins compose naturally:
+
+```
+match $.user with {
+    {email: e} when e.ends_with("@corp.com")    -> "internal",
+    {email: e} when e.contains("admin")          -> "admin-ish",
+    _                                            -> "external"
+}
+```
+
+### Object rest pattern
+
+`{k: v, ...*rest}` captures every key not listed in the pattern into a
+fresh `Val::Obj`. The same `...*expr` sigil is accepted in object body
+position as a shallow-spread synonym, so capture and splat use symmetric
+syntax:
+
+```
+match $.u with {
+    {a: a_old, c: c_old, ...*rest} -> {...*rest, a: "new", c: c_old},
+    _                              -> @
+}
+```
+
+### Range patterns
+
+```
+match $.code with {
+    200..300  -> "ok",
+    400..500  -> "client_error",
+    500..600  -> "server_error",
+    _         -> "unknown"
+}
+```
+
+Bounds may be integer or float; integer scrutinees widen to `f64` for the
+comparison. Negative bounds (`-10..0`) and inclusive upper (`0..=100`)
+are supported.
+
+### Or-patterns
+
+```
+match $.method with {
+    "GET" | "HEAD"                     -> "safe",
+    "POST" | "PUT" | "PATCH"           -> "write",
+    "DELETE"                           -> "destructive"
+}
+```
+
+Every alternative must bind the same set of variable names; the parser
+rejects `{a: x} | {b: y}` because the body cannot consistently reference
+either binding.
+
+### Deep matching
+
+`$..match { arms }` walks every descendant in DFS pre-order, runs the
+arm list against each, and collects truthy arm-body results into an
+array. Falsy bodies and unmatched values are silently dropped.
+
+```
+$..match {
+    {tag: "click", id: i} -> i,
+    _                     -> false
+}
+```
+
+`$..match! { arms }` is the early-stop variant: returns the first truthy
+arm body and aborts the walk. Returns `null` when nothing matches.
+
+```
+$..match! {
+    {role: "admin"} -> @,
+    _               -> false
+}
+```
+
+When every arm shares an object key prefix, the runtime narrows
+candidates via the structural bitmap index before running the per-arm
+match — far cheaper than a full document walk on tape-backed inputs.
+
+### Composition
+
+`match` is an expression and composes with the rest of the language:
+
+```
+$.events.map(match @ with {
+    {tag: "view",  path: p} -> {sort: "view",  v: p},
+    {tag: "click", id: i}   -> {sort: "click", v: i},
+    _                       -> {sort: "other"}
+})
+
+$.reqs.filter(match @ with {
+    {method: "GET" \| "HEAD"} -> true,
+    _                         -> false
+})
+
+$.x | (match @ with { n when n > 5 -> "big", _ -> "small" })
+```
+
+When `.filter(match @ ...)` or `.map(match @ ...)` recognises a single
+match expression as the lambda body, a dedicated stage dispatches into
+the flat-IR runtime directly — no per-row VM stack overhead.
+
+---
+
 ## 22. Reserved Keywords
 
 ```
@@ -644,6 +800,7 @@ for  in  if
 let  lambda
 kind  is  as  when
 patch  DELETE
+match  with  try  has
 ```
 
 Cannot be used as identifiers. `DELETE` must be uppercase and only appears as a patch-field value.
@@ -707,4 +864,30 @@ $.orders.group_by(region).transform_values(lambda v: v.sum(total))
 
 // Cross join via comprehension
 [{u: u.name, p: p.name} for u in $.users for p in $.products if p.owner == u.id]
+
+// Pattern match: tagged-union dispatch
+$.events.map(match @ with {
+    {tag: "view",  path: p}  -> {sort: "view",  v: p},
+    {tag: "click", id: i}    -> {sort: "click", v: i},
+    {tag: "error", code: c}  -> {sort: "error", v: c},
+    _                        -> {sort: "other"}
+})
+
+// Pattern match: object rest capture + splat
+match $.user with {
+    {role: "admin", ...*rest} -> {...*rest, role: "superadmin"},
+    other                     -> other
+}
+
+// Deep match: collect every click event in the tree
+$..match {
+    {tag: "click", id: i} -> i,
+    _                     -> false
+}
+
+// Deep match: return the first admin user found anywhere
+$..match! {
+    {role: "admin", ...*rest} -> rest,
+    _                         -> false
+}
 ```

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -136,7 +136,10 @@ impl Builtin for Compact {
     const NAME: &'static str = "compact";
 
     fn spec() -> BuiltinSpec {
-        BuiltinSpec::new(BuiltinCategory::StreamingFilter, BuiltinCardinality::Filtering).cost(10.0)
+        BuiltinSpec::new(BuiltinCategory::StreamingFilter, BuiltinCardinality::Filtering)
+            .cost(10.0)
+            .demand_law(BuiltinDemandLaw::FilterLike)
+            .order_effect(BuiltinPipelineOrderEffect::PredicatePrefix)
     }
     #[inline]
     fn apply_one(recv: &crate::data::value::Val) -> Option<crate::data::value::Val> {
@@ -151,7 +154,10 @@ impl Builtin for Remove {
     const NAME: &'static str = "remove";
 
     fn spec() -> BuiltinSpec {
-        BuiltinSpec::new(BuiltinCategory::StreamingFilter, BuiltinCardinality::Filtering).cost(10.0)
+        BuiltinSpec::new(BuiltinCategory::StreamingFilter, BuiltinCardinality::Filtering)
+            .cost(10.0)
+            .demand_law(BuiltinDemandLaw::FilterLike)
+            .order_effect(BuiltinPipelineOrderEffect::PredicatePrefix)
     }
     #[inline]
     fn apply_args(recv: &crate::data::value::Val, args: &super::BuiltinArgs) -> Option<crate::data::value::Val> {
@@ -979,7 +985,7 @@ impl Builtin for FindFirst {
     fn spec() -> BuiltinSpec {
         BuiltinSpec::new(BuiltinCategory::StreamingFilter, BuiltinCardinality::Filtering)
             .cost(10.0)
-            .demand_law(BuiltinDemandLaw::First)
+            .demand_law(BuiltinDemandLaw::FilterLike)
             .lowering(BuiltinPipelineLowering::TerminalExprArg {
                 terminal: BuiltinMethod::First,
             })

--- a/jetro-core/src/builtins/mod.rs
+++ b/jetro-core/src/builtins/mod.rs
@@ -1939,6 +1939,15 @@ impl BuiltinCall {
             }
         }
 
+        if method == BuiltinMethod::Remove {
+            return match args {
+                [Arg::Pos(expr)] => {
+                    Some(Self::new(method, BuiltinArgs::Val(literal_val(expr)?)))
+                }
+                _ => None,
+            };
+        }
+
         Self::from_static_args(
             method,
             name,

--- a/jetro-core/src/builtins/registry.rs
+++ b/jetro-core/src/builtins/registry.rs
@@ -11,7 +11,7 @@ use crate::{
         BuiltinPipelineOrderEffect, BuiltinPipelineShape, BuiltinSinkAccumulator,
         BuiltinStructural,
     },
-    parse::chain_ir::{Demand, PullDemand, ValueNeed},
+    plan::demand::{Demand, PullDemand, ValueNeed},
 };
 
 /// Compact, stable numeric identity for a builtin. One-to-one with
@@ -283,7 +283,6 @@ impl BuiltinId {
 
 // ── Main registry macro ───────────────────────────────────────────────────────
 
-
 // ── Trait-driven name lookup (replaces builtin_registry! macro) ───────────────
 
 #[inline]
@@ -348,15 +347,9 @@ mod tests {
     #[test]
     fn registry_name_lookup_matches_legacy_lookup() {
         for (method, canonical, aliases) in all_method_entries() {
-            assert_eq!(
-                by_name(canonical).and_then(BuiltinId::method),
-                Some(method)
-            );
+            assert_eq!(by_name(canonical).and_then(BuiltinId::method), Some(method));
             for alias in aliases {
-                assert_eq!(
-                    by_name(alias).and_then(BuiltinId::method),
-                    Some(method)
-                );
+                assert_eq!(by_name(alias).and_then(BuiltinId::method), Some(method));
             }
         }
         assert_eq!(by_name("missing_builtin"), None);

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -14,7 +14,7 @@ use crate::data::context::EvalError;
 use crate::vm::{
     Opcode, Program, CompiledCall, CompiledObjEntry, KvStep, CompiledFSPart,
     BindObjSpec, CompiledPipeStep, CompSpec, DictCompSpec,
-    CompiledPatch, CompiledPatchOp, CompiledPatchVal, CompiledPathStep,
+    CompiledMatch, CompiledMatchArm, CompiledPatch, CompiledPatchOp, CompiledPatchVal, CompiledPathStep,
     fresh_ics, disable_opcode_fusion,
 };
 
@@ -596,9 +596,28 @@ impl Compiler {
             }
 
             Expr::DeleteMark => {
-                
-                
+
+
                 ops.push(Opcode::DeleteMarkErr);
+            }
+
+            Expr::Match { scrutinee, arms } => {
+                let scrutinee_prog = Arc::new(Self::compile_sub(scrutinee, ctx));
+                let compiled_arms: Vec<CompiledMatchArm> = arms
+                    .iter()
+                    .map(|arm| CompiledMatchArm {
+                        pat: arm.pat.clone(),
+                        guard: arm
+                            .guard
+                            .as_ref()
+                            .map(|g| Arc::new(Self::compile_sub(g, ctx))),
+                        body: Arc::new(Self::compile_sub(&arm.body, ctx)),
+                    })
+                    .collect();
+                ops.push(Opcode::Match(Arc::new(CompiledMatch {
+                    scrutinee: scrutinee_prog,
+                    arms: Arc::from(compiled_arms),
+                })));
             }
         }
     }

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -18,6 +18,20 @@ use crate::vm::{
     fresh_ics, disable_opcode_fusion,
 };
 
+/// Classify each pre-compiled sub-program against the `BodyKernel`
+/// fast-path catalog so higher-order builtins (`.filter`, `.map`,
+/// `.any`, ...) can dispatch through `eval_kernel` at native Rust
+/// speed instead of re-entering the VM per element.
+pub(crate) fn classify_sub_kernels(
+    progs: &[Arc<Program>],
+) -> Arc<[crate::exec::pipeline::BodyKernel]> {
+    progs
+        .iter()
+        .map(|p| crate::exec::pipeline::BodyKernel::classify(p))
+        .collect::<Vec<_>>()
+        .into()
+}
+
 /// Compile-time variable scope used by the `Compiler` to decide whether an
 /// identifier refers to a bound variable or a built-in/field name.
 #[derive(Clone, Default)]
@@ -552,10 +566,12 @@ impl Compiler {
                             Arg::Pos(e) | Arg::Named(_, e) => Arc::new(Self::compile_sub(e, ctx)),
                         })
                         .collect();
+                    let sub_kernels = classify_sub_kernels(&sub_progs);
                     let call = Arc::new(CompiledCall {
                         method: BuiltinMethod::from_name(name.as_str()),
                         name: Arc::from(name.as_str()),
                         sub_progs: sub_progs.into(),
+                        sub_kernels,
                         orig_args: rest_args.into(),
                         demand_max_keep: None,
                     });
@@ -568,10 +584,12 @@ impl Compiler {
                             Arg::Pos(e) | Arg::Named(_, e) => Arc::new(Self::compile_sub(e, ctx)),
                         })
                         .collect();
+                    let sub_kernels = classify_sub_kernels(&sub_progs);
                     let call = Arc::new(CompiledCall {
                         method: BuiltinMethod::Unknown,
                         name: Arc::from(name.as_str()),
                         sub_progs: sub_progs.into(),
+                        sub_kernels,
                         orig_args: args.iter().cloned().collect::<Vec<_>>().into(),
                         demand_max_keep: None,
                     });
@@ -661,10 +679,12 @@ impl Compiler {
                 Arg::Pos(e) | Arg::Named(_, e) => Arc::new(Self::compile_lambda_or_expr(e, ctx)),
             })
             .collect();
+        let sub_kernels = classify_sub_kernels(&sub_progs);
         CompiledCall {
             method,
             name: Arc::from(name),
             sub_progs: sub_progs.into(),
+            sub_kernels,
             orig_args: args.iter().cloned().collect::<Vec<_>>().into(),
             demand_max_keep: None,
         }
@@ -847,6 +867,7 @@ impl Compiler {
                     method: BuiltinMethod::from_name(name),
                     name: Arc::from(name.as_str()),
                     sub_progs: Arc::from(&[] as &[Arc<Program>]),
+                    sub_kernels: Arc::from(&[] as &[crate::exec::pipeline::BodyKernel]),
                     orig_args: Arc::from(&[] as &[Arg]),
                     demand_max_keep: None,
                 };
@@ -856,11 +877,14 @@ impl Compiler {
             Expr::Chain(base, steps) if !steps.is_empty() => {
                 if let Expr::Ident(name) = base.as_ref() {
                     if !ctx.has(name) {
-                        
+
                         let call = CompiledCall {
                             method: BuiltinMethod::from_name(name),
                             name: Arc::from(name.as_str()),
                             sub_progs: Arc::from(&[] as &[Arc<Program>]),
+                            sub_kernels: Arc::from(
+                                &[] as &[crate::exec::pipeline::BodyKernel],
+                            ),
                             orig_args: Arc::from(&[] as &[Arg]),
                             demand_max_keep: None,
                         };

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -14,7 +14,7 @@ use crate::data::context::EvalError;
 use crate::vm::{
     Opcode, Program, CompiledCall, CompiledObjEntry, KvStep, CompiledFSPart,
     BindObjSpec, CompiledPipeStep, CompSpec, DictCompSpec,
-    CompiledMatch, CompiledMatchArm, CompiledPatch, CompiledPatchOp, CompiledPatchVal, CompiledPathStep,
+    CompiledMatch, CompiledPatch, CompiledPatchOp, CompiledPatchVal, CompiledPathStep, MatchOp, MatchSlot,
     fresh_ics, disable_opcode_fusion,
 };
 
@@ -602,22 +602,8 @@ impl Compiler {
             }
 
             Expr::Match { scrutinee, arms } => {
-                let scrutinee_prog = Arc::new(Self::compile_sub(scrutinee, ctx));
-                let compiled_arms: Vec<CompiledMatchArm> = arms
-                    .iter()
-                    .map(|arm| CompiledMatchArm {
-                        pat: arm.pat.clone(),
-                        guard: arm
-                            .guard
-                            .as_ref()
-                            .map(|g| Arc::new(Self::compile_sub(g, ctx))),
-                        body: Arc::new(Self::compile_sub(&arm.body, ctx)),
-                    })
-                    .collect();
-                ops.push(Opcode::Match(Arc::new(CompiledMatch {
-                    scrutinee: scrutinee_prog,
-                    arms: Arc::from(compiled_arms),
-                })));
+                let compiled = compile_match(scrutinee, arms, ctx);
+                ops.push(Opcode::Match(Arc::new(compiled)));
             }
         }
     }
@@ -1062,5 +1048,529 @@ impl PassConfig {
             }
         }
         bits
+    }
+}
+
+/// Lower a `match scrutinee with { arms }` AST node into a `CompiledMatch`
+/// suitable for the flat decision-machine interpreter in `vm::exec`. Each
+/// arm contributes a contiguous block of `MatchOp`s framed by `ResetArm`,
+/// pattern tests, optional guard, and a terminating `Body`. Failed tests
+/// jump forward to the start of the next arm; the trailing `Fail` op is
+/// reached only when no arm matches.
+fn compile_match(
+    scrutinee: &Expr,
+    arms: &[crate::parse::ast::MatchArm],
+    ctx: &VarCtx,
+) -> CompiledMatch {
+    use crate::parse::ast::Pat;
+
+    let mut b = MatchBuilder::default();
+    // Reserve a placeholder for each arm-start PC so backward jumps from a
+    // miss inside arm N go to arm N+1's `ResetArm`. Final fall-through PC
+    // is set to the position of the trailing `Fail` op.
+    let mut arm_starts: Vec<u32> = Vec::with_capacity(arms.len());
+
+    // Cross-arm prefix sharing: when every arm is an object pattern that
+    // tests the same first key (the most common shape for tagged-union
+    // dispatch), the `ObjCheck` and `LoadField` for that key are hoisted
+    // out of the per-arm prologue. Slot 1 then holds the loaded key value
+    // and is preserved across arms via `ResetArm.keep_above = 2`.
+    let shared_key: Option<Arc<str>> = detect_shared_first_key(arms);
+    let mut prelude_pending: Vec<u32> = Vec::new();
+    if let Some(key) = shared_key.as_ref() {
+        // Emit shared prelude. Failures jump to the trailing `Fail` op
+        // (target is patched once `fail_pc` is known).
+        let p1 = b.emit(MatchOp::ObjCheck {
+            slot: 0,
+            else_pc: u32::MAX,
+        });
+        let p2 = b.emit(MatchOp::LoadField {
+            src: 0,
+            key: Arc::clone(key),
+            dst: 1,
+            else_pc: u32::MAX,
+        });
+        prelude_pending.push(p1);
+        prelude_pending.push(p2);
+    }
+    let keep_above: u16 = if shared_key.is_some() { 2 } else { 1 };
+
+    for arm in arms {
+        // Open a fresh patch-bucket for this arm so its `else_pc`
+        // placeholders are tracked independently of earlier arms.
+        b.pending_else.push(Vec::new());
+        arm_starts.push(b.next_pc());
+        // ResetArm placeholder; slot count patched once we know how many
+        // sub-projections the arm allocated.
+        let reset_idx = b.emit(MatchOp::ResetArm {
+            slots: keep_above,
+            keep_above,
+        });
+
+        // Slot space: when sharing is active, slot 1 already holds the
+        // shared key's loaded value, so per-arm allocation begins at 2.
+        let mut slot_alloc = SlotAlloc::starting_at(keep_above);
+
+        match (shared_key.as_ref(), &arm.pat) {
+            (Some(key), Pat::Obj { fields, open: _ }) => {
+                // Compile the shared-key field's sub-pattern against
+                // slot 1 directly; remaining fields take the standard
+                // load-field path.
+                for (k, sub_pat) in fields {
+                    if k.as_str() == key.as_ref() {
+                        b.compile_pat_for_arm(sub_pat, 1, &mut slot_alloc);
+                    } else {
+                        let dst = slot_alloc.alloc();
+                        b.emit_with_pending_else(MatchOp::LoadField {
+                            src: 0,
+                            key: Arc::from(k.as_str()),
+                            dst,
+                            else_pc: u32::MAX,
+                        });
+                        b.compile_pat_for_arm(sub_pat, dst, &mut slot_alloc);
+                    }
+                }
+            }
+            _ => {
+                // Standard codegen path: full pattern compile against slot 0.
+                b.compile_pat_for_arm(&arm.pat, 0, &mut slot_alloc);
+            }
+        }
+
+        // Guard (optional).
+        if let Some(guard_expr) = arm.guard.as_ref() {
+            let prog = Arc::new(Compiler::compile_sub(guard_expr, ctx));
+            let prog_idx = b.add_guard(prog);
+            b.emit_with_pending_else(MatchOp::Guard {
+                prog: prog_idx,
+                else_pc: u32::MAX,
+            });
+        }
+
+        // Body terminator: bindings already pushed; run body program.
+        let body_prog = Arc::new(Compiler::compile_sub(&arm.body, ctx));
+        let body_idx = b.add_body(body_prog);
+        b.emit(MatchOp::Body { prog: body_idx });
+
+        // Patch arm-local slot count into the reset op.
+        b.patch_reset_slots(reset_idx, slot_alloc.high_water_mark());
+    }
+
+    let fail_pc = b.next_pc();
+    b.emit(MatchOp::Fail);
+
+    // Patch the shared-prelude placeholders (object check + key load) to
+    // the trailing `Fail` op when sharing is active.
+    for pc in prelude_pending {
+        b.patch_else_pc(pc, fail_pc);
+    }
+
+    // Patch all `else_pc` placeholders to next-arm-start (or `fail_pc` for
+    // the last arm).
+    for (i, miss_pcs) in std::mem::take(&mut b.pending_else).into_iter().enumerate() {
+        let target = arm_starts.get(i + 1).copied().unwrap_or(fail_pc);
+        for pc in miss_pcs {
+            b.patch_else_pc(pc, target);
+        }
+    }
+
+    // Compute the maximum slot count the runtime ever needs, so the VM
+    // can size its slot vector once instead of growing per arm. The walk
+    // inspects each `ResetArm.slots` and any explicit `dst` slot — slots
+    // are dense within a single match expression.
+    let max_slots = compute_max_slots(&b.ops);
+
+    CompiledMatch {
+        scrutinee: Arc::new(Compiler::compile_sub(scrutinee, ctx)),
+        ops: Arc::from(b.ops),
+        lits: Arc::from(b.lits),
+        guards: Arc::from(b.guards),
+        bodies: Arc::from(b.bodies),
+        subpats: Arc::from(b.subpats),
+        max_slots,
+    }
+}
+
+/// Walk a freshly-emitted op stream and return the largest slot index
+/// referenced plus one. Used to size the runtime slot vector once at the
+/// top of `exec_match` so prelude ops (which run before any `ResetArm`)
+/// can index any slot up to `max_slots - 1`.
+fn compute_max_slots(ops: &[MatchOp]) -> u16 {
+    let mut hi: u16 = 1;
+    for op in ops {
+        match op {
+            MatchOp::ResetArm { slots, .. } => {
+                if *slots > hi {
+                    hi = *slots;
+                }
+            }
+            MatchOp::KindCheck { slot, .. }
+            | MatchOp::LitEq { slot, .. }
+            | MatchOp::ObjCheck { slot, .. }
+            | MatchOp::LenCheck { slot, .. }
+            | MatchOp::TestSubPat { slot, .. }
+            | MatchOp::Bind { slot, .. } => {
+                let n = slot.saturating_add(1);
+                if n > hi {
+                    hi = n;
+                }
+            }
+            MatchOp::LoadField { src, dst, .. } => {
+                let n = src.max(dst).saturating_add(1);
+                if n > hi {
+                    hi = n;
+                }
+            }
+            MatchOp::LoadIndex { src, dst, .. } | MatchOp::LoadTail { src, dst, .. } => {
+                let n = src.max(dst).saturating_add(1);
+                if n > hi {
+                    hi = n;
+                }
+            }
+            MatchOp::Guard { .. }
+            | MatchOp::Body { .. }
+            | MatchOp::Fail
+            | MatchOp::Jump { .. } => {}
+        }
+    }
+    hi
+}
+
+/// Detect when every arm is a `Pat::Obj` that lists the same first key.
+/// This is the dispatch shape for tagged-union match expressions
+/// (`{role: "admin"} -> ..., {role: "user"} -> ...`) and unlocks
+/// hoisting the shared `ObjCheck + LoadField` ops out of every arm's
+/// prologue. Returns the shared key when applicable, `None` otherwise.
+///
+/// The optimization is conservative: it requires every arm — including
+/// the catch-all — to be `Pat::Obj` with the same leading key. Mixing
+/// `Pat::Wild` / `Pat::Bind` catch-alls would require splitting the
+/// failure path between "not an object" and "object but no arm matched"
+/// and is left to a richer cross-arm pass.
+fn detect_shared_first_key(arms: &[crate::parse::ast::MatchArm]) -> Option<Arc<str>> {
+    use crate::parse::ast::Pat;
+    if arms.len() < 2 {
+        return None;
+    }
+    let mut shared: Option<&str> = None;
+    for arm in arms {
+        let Pat::Obj { fields, .. } = &arm.pat else {
+            return None;
+        };
+        let Some((first_key, _)) = fields.first() else {
+            return None;
+        };
+        match shared {
+            None => shared = Some(first_key.as_str()),
+            Some(k) if k == first_key.as_str() => {}
+            _ => return None,
+        }
+    }
+    shared.map(Arc::from)
+}
+
+/// Mutable state used while emitting a `CompiledMatch`. Tracks the op
+/// stream, sub-program pools, the literal pool, and the per-arm
+/// `else_pc` placeholders that need patching once arm-start PCs are known.
+#[derive(Default)]
+struct MatchBuilder {
+    ops: Vec<MatchOp>,
+    lits: Vec<crate::parse::ast::PatLit>,
+    guards: Vec<Arc<Program>>,
+    bodies: Vec<Arc<Program>>,
+    subpats: Vec<crate::parse::ast::Pat>,
+    /// One entry per arm; each holds the op indices whose `else_pc` field
+    /// must be patched to point to the next arm's start.
+    pending_else: Vec<Vec<u32>>,
+}
+
+impl MatchBuilder {
+    /// PC of the next op to be emitted.
+    fn next_pc(&self) -> u32 {
+        self.ops.len() as u32
+    }
+
+    /// Append an op without registering it for an arm-relative patch.
+    fn emit(&mut self, op: MatchOp) -> u32 {
+        let idx = self.ops.len() as u32;
+        self.ops.push(op);
+        idx
+    }
+
+    /// Append an op whose `else_pc` field is a sentinel; record its index
+    /// in the current arm's patch bucket so it can be resolved to the
+    /// next-arm start once the arm has finished emitting.
+    fn emit_with_pending_else(&mut self, op: MatchOp) -> u32 {
+        let idx = self.emit(op);
+        let bucket = self
+            .pending_else
+            .last_mut()
+            .expect("emit_with_pending_else called outside an arm");
+        bucket.push(idx);
+        idx
+    }
+
+    /// Append a literal to the pool, returning its index.
+    fn add_lit(&mut self, lit: crate::parse::ast::PatLit) -> u16 {
+        let idx = self.lits.len() as u16;
+        self.lits.push(lit);
+        idx
+    }
+
+    /// Append a sub-pattern (e.g. `Or`) to the pool, returning its index.
+    fn add_subpat(&mut self, pat: crate::parse::ast::Pat) -> u16 {
+        let idx = self.subpats.len() as u16;
+        self.subpats.push(pat);
+        idx
+    }
+
+    /// Append a guard sub-program, returning its index.
+    fn add_guard(&mut self, prog: Arc<Program>) -> u16 {
+        let idx = self.guards.len() as u16;
+        self.guards.push(prog);
+        idx
+    }
+
+    /// Append a body sub-program, returning its index.
+    fn add_body(&mut self, prog: Arc<Program>) -> u16 {
+        let idx = self.bodies.len() as u16;
+        self.bodies.push(prog);
+        idx
+    }
+
+    /// Patch the slot-count field of a previously emitted `ResetArm`.
+    fn patch_reset_slots(&mut self, reset_idx: u32, slots: u16) {
+        if let MatchOp::ResetArm { slots: s, .. } = &mut self.ops[reset_idx as usize] {
+            *s = slots;
+        }
+    }
+
+    /// Patch the `else_pc` field of a previously emitted miss-jumping op.
+    fn patch_else_pc(&mut self, idx: u32, target: u32) {
+        match &mut self.ops[idx as usize] {
+            MatchOp::KindCheck { else_pc, .. }
+            | MatchOp::LitEq { else_pc, .. }
+            | MatchOp::ObjCheck { else_pc, .. }
+            | MatchOp::LoadField { else_pc, .. }
+            | MatchOp::LenCheck { else_pc, .. }
+            | MatchOp::TestSubPat { else_pc, .. }
+            | MatchOp::Guard { else_pc, .. } => *else_pc = target,
+            other => panic!("patch_else_pc on op without else_pc: {other:?}"),
+        }
+    }
+
+    /// Compile a single arm's pattern by emitting the appropriate test /
+    /// load / bind ops against `slot`, allocating sub-slots for nested
+    /// projections from `slot_alloc`.
+    fn compile_pat_for_arm(
+        &mut self,
+        pat: &crate::parse::ast::Pat,
+        slot: MatchSlot,
+        slot_alloc: &mut SlotAlloc,
+    ) {
+        use crate::parse::ast::Pat;
+        match pat {
+            Pat::Wild => {
+                // Always matches; emit nothing.
+            }
+            Pat::Bind(name) => {
+                self.emit(MatchOp::Bind {
+                    name: Arc::from(name.as_str()),
+                    slot,
+                });
+            }
+            Pat::Lit(lit) => {
+                let lit_idx = self.add_lit(lit.clone());
+                self.emit_with_pending_else(MatchOp::LitEq {
+                    slot,
+                    lit: lit_idx,
+                    else_pc: u32::MAX,
+                });
+            }
+            Pat::Kind { name, kind } => {
+                self.emit_with_pending_else(MatchOp::KindCheck {
+                    slot,
+                    kind: *kind,
+                    else_pc: u32::MAX,
+                });
+                if let Some(n) = name.as_deref() {
+                    self.emit(MatchOp::Bind {
+                        name: Arc::from(n),
+                        slot,
+                    });
+                }
+            }
+            Pat::Or(alts) if alts.iter().all(|a| matches!(a, Pat::Lit(_))) => {
+                // Or-of-literals cascade: emit one `LitEq` per alt with a
+                // forward miss-jump to the next alt's PC, plus an
+                // unconditional jump after each successful test that
+                // skips past every remaining alternative. The last alt's
+                // miss jumps to the arm boundary like any other test.
+                //
+                // Layout for `a | b | c`:
+                //   pc0:  LitEq a, else_pc=pc2
+                //   pc1:  Jump exit
+                //   pc2:  LitEq b, else_pc=pc4
+                //   pc3:  Jump exit
+                //   pc4:  LitEq c, else_pc=ARM_MISS
+                //   exit: ...
+                let mut miss_to_patch: Vec<(u32, usize)> = Vec::new();
+                let mut jump_to_patch: Vec<u32> = Vec::new();
+                for (i, alt) in alts.iter().enumerate() {
+                    let Pat::Lit(lit) = alt else {
+                        unreachable!("guarded above")
+                    };
+                    let lit_idx = self.add_lit(lit.clone());
+                    let is_last = i + 1 == alts.len();
+                    let cmp_pc = if is_last {
+                        // Final alt: miss exits to arm boundary via the
+                        // standard pending_else patch path.
+                        self.emit_with_pending_else(MatchOp::LitEq {
+                            slot,
+                            lit: lit_idx,
+                            else_pc: u32::MAX,
+                        })
+                    } else {
+                        let pc = self.emit(MatchOp::LitEq {
+                            slot,
+                            lit: lit_idx,
+                            else_pc: u32::MAX,
+                        });
+                        // Unconditional jump-to-exit on success.
+                        let jpc = self.emit(MatchOp::Jump {
+                            target_pc: u32::MAX,
+                        });
+                        miss_to_patch.push((pc, i + 1));
+                        jump_to_patch.push(jpc);
+                        pc
+                    };
+                    let _ = cmp_pc;
+                }
+                let exit_pc = self.next_pc();
+                // Patch each non-final miss to the start of the next alt.
+                let alt_starts: Vec<u32> = (0..alts.len())
+                    .map(|i| {
+                        // Each alt occupies 1 op (LitEq) + 1 op (Jump)
+                        // except the final which has no Jump. Compute by
+                        // recovering from `miss_to_patch` ordering: the
+                        // alts were emitted contiguously, and we recorded
+                        // each cmp_pc.
+                        miss_to_patch
+                            .iter()
+                            .find(|(_, idx)| *idx == i)
+                            .map(|(_pc, _)| {
+                                // alt i (i>=1) starts immediately after
+                                // alt (i-1)'s Jump op.
+                                miss_to_patch[i - 1].0 + 2
+                            })
+                            .unwrap_or_else(|| miss_to_patch.first().map(|(p, _)| *p).unwrap_or(0))
+                    })
+                    .collect();
+                for (cmp_pc, alt_idx) in &miss_to_patch {
+                    let target = alt_starts[*alt_idx];
+                    self.patch_else_pc(*cmp_pc, target);
+                }
+                // Patch every success-jump to the cascade exit.
+                for jpc in jump_to_patch {
+                    if let MatchOp::Jump { target_pc } = &mut self.ops[jpc as usize] {
+                        *target_pc = exit_pc;
+                    }
+                }
+            }
+            Pat::Or(_) => {
+                // Or-patterns with binders or nested shapes retain their
+                // tree shape so the runtime helper can backtrack bindings
+                // between alternatives.
+                let subpat_idx = self.add_subpat(pat.clone());
+                self.emit_with_pending_else(MatchOp::TestSubPat {
+                    slot,
+                    subpat: subpat_idx,
+                    else_pc: u32::MAX,
+                });
+            }
+            Pat::Obj { fields, open: _ } => {
+                self.emit_with_pending_else(MatchOp::ObjCheck {
+                    slot,
+                    else_pc: u32::MAX,
+                });
+                for (key, sub_pat) in fields {
+                    let dst = slot_alloc.alloc();
+                    self.emit_with_pending_else(MatchOp::LoadField {
+                        src: slot,
+                        key: Arc::from(key.as_str()),
+                        dst,
+                        else_pc: u32::MAX,
+                    });
+                    self.compile_pat_for_arm(sub_pat, dst, slot_alloc);
+                }
+            }
+            Pat::Arr { elems, rest } => {
+                let prefix = elems.len() as u32;
+                let exact = rest.is_none();
+                self.emit_with_pending_else(MatchOp::LenCheck {
+                    slot,
+                    len: prefix,
+                    exact,
+                    else_pc: u32::MAX,
+                });
+                for (i, sub_pat) in elems.iter().enumerate() {
+                    let dst = slot_alloc.alloc();
+                    self.emit(MatchOp::LoadIndex {
+                        src: slot,
+                        idx: i as u32,
+                        dst,
+                    });
+                    self.compile_pat_for_arm(sub_pat, dst, slot_alloc);
+                }
+                if let Some(rest_name) = rest.as_ref().and_then(|n| n.as_deref()) {
+                    let dst = slot_alloc.alloc();
+                    self.emit(MatchOp::LoadTail {
+                        src: slot,
+                        from: prefix,
+                        dst,
+                    });
+                    self.emit(MatchOp::Bind {
+                        name: Arc::from(rest_name),
+                        slot: dst,
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Per-arm slot index allocator. Slot 0 is reserved for the scrutinee, so
+/// allocation begins at 1. The high-water mark drives `ResetArm.slots`.
+struct SlotAlloc {
+    next: u16,
+}
+
+impl SlotAlloc {
+    /// Create a fresh allocator that will hand out slots starting at index 1.
+    #[allow(dead_code)]
+    fn new() -> Self {
+        Self::starting_at(1)
+    }
+
+    /// Create an allocator whose next slot index is `start`. Used when a
+    /// match-level prelude has already populated some slots that should
+    /// not collide with arm-local sub-projections.
+    fn starting_at(start: u16) -> Self {
+        Self { next: start.max(1) }
+    }
+
+    /// Allocate and return the next slot index.
+    fn alloc(&mut self) -> MatchSlot {
+        let s = self.next;
+        self.next = self
+            .next
+            .checked_add(1)
+            .expect("match arm exceeded u16 slot capacity");
+        s
+    }
+
+    /// Return the total number of slots required so far (including slot 0).
+    fn high_water_mark(&self) -> u16 {
+        self.next
     }
 }

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -1180,7 +1180,7 @@ pub(crate) fn compile_match(
             // `shared_keys.len()` fields agree on key order. Compile
             // those sub-patterns against prelude-allocated slots; let
             // any extra fields go through the standard load-field path.
-            let Pat::Obj { fields, open: _ } = &arm.pat else {
+            let Pat::Obj { fields, rest: _ } = &arm.pat else {
                 unreachable!("shared-prefix invariant: every arm is Pat::Obj");
             };
             for (i, key) in shared_keys.iter().enumerate() {
@@ -1427,6 +1427,12 @@ fn compute_max_slots(ops: &[MatchOp]) -> u16 {
                 }
             }
             MatchOp::LoadIndex { src, dst, .. } | MatchOp::LoadTail { src, dst, .. } => {
+                let n = src.max(dst).saturating_add(1);
+                if n > hi {
+                    hi = n;
+                }
+            }
+            MatchOp::LoadObjRest { src, dst, .. } => {
                 let n = src.max(dst).saturating_add(1);
                 if n > hi {
                     hi = n;
@@ -1793,7 +1799,7 @@ impl MatchBuilder {
                     else_pc: u32::MAX,
                 });
             }
-            Pat::Obj { fields, open: _ } => {
+            Pat::Obj { fields, rest } => {
                 self.emit_with_pending_else(MatchOp::ObjCheck {
                     slot,
                     else_pc: u32::MAX,
@@ -1807,6 +1813,24 @@ impl MatchBuilder {
                         else_pc: u32::MAX,
                     });
                     self.compile_pat_for_arm(sub_pat, dst, slot_alloc);
+                }
+                // A named `...rest` rest binding captures every key not
+                // listed in `fields` into a freshly built `Val::Obj`.
+                // Anonymous `...` is recorded in the AST but emits no
+                // ops because the runtime already admits extra keys.
+                if let Some(Some(rest_name)) = rest {
+                    let listed_keys: Arc<[Arc<str>]> =
+                        fields.iter().map(|(k, _)| Arc::from(k.as_str())).collect();
+                    let dst = slot_alloc.alloc();
+                    self.emit(MatchOp::LoadObjRest {
+                        src: slot,
+                        listed_keys,
+                        dst,
+                    });
+                    self.emit(MatchOp::Bind {
+                        name: Arc::from(rest_name.as_str()),
+                        slot: dst,
+                    });
                 }
             }
             Pat::Arr { elems, rest } => {

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -630,16 +630,23 @@ impl Compiler {
                 ops.push(Opcode::InlineFilter(Arc::new(Self::compile_sub(pred, ctx))));
             }
             Step::Quantifier(k) => ops.push(Opcode::Quantifier(*k)),
-            Step::DeepMatch(arms) => {
-                // The deep-match step shares its compile path with the
-                // expression-level `match`, with the receiver stack value
-                // serving as both the descent root and the per-element
-                // scrutinee. The synthesised `MatchScrutinee::Current`
-                // tells the runtime to read the iteration item directly
-                // rather than re-evaluating a sub-program per descendant.
+            Step::DeepMatch { arms, early_stop } => {
+                // Both deep-match shapes share their compile path with
+                // expression-level `match`; the receiver stack value
+                // doubles as the descent root and the per-element
+                // scrutinee. `MatchScrutinee::Current` tells the runtime
+                // to read the iteration item from `@` rather than
+                // re-evaluating a sub-program per descendant. The
+                // `early_stop` flag selects between the collect-all and
+                // first-match runtime opcodes.
                 let scrutinee_marker = Expr::Current;
                 let cm = compile_match(&scrutinee_marker, arms, ctx);
-                ops.push(Opcode::DeepMatchAll(Arc::new(cm)));
+                let cm = Arc::new(cm);
+                if *early_stop {
+                    ops.push(Opcode::DeepMatchFirst(cm));
+                } else {
+                    ops.push(Opcode::DeepMatchAll(cm));
+                }
             }
         }
     }
@@ -1286,7 +1293,94 @@ fn compile_match(
         is_exhaustive: arms.iter().any(|a| {
             a.guard.is_none() && matches!(a.pat, Pat::Wild | Pat::Bind(_))
         }),
+        shape_summary: derive_shape_summary(arms),
     }
+}
+
+/// Inspect the typed (non-catch-all) arms of a `match` and return a
+/// structural summary the deep-match runtime can use to pre-filter
+/// candidates via a bitmap index. Returns `None` when arms are
+/// heterogeneous or the leading shape cannot be characterised by one
+/// of the recognised summaries.
+fn derive_shape_summary(
+    arms: &[crate::parse::ast::MatchArm],
+) -> Option<crate::vm::MatchShapeSummary> {
+    use crate::parse::ast::Pat;
+
+    // Strip a trailing catch-all (`_` / unbound bind) from consideration —
+    // it does not constrain the candidate set; the typed arms above it
+    // determine the summary.
+    let typed: &[crate::parse::ast::MatchArm] = match arms.last() {
+        Some(a) if matches!(a.pat, Pat::Wild | Pat::Bind(_)) => &arms[..arms.len() - 1],
+        _ => arms,
+    };
+    if typed.is_empty() {
+        return None;
+    }
+
+    // Object-of-keys summary — every typed arm is a `Pat::Obj`. Collect
+    // the union of leading keys.
+    if typed.iter().all(|a| matches!(a.pat, Pat::Obj { .. })) {
+        let mut keys: Vec<Arc<str>> = Vec::new();
+        for arm in typed {
+            if let Pat::Obj { fields, .. } = &arm.pat {
+                for (k, _) in fields {
+                    let arc: Arc<str> = Arc::from(k.as_str());
+                    if !keys.iter().any(|existing| existing.as_ref() == k.as_str()) {
+                        keys.push(arc);
+                    }
+                }
+            }
+        }
+        if !keys.is_empty() {
+            return Some(crate::vm::MatchShapeSummary::ObjAnyOfKeys(Arc::from(keys)));
+        }
+    }
+
+    // Kind-only summary — every typed arm is `Pat::Kind` of the same
+    // scalar kind.
+    if let Pat::Kind {
+        kind: first_kind, ..
+    } = &typed[0].pat
+    {
+        if typed.iter().all(|a| match &a.pat {
+            Pat::Kind { kind, .. } => kind == first_kind,
+            _ => false,
+        }) {
+            return Some(crate::vm::MatchShapeSummary::KindOnly(*first_kind));
+        }
+    }
+
+    // Numeric-range summary — every typed arm is a `Pat::Range`. Take
+    // the union (min lo, max hi).
+    if typed.iter().all(|a| matches!(a.pat, Pat::Range { .. })) {
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        let mut inclusive = false;
+        for arm in typed {
+            if let Pat::Range {
+                lo: l,
+                hi: h,
+                inclusive: inc,
+            } = &arm.pat
+            {
+                if *l < lo {
+                    lo = *l;
+                }
+                if *h > hi {
+                    hi = *h;
+                }
+                if *inc {
+                    inclusive = true;
+                }
+            }
+        }
+        if lo.is_finite() && hi.is_finite() && lo <= hi {
+            return Some(crate::vm::MatchShapeSummary::NumericRange { lo, hi, inclusive });
+        }
+    }
+
+    None
 }
 
 /// Pick the cheapest strategy for evaluating a `match` scrutinee at run

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -1070,32 +1070,64 @@ fn compile_match(
     // is set to the position of the trailing `Fail` op.
     let mut arm_starts: Vec<u32> = Vec::with_capacity(arms.len());
 
-    // Cross-arm prefix sharing: when every arm is an object pattern that
-    // tests the same first key (the most common shape for tagged-union
-    // dispatch), the `ObjCheck` and `LoadField` for that key are hoisted
-    // out of the per-arm prologue. Slot 1 then holds the loaded key value
-    // and is preserved across arms via `ResetArm.keep_above = 2`.
-    let shared_key: Option<Arc<str>> = detect_shared_first_key(arms);
+    // Cross-arm prefix sharing comes in two flavours: object patterns
+    // share a leading key sequence, or array patterns share a fixed
+    // length. The two are mutually exclusive (an arm is `Pat::Obj` xor
+    // `Pat::Arr`), so each match expression picks at most one prelude
+    // shape. Loaded values land in slots `1..=N` and are preserved
+    // across arms via `ResetArm.keep_above = N + 1`. A trailing
+    // wildcard or bind arm participates as a catch-all: prelude
+    // failures (not-an-object, key missing, length mismatch) jump
+    // straight to the catch-all arm rather than the global `Fail` op.
+    let trailing_catchall_idx: Option<usize> = arms
+        .last()
+        .map(|a| matches!(a.pat, Pat::Wild | Pat::Bind(_)))
+        .filter(|b| *b)
+        .map(|_| arms.len() - 1);
+    let typed_arms: &[crate::parse::ast::MatchArm] = match trailing_catchall_idx {
+        Some(_) => &arms[..arms.len() - 1],
+        None => arms,
+    };
+    let shared_keys: Vec<Arc<str>> = detect_shared_key_prefix(typed_arms);
+    let shared_arr_len: Option<u32> = if shared_keys.is_empty() {
+        detect_shared_arr_len(typed_arms)
+    } else {
+        None
+    };
     let mut prelude_pending: Vec<u32> = Vec::new();
-    if let Some(key) = shared_key.as_ref() {
-        // Emit shared prelude. Failures jump to the trailing `Fail` op
-        // (target is patched once `fail_pc` is known).
-        let p1 = b.emit(MatchOp::ObjCheck {
+    if !shared_keys.is_empty() {
+        // Object prelude: `ObjCheck` plus one `LoadField` per shared key.
+        let p_check = b.emit(MatchOp::ObjCheck {
             slot: 0,
             else_pc: u32::MAX,
         });
-        let p2 = b.emit(MatchOp::LoadField {
-            src: 0,
-            key: Arc::clone(key),
-            dst: 1,
+        prelude_pending.push(p_check);
+        for (i, key) in shared_keys.iter().enumerate() {
+            let p_load = b.emit(MatchOp::LoadField {
+                src: 0,
+                key: Arc::clone(key),
+                dst: (i + 1) as u16,
+                else_pc: u32::MAX,
+            });
+            prelude_pending.push(p_load);
+        }
+    } else if let Some(len) = shared_arr_len {
+        // Array prelude: a single `LenCheck` against the agreed length.
+        let p_len = b.emit(MatchOp::LenCheck {
+            slot: 0,
+            len,
+            exact: true,
             else_pc: u32::MAX,
         });
-        prelude_pending.push(p1);
-        prelude_pending.push(p2);
+        prelude_pending.push(p_len);
     }
-    let keep_above: u16 = if shared_key.is_some() { 2 } else { 1 };
+    let keep_above: u16 = if !shared_keys.is_empty() {
+        (shared_keys.len() + 1) as u16
+    } else {
+        1
+    };
 
-    for arm in arms {
+    for (arm_idx, arm) in arms.iter().enumerate() {
         // Open a fresh patch-bucket for this arm so its `else_pc`
         // placeholders are tracked independently of earlier arms.
         b.pending_else.push(Vec::new());
@@ -1111,30 +1143,54 @@ fn compile_match(
         // shared key's loaded value, so per-arm allocation begins at 2.
         let mut slot_alloc = SlotAlloc::starting_at(keep_above);
 
-        match (shared_key.as_ref(), &arm.pat) {
-            (Some(key), Pat::Obj { fields, open: _ }) => {
-                // Compile the shared-key field's sub-pattern against
-                // slot 1 directly; remaining fields take the standard
-                // load-field path.
-                for (k, sub_pat) in fields {
-                    if k.as_str() == key.as_ref() {
-                        b.compile_pat_for_arm(sub_pat, 1, &mut slot_alloc);
-                    } else {
-                        let dst = slot_alloc.alloc();
-                        b.emit_with_pending_else(MatchOp::LoadField {
-                            src: 0,
-                            key: Arc::from(k.as_str()),
-                            dst,
-                            else_pc: u32::MAX,
-                        });
-                        b.compile_pat_for_arm(sub_pat, dst, &mut slot_alloc);
-                    }
-                }
+        // The trailing catch-all arm uses standard codegen even when a
+        // shared prefix is active. Sharing only governs the typed arms
+        // (which are uniformly `Pat::Obj` or `Pat::Arr`); the catch-all
+        // is `Pat::Wild` / `Pat::Bind` and produces no field tests.
+        let is_trailing_catchall = trailing_catchall_idx == Some(arm_idx);
+
+        if !shared_keys.is_empty() && !is_trailing_catchall {
+            // Object prefix sharing: every arm is `Pat::Obj` whose first
+            // `shared_keys.len()` fields agree on key order. Compile
+            // those sub-patterns against prelude-allocated slots; let
+            // any extra fields go through the standard load-field path.
+            let Pat::Obj { fields, open: _ } = &arm.pat else {
+                unreachable!("shared-prefix invariant: every arm is Pat::Obj");
+            };
+            for (i, key) in shared_keys.iter().enumerate() {
+                debug_assert_eq!(fields[i].0.as_str(), key.as_ref());
+                b.compile_pat_for_arm(&fields[i].1, (i + 1) as u16, &mut slot_alloc);
             }
-            _ => {
-                // Standard codegen path: full pattern compile against slot 0.
-                b.compile_pat_for_arm(&arm.pat, 0, &mut slot_alloc);
+            for (k, sub_pat) in fields.iter().skip(shared_keys.len()) {
+                let dst = slot_alloc.alloc();
+                b.emit_with_pending_else(MatchOp::LoadField {
+                    src: 0,
+                    key: Arc::from(k.as_str()),
+                    dst,
+                    else_pc: u32::MAX,
+                });
+                b.compile_pat_for_arm(sub_pat, dst, &mut slot_alloc);
             }
+        } else if shared_arr_len.is_some() && !is_trailing_catchall {
+            // Array length sharing: every arm is `Pat::Arr` with the
+            // same exact length and no rest binding. The prelude has
+            // already verified the length, so per-arm codegen skips
+            // `LenCheck` and goes straight to per-element loads.
+            let Pat::Arr { elems, rest: _ } = &arm.pat else {
+                unreachable!("shared-arr invariant: every arm is Pat::Arr");
+            };
+            for (i, sub_pat) in elems.iter().enumerate() {
+                let dst = slot_alloc.alloc();
+                b.emit(MatchOp::LoadIndex {
+                    src: 0,
+                    idx: i as u32,
+                    dst,
+                });
+                b.compile_pat_for_arm(sub_pat, dst, &mut slot_alloc);
+            }
+        } else {
+            // Standard codegen path: full pattern compile against slot 0.
+            b.compile_pat_for_arm(&arm.pat, 0, &mut slot_alloc);
         }
 
         // Guard (optional).
@@ -1159,10 +1215,14 @@ fn compile_match(
     let fail_pc = b.next_pc();
     b.emit(MatchOp::Fail);
 
-    // Patch the shared-prelude placeholders (object check + key load) to
-    // the trailing `Fail` op when sharing is active.
+    // Patch the shared-prelude placeholders (object check, key loads,
+    // length check) to the catch-all arm's start if one exists, or to
+    // the trailing `Fail` op otherwise.
+    let prelude_miss_target: u32 = trailing_catchall_idx
+        .and_then(|i| arm_starts.get(i).copied())
+        .unwrap_or(fail_pc);
     for pc in prelude_pending {
-        b.patch_else_pc(pc, fail_pc);
+        b.patch_else_pc(pc, prelude_miss_target);
     }
 
     // Patch all `else_pc` placeholders to next-arm-start (or `fail_pc` for
@@ -1236,37 +1296,85 @@ fn compute_max_slots(ops: &[MatchOp]) -> u16 {
     hi
 }
 
-/// Detect when every arm is a `Pat::Obj` that lists the same first key.
-/// This is the dispatch shape for tagged-union match expressions
-/// (`{role: "admin"} -> ..., {role: "user"} -> ...`) and unlocks
-/// hoisting the shared `ObjCheck + LoadField` ops out of every arm's
-/// prologue. Returns the shared key when applicable, `None` otherwise.
+/// Detect when every arm of a `match` is a fixed-length array pattern
+/// (`Pat::Arr` with no rest binding) of the same length, allowing the
+/// `LenCheck` to be hoisted into a single match-level prelude. Returns
+/// the agreed length when applicable, `None` otherwise.
 ///
-/// The optimization is conservative: it requires every arm — including
-/// the catch-all — to be `Pat::Obj` with the same leading key. Mixing
-/// `Pat::Wild` / `Pat::Bind` catch-alls would require splitting the
-/// failure path between "not an object" and "object but no arm matched"
-/// and is left to a richer cross-arm pass.
-fn detect_shared_first_key(arms: &[crate::parse::ast::MatchArm]) -> Option<Arc<str>> {
+/// Like the object variant, the optimization needs at least two arms
+/// and is disabled when any arm has a different shape (including arms
+/// that bind a rest tail, since a rest binding implies a `>=` length
+/// test that does not compose with an exact-length prelude).
+fn detect_shared_arr_len(arms: &[crate::parse::ast::MatchArm]) -> Option<u32> {
     use crate::parse::ast::Pat;
+
     if arms.len() < 2 {
         return None;
     }
-    let mut shared: Option<&str> = None;
+    let mut shared: Option<u32> = None;
     for arm in arms {
-        let Pat::Obj { fields, .. } = &arm.pat else {
+        let Pat::Arr { elems, rest } = &arm.pat else {
             return None;
         };
-        let Some((first_key, _)) = fields.first() else {
+        if rest.is_some() {
             return None;
-        };
+        }
+        let len = elems.len() as u32;
         match shared {
-            None => shared = Some(first_key.as_str()),
-            Some(k) if k == first_key.as_str() => {}
+            None => shared = Some(len),
+            Some(n) if n == len => {}
             _ => return None,
         }
     }
-    shared.map(Arc::from)
+    shared
+}
+
+/// Detect the longest leading key sequence that every arm of a `match`
+/// agrees on. Each arm must be a `Pat::Obj` whose first N fields list the
+/// same keys in the same order; the returned vector contains those keys
+/// (in source order) and unlocks hoisting the corresponding
+/// `ObjCheck + LoadField` ops out of every arm's prologue.
+///
+/// Returns an empty vector when any arm is non-object, when arms have no
+/// leading key in common, or when fewer than two arms exist (the
+/// optimization needs at least two arms to be worth its prelude cost).
+fn detect_shared_key_prefix(arms: &[crate::parse::ast::MatchArm]) -> Vec<Arc<str>> {
+    use crate::parse::ast::Pat;
+
+    if arms.len() < 2 {
+        return Vec::new();
+    }
+
+    // Seed the shared prefix with the first arm's full key list.
+    let Pat::Obj {
+        fields: first_fields,
+        ..
+    } = &arms[0].pat
+    else {
+        return Vec::new();
+    };
+    let mut prefix: Vec<&str> = first_fields.iter().map(|(k, _)| k.as_str()).collect();
+    if prefix.is_empty() {
+        return Vec::new();
+    }
+
+    // Intersect against each subsequent arm.
+    for arm in &arms[1..] {
+        let Pat::Obj { fields, .. } = &arm.pat else {
+            return Vec::new();
+        };
+        let common = prefix
+            .iter()
+            .zip(fields.iter().map(|(k, _)| k.as_str()))
+            .take_while(|(a, b)| **a == *b)
+            .count();
+        prefix.truncate(common);
+        if prefix.is_empty() {
+            return Vec::new();
+        }
+    }
+
+    prefix.into_iter().map(Arc::from).collect()
 }
 
 /// Mutable state used while emitting a `CompiledMatch`. Tracks the op

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -630,6 +630,17 @@ impl Compiler {
                 ops.push(Opcode::InlineFilter(Arc::new(Self::compile_sub(pred, ctx))));
             }
             Step::Quantifier(k) => ops.push(Opcode::Quantifier(*k)),
+            Step::DeepMatch(arms) => {
+                // The deep-match step shares its compile path with the
+                // expression-level `match`, with the receiver stack value
+                // serving as both the descent root and the per-element
+                // scrutinee. The synthesised `MatchScrutinee::Current`
+                // tells the runtime to read the iteration item directly
+                // rather than re-evaluating a sub-program per descendant.
+                let scrutinee_marker = Expr::Current;
+                let cm = compile_match(&scrutinee_marker, arms, ctx);
+                ops.push(Opcode::DeepMatchAll(Arc::new(cm)));
+            }
         }
     }
 

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -1094,6 +1094,13 @@ fn compile_match(
     } else {
         None
     };
+    let shared_kind: Option<crate::parse::ast::KindType> = if shared_keys.is_empty()
+        && shared_arr_len.is_none()
+    {
+        detect_shared_kind(typed_arms)
+    } else {
+        None
+    };
     let mut prelude_pending: Vec<u32> = Vec::new();
     if !shared_keys.is_empty() {
         // Object prelude: `ObjCheck` plus one `LoadField` per shared key.
@@ -1120,6 +1127,15 @@ fn compile_match(
             else_pc: u32::MAX,
         });
         prelude_pending.push(p_len);
+    } else if let Some(kind) = shared_kind {
+        // Kind prelude: every arm tests the same scalar kind. Hoist the
+        // single `KindCheck` so per-arm prologue only emits the binding.
+        let p_kind = b.emit(MatchOp::KindCheck {
+            slot: 0,
+            kind,
+            else_pc: u32::MAX,
+        });
+        prelude_pending.push(p_kind);
     }
     let keep_above: u16 = if !shared_keys.is_empty() {
         (shared_keys.len() + 1) as u16
@@ -1170,6 +1186,19 @@ fn compile_match(
                     else_pc: u32::MAX,
                 });
                 b.compile_pat_for_arm(sub_pat, dst, &mut slot_alloc);
+            }
+        } else if shared_kind.is_some() && !is_trailing_catchall {
+            // Kind sharing: every arm is `Pat::Kind` testing the same
+            // scalar kind. The prelude has already verified the kind, so
+            // per-arm codegen only needs to push the optional binding.
+            let Pat::Kind { name, kind: _ } = &arm.pat else {
+                unreachable!("shared-kind invariant: every arm is Pat::Kind");
+            };
+            if let Some(n) = name.as_deref() {
+                b.emit(MatchOp::Bind {
+                    name: Arc::from(n),
+                    slot: 0,
+                });
             }
         } else if shared_arr_len.is_some() && !is_trailing_catchall {
             // Array length sharing: every arm is `Pat::Arr` with the
@@ -1241,13 +1270,28 @@ fn compile_match(
     let max_slots = compute_max_slots(&b.ops);
 
     CompiledMatch {
-        scrutinee: Arc::new(Compiler::compile_sub(scrutinee, ctx)),
+        scrutinee: classify_match_scrutinee(scrutinee, ctx),
         ops: Arc::from(b.ops),
         lits: Arc::from(b.lits),
         guards: Arc::from(b.guards),
         bodies: Arc::from(b.bodies),
         subpats: Arc::from(b.subpats),
         max_slots,
+        is_exhaustive: arms.iter().any(|a| {
+            a.guard.is_none() && matches!(a.pat, Pat::Wild | Pat::Bind(_))
+        }),
+    }
+}
+
+/// Pick the cheapest strategy for evaluating a `match` scrutinee at run
+/// time. `match @ with { ... }` and `match $ with { ... }` skip VM
+/// re-entry entirely by reading directly from `Env::current` /
+/// `Env::root`; everything else compiles a sub-program.
+fn classify_match_scrutinee(expr: &Expr, ctx: &VarCtx) -> crate::vm::MatchScrutinee {
+    match expr {
+        Expr::Current => crate::vm::MatchScrutinee::Current,
+        Expr::Root => crate::vm::MatchScrutinee::Root,
+        _ => crate::vm::MatchScrutinee::Program(Arc::new(Compiler::compile_sub(expr, ctx))),
     }
 }
 
@@ -1266,6 +1310,7 @@ fn compute_max_slots(ops: &[MatchOp]) -> u16 {
             }
             MatchOp::KindCheck { slot, .. }
             | MatchOp::LitEq { slot, .. }
+            | MatchOp::RangeCheck { slot, .. }
             | MatchOp::ObjCheck { slot, .. }
             | MatchOp::LenCheck { slot, .. }
             | MatchOp::TestSubPat { slot, .. }
@@ -1294,6 +1339,31 @@ fn compute_max_slots(ops: &[MatchOp]) -> u16 {
         }
     }
     hi
+}
+
+/// Detect when every arm of a `match` is a `Pat::Kind` pattern testing
+/// the same scalar kind (`s: string`, `n: number`, ...). When applicable
+/// the runtime kind check is hoisted out of every per-arm prologue and
+/// emitted once as a match-level prelude, similar to the object/array
+/// prefix sharing variants.
+fn detect_shared_kind(arms: &[crate::parse::ast::MatchArm]) -> Option<crate::parse::ast::KindType> {
+    use crate::parse::ast::Pat;
+
+    if arms.len() < 2 {
+        return None;
+    }
+    let mut shared: Option<crate::parse::ast::KindType> = None;
+    for arm in arms {
+        let Pat::Kind { kind, .. } = &arm.pat else {
+            return None;
+        };
+        match shared {
+            None => shared = Some(*kind),
+            Some(k) if k == *kind => {}
+            _ => return None,
+        }
+    }
+    shared
 }
 
 /// Detect when every arm of a `match` is a fixed-length array pattern
@@ -1458,6 +1528,7 @@ impl MatchBuilder {
         match &mut self.ops[idx as usize] {
             MatchOp::KindCheck { else_pc, .. }
             | MatchOp::LitEq { else_pc, .. }
+            | MatchOp::RangeCheck { else_pc, .. }
             | MatchOp::ObjCheck { else_pc, .. }
             | MatchOp::LoadField { else_pc, .. }
             | MatchOp::LenCheck { else_pc, .. }
@@ -1492,6 +1563,15 @@ impl MatchBuilder {
                 self.emit_with_pending_else(MatchOp::LitEq {
                     slot,
                     lit: lit_idx,
+                    else_pc: u32::MAX,
+                });
+            }
+            Pat::Range { lo, hi, inclusive } => {
+                self.emit_with_pending_else(MatchOp::RangeCheck {
+                    slot,
+                    lo: *lo,
+                    hi: *hi,
+                    inclusive: *inclusive,
                     else_pc: u32::MAX,
                 });
             }

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -1070,36 +1070,29 @@ fn compile_match(
     // is set to the position of the trailing `Fail` op.
     let mut arm_starts: Vec<u32> = Vec::with_capacity(arms.len());
 
-    // Cross-arm prefix sharing comes in two flavours: object patterns
-    // share a leading key sequence, or array patterns share a fixed
-    // length. The two are mutually exclusive (an arm is `Pat::Obj` xor
-    // `Pat::Arr`), so each match expression picks at most one prelude
-    // shape. Loaded values land in slots `1..=N` and are preserved
-    // across arms via `ResetArm.keep_above = N + 1`. A trailing
-    // wildcard or bind arm participates as a catch-all: prelude
-    // failures (not-an-object, key missing, length mismatch) jump
-    // straight to the catch-all arm rather than the global `Fail` op.
-    let trailing_catchall_idx: Option<usize> = arms
-        .last()
-        .map(|a| matches!(a.pat, Pat::Wild | Pat::Bind(_)))
-        .filter(|b| *b)
-        .map(|_| arms.len() - 1);
-    let typed_arms: &[crate::parse::ast::MatchArm] = match trailing_catchall_idx {
-        Some(_) => &arms[..arms.len() - 1],
-        None => arms,
-    };
-    let shared_keys: Vec<Arc<str>> = detect_shared_key_prefix(typed_arms);
-    let shared_arr_len: Option<u32> = if shared_keys.is_empty() {
-        detect_shared_arr_len(typed_arms)
+    // Cross-arm prefix sharing recognises a *contiguous leading run* of
+    // arms that agree on shape (all `Pat::Obj` with shared keys, all
+    // `Pat::Arr` with same length, or all `Pat::Kind` of the same kind).
+    // The shared check is hoisted into a single match-level prelude;
+    // arms in the leading run use a compressed codegen that skips the
+    // hoisted ops, while later arms (mixed shapes, catch-alls, etc.)
+    // fall through to standard codegen. A failed prelude check jumps to
+    // the first non-shared arm — or to the global `Fail` op when the
+    // entire arm list participates in sharing.
+    let (shared_keys, shared_arms_n) = detect_shared_key_prefix(arms);
+    let (shared_arr_len, shared_arms_n) = if shared_keys.is_empty() {
+        detect_shared_arr_len(arms)
+            .map(|(len, n)| (Some(len), n))
+            .unwrap_or((None, 0))
     } else {
-        None
+        (None, shared_arms_n)
     };
-    let shared_kind: Option<crate::parse::ast::KindType> = if shared_keys.is_empty()
-        && shared_arr_len.is_none()
-    {
-        detect_shared_kind(typed_arms)
+    let (shared_kind, shared_arms_n) = if shared_keys.is_empty() && shared_arr_len.is_none() {
+        detect_shared_kind(arms)
+            .map(|(kind, n)| (Some(kind), n))
+            .unwrap_or((None, 0))
     } else {
-        None
+        (None, shared_arms_n)
     };
     let mut prelude_pending: Vec<u32> = Vec::new();
     if !shared_keys.is_empty() {
@@ -1148,24 +1141,23 @@ fn compile_match(
         // placeholders are tracked independently of earlier arms.
         b.pending_else.push(Vec::new());
         arm_starts.push(b.next_pc());
-        // ResetArm placeholder; slot count patched once we know how many
-        // sub-projections the arm allocated.
+        // Per-arm reset preserves the prelude-allocated slots only for
+        // arms that are part of the shared run; arms outside the shared
+        // run get the default `keep_above = 1` reset so their reads of
+        // the shared slots return null and routinely fall through.
+        let arm_in_share = arm_idx < shared_arms_n;
+        let arm_keep = if arm_in_share { keep_above } else { 1 };
         let reset_idx = b.emit(MatchOp::ResetArm {
-            slots: keep_above,
-            keep_above,
+            slots: arm_keep,
+            keep_above: arm_keep,
         });
 
-        // Slot space: when sharing is active, slot 1 already holds the
-        // shared key's loaded value, so per-arm allocation begins at 2.
-        let mut slot_alloc = SlotAlloc::starting_at(keep_above);
+        // Slot space: when sharing applies to this arm, slot 1.. already
+        // hold the prelude's loaded values, so per-arm allocation begins
+        // above the prelude region.
+        let mut slot_alloc = SlotAlloc::starting_at(arm_keep);
 
-        // The trailing catch-all arm uses standard codegen even when a
-        // shared prefix is active. Sharing only governs the typed arms
-        // (which are uniformly `Pat::Obj` or `Pat::Arr`); the catch-all
-        // is `Pat::Wild` / `Pat::Bind` and produces no field tests.
-        let is_trailing_catchall = trailing_catchall_idx == Some(arm_idx);
-
-        if !shared_keys.is_empty() && !is_trailing_catchall {
+        if arm_in_share && !shared_keys.is_empty() {
             // Object prefix sharing: every arm is `Pat::Obj` whose first
             // `shared_keys.len()` fields agree on key order. Compile
             // those sub-patterns against prelude-allocated slots; let
@@ -1187,7 +1179,7 @@ fn compile_match(
                 });
                 b.compile_pat_for_arm(sub_pat, dst, &mut slot_alloc);
             }
-        } else if shared_kind.is_some() && !is_trailing_catchall {
+        } else if arm_in_share && shared_kind.is_some() {
             // Kind sharing: every arm is `Pat::Kind` testing the same
             // scalar kind. The prelude has already verified the kind, so
             // per-arm codegen only needs to push the optional binding.
@@ -1200,7 +1192,7 @@ fn compile_match(
                     slot: 0,
                 });
             }
-        } else if shared_arr_len.is_some() && !is_trailing_catchall {
+        } else if arm_in_share && shared_arr_len.is_some() {
             // Array length sharing: every arm is `Pat::Arr` with the
             // same exact length and no rest binding. The prelude has
             // already verified the length, so per-arm codegen skips
@@ -1245,11 +1237,14 @@ fn compile_match(
     b.emit(MatchOp::Fail);
 
     // Patch the shared-prelude placeholders (object check, key loads,
-    // length check) to the catch-all arm's start if one exists, or to
-    // the trailing `Fail` op otherwise.
-    let prelude_miss_target: u32 = trailing_catchall_idx
-        .and_then(|i| arm_starts.get(i).copied())
-        .unwrap_or(fail_pc);
+    // length check, kind check) to the start of the first arm that did
+    // not participate in sharing. When every arm participates the miss
+    // path is the trailing `Fail` op.
+    let prelude_miss_target: u32 = if shared_arms_n < arms.len() {
+        arm_starts[shared_arms_n]
+    } else {
+        fail_pc
+    };
     for pc in prelude_pending {
         b.patch_else_pc(pc, prelude_miss_target);
     }
@@ -1341,78 +1336,86 @@ fn compute_max_slots(ops: &[MatchOp]) -> u16 {
     hi
 }
 
-/// Detect when every arm of a `match` is a `Pat::Kind` pattern testing
-/// the same scalar kind (`s: string`, `n: number`, ...). When applicable
-/// the runtime kind check is hoisted out of every per-arm prologue and
-/// emitted once as a match-level prelude, similar to the object/array
-/// prefix sharing variants.
-fn detect_shared_kind(arms: &[crate::parse::ast::MatchArm]) -> Option<crate::parse::ast::KindType> {
+/// Detect a contiguous leading run of `Pat::Kind` arms that all test
+/// the same scalar kind. Returns `(kind, n)` where `n` is the number of
+/// participating arms; arms `arms[n..]` fall through to standard
+/// codegen. Like the other shared-prefix detectors, requires at least
+/// two participating arms.
+fn detect_shared_kind(
+    arms: &[crate::parse::ast::MatchArm],
+) -> Option<(crate::parse::ast::KindType, usize)> {
     use crate::parse::ast::Pat;
 
     if arms.len() < 2 {
         return None;
     }
-    let mut shared: Option<crate::parse::ast::KindType> = None;
-    for arm in arms {
-        let Pat::Kind { kind, .. } = &arm.pat else {
-            return None;
-        };
-        match shared {
-            None => shared = Some(*kind),
-            Some(k) if k == *kind => {}
-            _ => return None,
+    let Pat::Kind { kind: first, .. } = &arms[0].pat else {
+        return None;
+    };
+    let shared = *first;
+    let mut count = 1usize;
+    for arm in &arms[1..] {
+        match &arm.pat {
+            Pat::Kind { kind, .. } if *kind == shared => count += 1,
+            _ => break,
         }
     }
-    shared
+    if count < 2 {
+        None
+    } else {
+        Some((shared, count))
+    }
 }
 
-/// Detect when every arm of a `match` is a fixed-length array pattern
-/// (`Pat::Arr` with no rest binding) of the same length, allowing the
-/// `LenCheck` to be hoisted into a single match-level prelude. Returns
-/// the agreed length when applicable, `None` otherwise.
-///
-/// Like the object variant, the optimization needs at least two arms
-/// and is disabled when any arm has a different shape (including arms
-/// that bind a rest tail, since a rest binding implies a `>=` length
-/// test that does not compose with an exact-length prelude).
-fn detect_shared_arr_len(arms: &[crate::parse::ast::MatchArm]) -> Option<u32> {
+/// Detect a contiguous leading run of fixed-length `Pat::Arr` arms that
+/// all agree on length. Returns `(len, n)` where `n` is the number of
+/// participating arms; arms `arms[n..]` fall through to standard
+/// codegen. Rest bindings disable participation because they imply a
+/// `>=` length test rather than an exact one.
+fn detect_shared_arr_len(arms: &[crate::parse::ast::MatchArm]) -> Option<(u32, usize)> {
     use crate::parse::ast::Pat;
 
     if arms.len() < 2 {
         return None;
     }
-    let mut shared: Option<u32> = None;
-    for arm in arms {
-        let Pat::Arr { elems, rest } = &arm.pat else {
-            return None;
-        };
-        if rest.is_some() {
-            return None;
-        }
-        let len = elems.len() as u32;
-        match shared {
-            None => shared = Some(len),
-            Some(n) if n == len => {}
-            _ => return None,
+    let Pat::Arr {
+        elems: first_elems,
+        rest: first_rest,
+    } = &arms[0].pat
+    else {
+        return None;
+    };
+    if first_rest.is_some() {
+        return None;
+    }
+    let shared = first_elems.len() as u32;
+    let mut count = 1usize;
+    for arm in &arms[1..] {
+        match &arm.pat {
+            Pat::Arr { elems, rest } if rest.is_none() && elems.len() as u32 == shared => {
+                count += 1;
+            }
+            _ => break,
         }
     }
-    shared
+    if count < 2 {
+        None
+    } else {
+        Some((shared, count))
+    }
 }
 
-/// Detect the longest leading key sequence that every arm of a `match`
-/// agrees on. Each arm must be a `Pat::Obj` whose first N fields list the
-/// same keys in the same order; the returned vector contains those keys
-/// (in source order) and unlocks hoisting the corresponding
-/// `ObjCheck + LoadField` ops out of every arm's prologue.
-///
-/// Returns an empty vector when any arm is non-object, when arms have no
-/// leading key in common, or when fewer than two arms exist (the
-/// optimization needs at least two arms to be worth its prelude cost).
-fn detect_shared_key_prefix(arms: &[crate::parse::ast::MatchArm]) -> Vec<Arc<str>> {
+/// Detect the longest leading key sequence shared by a contiguous run
+/// of `Pat::Obj` arms at the start of `arms`. The returned tuple is
+/// `(shared_keys, n)` where `n` is the number of leading arms that
+/// participate in the shared prefix; arms `arms[n..]` fall through to
+/// standard codegen. The optimization requires at least two participating
+/// arms to be worth its prelude cost.
+fn detect_shared_key_prefix(arms: &[crate::parse::ast::MatchArm]) -> (Vec<Arc<str>>, usize) {
     use crate::parse::ast::Pat;
 
     if arms.len() < 2 {
-        return Vec::new();
+        return (Vec::new(), 0);
     }
 
     // Seed the shared prefix with the first arm's full key list.
@@ -1421,30 +1424,39 @@ fn detect_shared_key_prefix(arms: &[crate::parse::ast::MatchArm]) -> Vec<Arc<str
         ..
     } = &arms[0].pat
     else {
-        return Vec::new();
+        return (Vec::new(), 0);
     };
     let mut prefix: Vec<&str> = first_fields.iter().map(|(k, _)| k.as_str()).collect();
     if prefix.is_empty() {
-        return Vec::new();
+        return (Vec::new(), 0);
     }
 
-    // Intersect against each subsequent arm.
+    // Walk subsequent arms, intersecting their leading key list with
+    // the running prefix. Stop at the first arm whose pattern is not
+    // `Pat::Obj` or whose first key does not match — every arm that
+    // contributes must keep at least one key in the shared prefix.
+    let mut count = 1usize;
     for arm in &arms[1..] {
         let Pat::Obj { fields, .. } = &arm.pat else {
-            return Vec::new();
+            break;
         };
         let common = prefix
             .iter()
             .zip(fields.iter().map(|(k, _)| k.as_str()))
             .take_while(|(a, b)| **a == *b)
             .count();
-        prefix.truncate(common);
-        if prefix.is_empty() {
-            return Vec::new();
+        if common == 0 {
+            break;
         }
+        prefix.truncate(common);
+        count += 1;
     }
 
-    prefix.into_iter().map(Arc::from).collect()
+    if count < 2 || prefix.is_empty() {
+        return (Vec::new(), 0);
+    }
+
+    (prefix.into_iter().map(Arc::from).collect(), count)
 }
 
 /// Mutable state used while emitting a `CompiledMatch`. Tracks the op

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -21,7 +21,7 @@ use crate::vm::{
 /// Compile-time variable scope used by the `Compiler` to decide whether an
 /// identifier refers to a bound variable or a built-in/field name.
 #[derive(Clone, Default)]
-struct VarCtx {
+pub(crate) struct VarCtx {
     /// Deduplicated set of names currently in scope; stored inline for small counts.
     known: SmallVec<[Arc<str>; 4]>,
 }
@@ -1075,7 +1075,7 @@ impl PassConfig {
 /// pattern tests, optional guard, and a terminating `Body`. Failed tests
 /// jump forward to the start of the next arm; the trailing `Fail` op is
 /// reached only when no arm matches.
-fn compile_match(
+pub(crate) fn compile_match(
     scrutinee: &Expr,
     arms: &[crate::parse::ast::MatchArm],
     ctx: &VarCtx,

--- a/jetro-core/src/compile/passes.rs
+++ b/jetro-core/src/compile/passes.rs
@@ -17,6 +17,7 @@ fn make_noarg_call(method: BuiltinMethod, name: &str) -> Opcode {
         method,
         name: Arc::from(name),
         sub_progs: Arc::from(&[] as &[Arc<Program>]),
+        sub_kernels: Arc::from(&[] as &[crate::exec::pipeline::BodyKernel]),
         orig_args: Arc::from(&[] as &[Arg]),
         demand_max_keep: None,
     }))

--- a/jetro-core/src/data/context.rs
+++ b/jetro-core/src/data/context.rs
@@ -87,6 +87,15 @@ impl Env {
         self.current = old;
     }
 
+    /// Return `true` when no let-bindings are currently in scope. Used by
+    /// HOF kernel fast paths to detect that a `LoadIdent` cannot resolve
+    /// to a binding and is therefore safe to interpret as a field read on
+    /// the current item.
+    #[inline]
+    pub fn has_no_vars(&self) -> bool {
+        self.vars.is_empty()
+    }
+
     /// Look up a named variable; searches in reverse so the innermost binding wins.
     #[inline]
     pub fn get_var(&self, name: &str) -> Option<&Val> {

--- a/jetro-core/src/data/intern.rs
+++ b/jetro-core/src/data/intern.rs
@@ -1,0 +1,71 @@
+//! Engine-scoped JSON key interner.
+//!
+//! Object keys repeat across rows of a JSON document, so the parser
+//! routes every key through this cache to share one `Arc<str>` per
+//! distinct key. A `KeyCache` instance is engine-owned (held by
+//! [`crate::JetroEngine`]) so per-engine isolation is possible without
+//! threading the cache through every signature; trait-impl ingest
+//! paths fall back to the per-thread [`default_cache`].
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock, RwLock};
+
+const KEY_CAP: usize = 4096;
+
+/// Shared key-interning state. Cheap to clone (single `Arc` bump).
+pub struct KeyCache {
+    map: RwLock<HashMap<Box<str>, Arc<str>>>,
+}
+
+impl KeyCache {
+    /// Allocate a fresh, empty cache wrapped in `Arc` for shared ownership.
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            map: RwLock::new(HashMap::with_capacity(64)),
+        })
+    }
+
+    /// Return a shared `Arc<str>` for `k`, reusing a cached entry when
+    /// possible. Falls back to a fresh allocation once the cache reaches
+    /// `KEY_CAP` entries (preventing unbounded growth on docs with
+    /// adversarial unique keys).
+    #[inline]
+    pub fn intern(&self, k: &str) -> Arc<str> {
+        if let Ok(m) = self.map.read() {
+            if let Some(a) = m.get(k) {
+                return Arc::clone(a);
+            }
+        }
+        let mut m = match self.map.write() {
+            Ok(g) => g,
+            Err(_) => return Arc::<str>::from(k),
+        };
+        if let Some(a) = m.get(k) {
+            return Arc::clone(a);
+        }
+        if m.len() >= KEY_CAP {
+            return Arc::<str>::from(k);
+        }
+        let a: Arc<str> = Arc::<str>::from(k);
+        m.insert(k.into(), Arc::clone(&a));
+        a
+    }
+
+    /// Drop every cached entry. Used by `JetroEngine::clear_cache`.
+    pub fn clear(&self) {
+        if let Ok(mut m) = self.map.write() {
+            m.clear();
+        }
+    }
+}
+
+static DEFAULT_KEY_CACHE: OnceLock<Arc<KeyCache>> = OnceLock::new();
+
+/// Process-wide key cache used by callers without an engine handle: the
+/// trait impls `From<serde_json::Value> for Val` and the standalone
+/// `Jetro::from_bytes` path. Engine-aware ingest goes through the
+/// engine's own [`KeyCache`] instead.
+#[inline]
+pub fn default_cache() -> &'static Arc<KeyCache> {
+    DEFAULT_KEY_CACHE.get_or_init(KeyCache::new)
+}

--- a/jetro-core/src/data/mod.rs
+++ b/jetro-core/src/data/mod.rs
@@ -7,6 +7,7 @@
 //! - [`runtime`] — per-evaluation runtime state shared across the engine.
 
 pub(crate) mod context;
+pub(crate) mod intern;
 pub(crate) mod runtime;
 pub(crate) mod tape;
 pub(crate) mod value;

--- a/jetro-core/src/data/runtime.rs
+++ b/jetro-core/src/data/runtime.rs
@@ -250,7 +250,14 @@ fn apply_compiled_item(
                 | Arg::Named(_, Expr::Lambda { params, .. }) => params.first().map(|s| s.as_str()),
                 _ => None,
             };
-            if lambda_name.is_none() {
+            // `LoadIdent` at the head of a body program dispatches to
+            // a no-arg builtin when current is array/string and the
+            // ident is a builtin name (e.g. `.map(len)` invokes `len`
+            // as a builtin) — a path the kernel form drops. Skip the
+            // fast path for those programs.
+            let starts_with_load_ident =
+                matches!(prog.ops.first(), Some(crate::vm::Opcode::LoadIdent(_)));
+            if lambda_name.is_none() && !starts_with_load_ident {
                 return eval_kernel(k, &item, |fallback_item| {
                     let frame = env.push_lam(None, fallback_item.clone());
                     let result = vm.exec_in_env(prog, env);

--- a/jetro-core/src/data/runtime.rs
+++ b/jetro-core/src/data/runtime.rs
@@ -215,6 +215,13 @@ fn eval_compiled_arg_at(
 /// Push `item` as the current value (`@`) into `env`, execute the sub-program
 /// at `arg`'s position, then restore the previous current value. Handles both
 /// named lambda parameters and implicit `@` bindings.
+///
+/// Higher-order builtins (`.filter`, `.map`, `.any`, `.all`, `.find`, ...)
+/// invoke this in a tight per-element loop. When the lambda body has been
+/// classified to a non-`Generic` `BodyKernel` at compile time, we dispatch
+/// through `eval_kernel` for native-speed Rust evaluation; otherwise the
+/// VM runs the program. The kernel form skips the per-iteration VM stack
+/// init and opcode-dispatch loop, which dominates simple predicates.
 fn apply_compiled_item(
     vm: &mut VM,
     call: &CompiledCall,
@@ -222,12 +229,38 @@ fn apply_compiled_item(
     arg: &Arg,
     env: &mut Env,
 ) -> Result<Val, EvalError> {
+    use crate::exec::pipeline::{eval_kernel, BodyKernel};
+
     let idx = arg_index(call.orig_args.as_ref(), arg)
         .ok_or_else(|| EvalError(format!("{}: argument lookup failed", call.name)))?;
     let prog = call
         .sub_progs
         .get(idx)
         .ok_or_else(|| EvalError(format!("{}: missing compiled argument", call.name)))?;
+    let kernel = call.sub_kernels.get(idx);
+
+    // Fast path: when the kernel is a non-`Generic` shape and the lambda
+    // does not introduce a named parameter, evaluate directly against
+    // `item` without entering the VM. The kernel reads `@` semantically
+    // by treating `item` as the current value.
+    if let Some(k) = kernel {
+        if !matches!(k, BodyKernel::Generic) {
+            let lambda_name = match arg {
+                Arg::Pos(Expr::Lambda { params, .. })
+                | Arg::Named(_, Expr::Lambda { params, .. }) => params.first().map(|s| s.as_str()),
+                _ => None,
+            };
+            if lambda_name.is_none() {
+                return eval_kernel(k, &item, |fallback_item| {
+                    let frame = env.push_lam(None, fallback_item.clone());
+                    let result = vm.exec_in_env(prog, env);
+                    env.pop_lam(frame);
+                    result
+                });
+            }
+        }
+    }
+
     match arg {
         Arg::Pos(Expr::Lambda { params, .. }) | Arg::Named(_, Expr::Lambda { params, .. }) => {
             let name = params.first().map(|s| s.as_str());

--- a/jetro-core/src/data/runtime.rs
+++ b/jetro-core/src/data/runtime.rs
@@ -244,7 +244,7 @@ fn apply_compiled_item(
     // `item` without entering the VM. The kernel reads `@` semantically
     // by treating `item` as the current value.
     if let Some(k) = kernel {
-        if !matches!(k, BodyKernel::Generic) {
+        if !matches!(k, BodyKernel::Generic) && env.has_no_vars() {
             let lambda_name = match arg {
                 Arg::Pos(Expr::Lambda { params, .. })
                 | Arg::Named(_, Expr::Lambda { params, .. }) => params.first().map(|s| s.as_str()),

--- a/jetro-core/src/data/value.rs
+++ b/jetro-core/src/data/value.rs
@@ -244,35 +244,16 @@ impl Val {
 }
 
 
-thread_local! {
-    /// Shared sentinel `Val::Null` available without allocation; used by callers that need a `&Val`.
-    static NULL_VAL: Val = Val::Null;
-    /// Per-thread key-interning cache: maps raw `Box<str>` → shared `Arc<str>` to deduplicate
-    /// object key allocations across repeated parses. Capped at 4096 entries to bound memory.
-    static KEY_INTERN: std::cell::RefCell<std::collections::HashMap<Box<str>, Arc<str>>> =
-        std::cell::RefCell::new(std::collections::HashMap::with_capacity(64));
-}
-
-
-/// Return a shared `Arc<str>` for `k`, reusing a cached copy when possible.
-/// Falls back to a fresh allocation once the per-thread cache exceeds 4096 entries.
+/// Return a shared `Arc<str>` for `k`, reusing a cached copy from the
+/// process-wide [`crate::data::intern::default_cache`] when possible.
+/// Used by `From<serde_json::Value> for Val` and the standalone
+/// `Jetro::from_bytes` path; engine-aware ingestion uses
+/// [`Val::from_value_with`] / [`Val::from_simd_borrowed_with`] /
+/// [`Val::from_tape_data_with`] instead, which thread an engine-owned
+/// [`crate::data::intern::KeyCache`].
 #[inline]
 pub fn intern_key(k: &str) -> Arc<str> {
-    const CAP: usize = 4096;
-    KEY_INTERN.with(|cell| {
-        let mut m = cell.borrow_mut();
-        if let Some(a) = m.get(k) {
-            return Arc::clone(a);
-        }
-        if m.len() >= CAP {
-            
-            
-            return Arc::<str>::from(k);
-        }
-        let a: Arc<str> = Arc::<str>::from(k);
-        m.insert(k.into(), Arc::clone(&a));
-        a
-    })
+    crate::data::intern::default_cache().intern(k)
 }
 
 
@@ -1303,6 +1284,231 @@ impl Val {
                 let mut out: IndexMap<Arc<str>, Val> = IndexMap::with_capacity(m.len());
                 for (k, v) in m.iter() {
                     out.insert(intern_key(k.as_ref()), Self::from_simd_borrowed(v));
+                }
+                Val::Obj(Arc::new(out))
+            }
+        }
+    }
+
+    // =================================================================
+    // Engine-aware ingest constructors.
+    //
+    // Each one mirrors the matching default-cache constructor above but
+    // routes object-key interning through the supplied
+    // [`crate::data::intern::KeyCache`]. `JetroEngine::parse_*` calls
+    // these so per-engine isolation is preserved without altering the
+    // existing `From` trait impls.
+    // =================================================================
+
+    /// Convert a borrowed `serde_json::Value` into `Val`, interning every
+    /// object key into `caches`. Promotes homogeneous arrays to columnar
+    /// lanes, matching `From<&serde_json::Value> for Val`.
+    pub fn from_value_with(
+        caches: &crate::data::intern::KeyCache,
+        v: &serde_json::Value,
+    ) -> Self {
+        match v {
+            serde_json::Value::Null => Val::Null,
+            serde_json::Value::Bool(b) => Val::Bool(*b),
+            serde_json::Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    Val::Int(i)
+                } else {
+                    Val::Float(n.as_f64().unwrap_or(0.0))
+                }
+            }
+            serde_json::Value::String(s) => Val::Str(Arc::from(s.as_str())),
+            serde_json::Value::Array(a) => {
+                let all_i64 = !a.is_empty()
+                    && a.iter()
+                        .all(|v| matches!(v, serde_json::Value::Number(n) if n.is_i64()));
+                if all_i64 {
+                    let out: Vec<i64> = a
+                        .iter()
+                        .filter_map(|v| {
+                            if let serde_json::Value::Number(n) = v {
+                                n.as_i64()
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    return Val::IntVec(Arc::new(out));
+                }
+                let all_str =
+                    !a.is_empty() && a.iter().all(|v| matches!(v, serde_json::Value::String(_)));
+                if all_str {
+                    let out: Vec<Arc<str>> = a
+                        .iter()
+                        .filter_map(|v| {
+                            if let serde_json::Value::String(s) = v {
+                                Some(Arc::from(s.as_str()))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    return Val::StrVec(Arc::new(out));
+                }
+                Val::Arr(Arc::new(
+                    a.iter().map(|v| Self::from_value_with(caches, v)).collect(),
+                ))
+            }
+            serde_json::Value::Object(m) => Val::Obj(Arc::new(
+                m.iter()
+                    .map(|(k, v)| (caches.intern(k.as_str()), Self::from_value_with(caches, v)))
+                    .collect(),
+            )),
+        }
+    }
+
+    /// Materialise a `Val` from a simd-json `TapeData`, interning object
+    /// keys through `caches` instead of the default thread-local cache.
+    #[cfg(feature = "simd-json")]
+    pub fn from_tape_data_with(
+        caches: &crate::data::intern::KeyCache,
+        tape: &Arc<crate::data::tape::TapeData>,
+    ) -> Val {
+        let mut idx = 0usize;
+        Self::from_tape_walk_with(caches, tape, &mut idx)
+    }
+
+    /// Recursive helper for [`Val::from_tape_data_with`]; mirrors
+    /// [`Val::from_tape_walk`] body for body, replacing every
+    /// `intern_key` call with `caches.intern`.
+    #[cfg(feature = "simd-json")]
+    fn from_tape_walk_with(
+        caches: &crate::data::intern::KeyCache,
+        tape: &Arc<crate::data::tape::TapeData>,
+        idx: &mut usize,
+    ) -> Val {
+        use crate::data::tape::TapeNode;
+        use simd_json::StaticNode as SN;
+        let here = tape.nodes[*idx];
+        *idx += 1;
+        match here {
+            TapeNode::Static(SN::Null) => Val::Null,
+            TapeNode::Static(SN::Bool(b)) => Val::Bool(b),
+            TapeNode::Static(SN::I64(n)) => Val::Int(n),
+            TapeNode::Static(SN::U64(n)) => {
+                if n <= i64::MAX as u64 {
+                    Val::Int(n as i64)
+                } else {
+                    Val::Float(n as f64)
+                }
+            }
+            TapeNode::Static(SN::F64(f)) => Val::Float(f),
+            TapeNode::String(_) => Val::StrSlice(tape.str_ref_at(*idx - 1)),
+            TapeNode::Array { len, .. } => {
+                if len == 0 {
+                    return Val::arr(Vec::new());
+                }
+                let first_idx = *idx;
+                let first = tape.nodes[first_idx];
+                let mut try_int = matches!(
+                    first,
+                    TapeNode::Static(SN::I64(_)) | TapeNode::Static(SN::U64(_))
+                );
+                let mut try_float = matches!(
+                    first,
+                    TapeNode::Static(SN::I64(_))
+                        | TapeNode::Static(SN::U64(_))
+                        | TapeNode::Static(SN::F64(_))
+                );
+                let mut try_str = matches!(first, TapeNode::String(_));
+                let mut probe = first_idx;
+                let mut counted = 0usize;
+                while counted < len && (try_int || try_float || try_str) {
+                    match tape.nodes[probe] {
+                        TapeNode::Static(SN::I64(_)) => {
+                            try_str = false;
+                            probe += 1;
+                        }
+                        TapeNode::Static(SN::U64(n)) => {
+                            if n > i64::MAX as u64 {
+                                try_int = false;
+                            }
+                            try_str = false;
+                            probe += 1;
+                        }
+                        TapeNode::Static(SN::F64(_)) => {
+                            try_int = false;
+                            try_str = false;
+                            probe += 1;
+                        }
+                        TapeNode::String(_) => {
+                            try_int = false;
+                            try_float = false;
+                            probe += 1;
+                        }
+                        TapeNode::Static(_) => {
+                            try_int = false;
+                            try_float = false;
+                            try_str = false;
+                            probe += 1;
+                        }
+                        TapeNode::Array { .. } | TapeNode::Object { .. } => {
+                            try_int = false;
+                            try_float = false;
+                            try_str = false;
+                            probe += tape.span(probe);
+                        }
+                    }
+                    counted += 1;
+                }
+                if try_int {
+                    let mut out: Vec<i64> = Vec::with_capacity(len);
+                    for _ in 0..len {
+                        match tape.nodes[*idx] {
+                            TapeNode::Static(SN::I64(n)) => out.push(n),
+                            TapeNode::Static(SN::U64(n)) if n <= i64::MAX as u64 => {
+                                out.push(n as i64)
+                            }
+                            _ => unreachable!("homogeneity check"),
+                        }
+                        *idx += 1;
+                    }
+                    return Val::IntVec(Arc::new(out));
+                }
+                if try_float {
+                    let mut out: Vec<f64> = Vec::with_capacity(len);
+                    for _ in 0..len {
+                        match tape.nodes[*idx] {
+                            TapeNode::Static(SN::I64(n)) => out.push(n as f64),
+                            TapeNode::Static(SN::U64(n)) => out.push(n as f64),
+                            TapeNode::Static(SN::F64(f)) => out.push(f),
+                            _ => unreachable!("homogeneity check"),
+                        }
+                        *idx += 1;
+                    }
+                    return Val::FloatVec(Arc::new(out));
+                }
+                if try_str {
+                    let mut out: Vec<crate::data::tape::StrRef> = Vec::with_capacity(len);
+                    for _ in 0..len {
+                        if let TapeNode::String(_) = tape.nodes[*idx] {
+                            out.push(tape.str_ref_at(*idx));
+                        }
+                        *idx += 1;
+                    }
+                    return Val::StrSliceVec(Arc::new(out));
+                }
+                let mut out: Vec<Val> = Vec::with_capacity(len);
+                for _ in 0..len {
+                    out.push(Self::from_tape_walk_with(caches, tape, idx));
+                }
+                Val::Arr(Arc::new(out))
+            }
+            TapeNode::Object { len, .. } => {
+                let mut out: IndexMap<Arc<str>, Val> = IndexMap::with_capacity(len);
+                for _ in 0..len {
+                    let key = match tape.nodes[*idx] {
+                        TapeNode::String(s) => s,
+                        _ => unreachable!("object key must be string"),
+                    };
+                    *idx += 1;
+                    let v = Self::from_tape_walk_with(caches, tape, idx);
+                    out.insert(caches.intern(key), v);
                 }
                 Val::Obj(Arc::new(out))
             }

--- a/jetro-core/src/exec/composed.rs
+++ b/jetro-core/src/exec/composed.rs
@@ -10,8 +10,8 @@ use smallvec::SmallVec;
 use std::borrow::{Borrow, Cow};
 
 use crate::builtins::BuiltinCall;
-use crate::parse::chain_ir::PullDemand;
 use crate::data::value::Val;
+use crate::plan::demand::PullDemand;
 
 /// Per-element output of a `Stage::apply`. `Pass(Cow::Borrowed)` is the
 /// hot path for filter and field-read (zero clone); `Cow::Owned` for
@@ -87,6 +87,43 @@ impl Stage for BuiltinStage {
         match self.call.apply(x) {
             Some(v) => StageOutput::Pass(Cow::Owned(v)),
             None => StageOutput::Filtered,
+        }
+    }
+}
+
+/// Pipeline-only row filter for `compact()`: drop null rows without applying
+/// the whole-array scalar compact operation to each element.
+pub struct CompactFilterStage;
+
+impl Stage for CompactFilterStage {
+    #[inline]
+    fn apply<'a>(&self, x: &'a Val) -> StageOutput<'a> {
+        if matches!(x, Val::Null) {
+            StageOutput::Filtered
+        } else {
+            StageOutput::Pass(Cow::Borrowed(x))
+        }
+    }
+}
+
+/// Pipeline-only row filter for literal `remove(value)`.
+pub struct RemoveValueFilterStage {
+    target: Val,
+}
+
+impl RemoveValueFilterStage {
+    pub fn new(target: Val) -> Self {
+        Self { target }
+    }
+}
+
+impl Stage for RemoveValueFilterStage {
+    #[inline]
+    fn apply<'a>(&self, x: &'a Val) -> StageOutput<'a> {
+        if crate::util::vals_eq(x, &self.target) {
+            StageOutput::Filtered
+        } else {
+            StageOutput::Pass(Cow::Borrowed(x))
         }
     }
 }
@@ -234,7 +271,12 @@ where
 }
 
 /// Run `stages` over `arr` and return the nth emitted output.
-pub fn run_pipeline_nth_with_demand(arr: &[Val], stages: &dyn Stage, demand: PullDemand, nth: usize) -> Val {
+pub fn run_pipeline_nth_with_demand(
+    arr: &[Val],
+    stages: &dyn Stage,
+    demand: PullDemand,
+    nth: usize,
+) -> Val {
     match demand {
         PullDemand::NthInput(i) => {
             run_pipeline_nth_iter_with_demand(arr.get(i).into_iter(), stages, PullDemand::All, 0)
@@ -340,7 +382,8 @@ where
                     return cow.into_owned();
                 }
                 emitted_outputs += 1;
-                if matches!(demand, PullDemand::UntilOutput(n) | PullDemand::LastInput(n) if emitted_outputs >= n) {
+                if matches!(demand, PullDemand::UntilOutput(n) | PullDemand::LastInput(n) if emitted_outputs >= n)
+                {
                     break;
                 }
             }
@@ -351,11 +394,13 @@ where
                         return it.into_owned();
                     }
                     emitted_outputs += 1;
-                    if matches!(demand, PullDemand::UntilOutput(n) | PullDemand::LastInput(n) if emitted_outputs >= n) {
+                    if matches!(demand, PullDemand::UntilOutput(n) | PullDemand::LastInput(n) if emitted_outputs >= n)
+                    {
                         break;
                     }
                 }
-                if matches!(demand, PullDemand::UntilOutput(n) | PullDemand::LastInput(n) if emitted_outputs >= n) {
+                if matches!(demand, PullDemand::UntilOutput(n) | PullDemand::LastInput(n) if emitted_outputs >= n)
+                {
                     break;
                 }
             }
@@ -955,8 +1000,14 @@ fn barrier_top_or_bottom_k(buf: Vec<Val>, key: &KeySource, k: usize, largest: bo
     } else {
         crate::exec::pipeline::StageStrategy::SortTopK(k)
     };
-    crate::exec::pipeline::bounded_sort_by_key_cmp(buf, false, strategy, |v| Ok(key.extract(v)), cmp_val)
-        .unwrap_or_default()
+    crate::exec::pipeline::bounded_sort_by_key_cmp(
+        buf,
+        false,
+        strategy,
+        |v| Ok(key.extract(v)),
+        cmp_val,
+    )
+    .unwrap_or_default()
 }
 
 /// Barrier operation: deduplicate rows, keeping the first occurrence of each
@@ -1499,8 +1550,8 @@ mod tests {
     #[test]
     fn step3d_phase3_filter_reorder() {
         // Two consecutive Filter stages should be fused/reordered into one by the planner.
-        use crate::parse::ast::BinOp;
         use crate::exec::pipeline::{plan_with_kernels, BodyKernel, Sink, Stage};
+        use crate::parse::ast::BinOp;
         use std::sync::Arc;
         let dummy = Arc::new(crate::vm::Program::new(Vec::new(), ""));
         let stages = vec![
@@ -1516,7 +1567,11 @@ mod tests {
             ),
         ];
         let kernels = vec![
-            BodyKernel::FieldCmpLit(Arc::from("price"), BinOp::Lt, crate::data::value::Val::Int(100)),
+            BodyKernel::FieldCmpLit(
+                Arc::from("price"),
+                BinOp::Lt,
+                crate::data::value::Val::Int(100),
+            ),
             BodyKernel::FieldCmpLit(
                 Arc::from("active"),
                 BinOp::Eq,

--- a/jetro-core/src/exec/composed.rs
+++ b/jetro-core/src/exec/composed.rs
@@ -674,6 +674,59 @@ impl Stage for GenericFilter {
     }
 }
 
+/// A pipeline stage that runs a compiled `match` expression as a boolean
+/// predicate against each row, bypassing VM stack/opcode dispatch. The
+/// arm bodies are expected to evaluate to truthy/falsy values; on
+/// match-time error the row is dropped.
+pub struct MatchFilter {
+    /// The compiled flat-IR match program to dispatch into per row.
+    pub cm: std::sync::Arc<crate::vm::CompiledMatch>,
+    /// Shared VM and environment context, wrapped for interior mutability.
+    pub ctx: std::rc::Rc<std::cell::RefCell<VmCtx>>,
+}
+
+impl Stage for MatchFilter {
+    /// Set `@` to `x`, evaluate the match flat-IR with `x` as the
+    /// scrutinee, and pass the row through when the chosen arm body is
+    /// truthy. Errors and non-exhaustive matches degrade to `Filtered`.
+    fn apply<'a>(&self, x: &'a Val) -> StageOutput<'a> {
+        let mut c = self.ctx.borrow_mut();
+        let VmCtx { vm, env } = &mut *c;
+        let prev = env.swap_current(x.clone());
+        let r = vm.exec_match(&self.cm, x, env);
+        env.restore_current(prev);
+        match r {
+            Ok(v) if crate::util::is_truthy(&v) => StageOutput::Pass(Cow::Borrowed(x)),
+            _ => StageOutput::Filtered,
+        }
+    }
+}
+
+/// A pipeline stage that runs a compiled `match` expression to project
+/// each row into a new value, bypassing VM stack/opcode dispatch.
+pub struct MatchMap {
+    /// The compiled flat-IR match program to dispatch into per row.
+    pub cm: std::sync::Arc<crate::vm::CompiledMatch>,
+    /// Shared VM and environment context, wrapped for interior mutability.
+    pub ctx: std::rc::Rc<std::cell::RefCell<VmCtx>>,
+}
+
+impl Stage for MatchMap {
+    /// Set `@` to `x`, evaluate the match flat-IR, and forward the
+    /// arm-body result. Errors degrade to `Filtered`.
+    fn apply<'a>(&self, x: &'a Val) -> StageOutput<'a> {
+        let mut c = self.ctx.borrow_mut();
+        let VmCtx { vm, env } = &mut *c;
+        let prev = env.swap_current(x.clone());
+        let r = vm.exec_match(&self.cm, x, env);
+        env.restore_current(prev);
+        match r {
+            Ok(v) => StageOutput::Pass(Cow::Owned(v)),
+            Err(_) => StageOutput::Filtered,
+        }
+    }
+}
+
 /// A pipeline stage that maps each element through a compiled expression,
 /// producing a new owned `Val` per row.
 pub struct GenericMap {

--- a/jetro-core/src/exec/composed.rs
+++ b/jetro-core/src/exec/composed.rs
@@ -687,13 +687,16 @@ pub struct MatchFilter {
 
 impl Stage for MatchFilter {
     /// Set `@` to `x`, evaluate the match flat-IR with `x` as the
-    /// scrutinee, and pass the row through when the chosen arm body is
-    /// truthy. Errors and non-exhaustive matches degrade to `Filtered`.
+    /// scrutinee via the view-domain runtime so missed-arm pattern
+    /// tests do not materialise sub-`Val`s, and pass the row through
+    /// when the chosen arm body is truthy. Errors and non-exhaustive
+    /// matches degrade to `Filtered`.
     fn apply<'a>(&self, x: &'a Val) -> StageOutput<'a> {
         let mut c = self.ctx.borrow_mut();
         let VmCtx { vm, env } = &mut *c;
         let prev = env.swap_current(x.clone());
-        let r = vm.exec_match(&self.cm, x, env);
+        let view = crate::data::view::ValView::new(x);
+        let r = crate::vm::exec::exec_match_view(vm, &self.cm, view, env);
         env.restore_current(prev);
         match r {
             Ok(v) if crate::util::is_truthy(&v) => StageOutput::Pass(Cow::Borrowed(x)),
@@ -712,13 +715,16 @@ pub struct MatchMap {
 }
 
 impl Stage for MatchMap {
-    /// Set `@` to `x`, evaluate the match flat-IR, and forward the
-    /// arm-body result. Errors degrade to `Filtered`.
+    /// Set `@` to `x`, evaluate the match flat-IR via the view-domain
+    /// runtime so pattern tests against borrowed sub-projections do not
+    /// allocate, and forward the arm-body result. Errors degrade to
+    /// `Filtered`.
     fn apply<'a>(&self, x: &'a Val) -> StageOutput<'a> {
         let mut c = self.ctx.borrow_mut();
         let VmCtx { vm, env } = &mut *c;
         let prev = env.swap_current(x.clone());
-        let r = vm.exec_match(&self.cm, x, env);
+        let view = crate::data::view::ValView::new(x);
+        let r = crate::vm::exec::exec_match_view(vm, &self.cm, view, env);
         env.restore_current(prev);
         match r {
             Ok(v) => StageOutput::Pass(Cow::Owned(v)),

--- a/jetro-core/src/exec/interpreted.rs
+++ b/jetro-core/src/exec/interpreted.rs
@@ -268,7 +268,23 @@ impl ExecCtx<'_> {
                     Ok(None) => return None,
                     Err(err) => return Some(Err(err)),
                 };
-                Some(structural.run(index, bytes))
+                // Only `StructuralPlan::DeepMatch` needs VM access for
+                // per-candidate guard / body programs; for the other
+                // variants we keep the VM-free entry so existing
+                // tests (which assert that `root_val` stays unmaterialised)
+                // are unaffected.
+                if matches!(structural, crate::exec::structural::StructuralPlan::DeepMatch { .. })
+                {
+                    let env = match self.take_env() {
+                        Ok(e) => e,
+                        Err(e) => return Some(Err(e)),
+                    };
+                    let result = structural.run_with_vm(index, bytes, &mut self.vm, &env);
+                    self.env = Some(env);
+                    Some(result)
+                } else {
+                    Some(structural.run(index, bytes))
+                }
             }
             (
                 BackendPreference::TapeView

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -9,12 +9,12 @@
 
 use std::sync::Arc;
 
-use crate::parse::ast::Expr;
 use crate::builtins::{
     BuiltinCancellation, BuiltinMethod, BuiltinNumericReducer, BuiltinViewStage,
 };
 use crate::data::context::{Env, EvalError};
 use crate::data::value::Val;
+use crate::parse::ast::Expr;
 
 mod capability;
 mod collector;
@@ -23,17 +23,17 @@ mod common;
 mod composed;
 mod exec;
 mod indexed_exec;
-mod kernels;
-pub(crate) mod materialized_exec;
 mod ir;
-mod lower;
+mod kernels;
 pub(crate) mod logical_lower;
+mod lower;
+pub(crate) mod materialized_exec;
 mod operator;
 mod plan;
-mod symbolic;
 mod reducer;
 mod row_source;
 mod sink_accumulator;
+mod symbolic;
 mod val_stage_flow;
 pub(crate) use capability::{
     view_capabilities, view_prefix_capabilities, SourceAccessMode, SourceCapabilities,
@@ -45,6 +45,9 @@ pub(crate) use common::{
     num_finalise, num_fold, ordered_by_key_cmp, walk_field_chain, BoundedKeySorter,
     OrderedKeySorter,
 };
+#[cfg(test)]
+pub use ir::Strategy;
+pub use ir::{PhysicalExecPath, Plan, Position, StageStrategy};
 pub use kernels::{eval_cmp_op, eval_kernel, BodyKernel};
 pub(crate) use kernels::{eval_view_kernel, CollectLayout, ObjectKernel, ViewKernelValue};
 pub use operator::{ReducerOp, ReducerSpec};
@@ -52,14 +55,11 @@ pub use operator::{ReducerOp, ReducerSpec};
 pub use plan::compute_strategies;
 #[cfg(test)]
 pub use plan::plan;
-pub use ir::{PhysicalExecPath, Plan, Position, StageStrategy};
 #[cfg(test)]
-pub use ir::Strategy;
+pub use plan::select_strategy;
 pub use plan::{
     compute_strategies_with_kernels, plan_with_exprs, plan_with_kernels, select_exec_path,
 };
-#[cfg(test)]
-pub use plan::select_strategy;
 pub(crate) use reducer::ReducerAccumulator;
 pub(crate) use sink_accumulator::SinkAccumulator;
 
@@ -548,9 +548,10 @@ mod tests {
     #[cfg(feature = "simd-json")]
     #[test]
     fn tape_row_source_walks_field_chain_array_lazily() {
-        let tape =
-            crate::data::tape::TapeData::parse(br#"{"books":[{"id":1},{"id":2}],"skip":[3]}"#.to_vec())
-                .unwrap();
+        let tape = crate::data::tape::TapeData::parse(
+            br#"{"books":[{"id":1},{"id":2}],"skip":[3]}"#.to_vec(),
+        )
+        .unwrap();
         let keys = vec![std::sync::Arc::<str>::from("books")];
 
         let source = row_source::TapeRowSource::from_field_chain(&tape, &keys);
@@ -655,7 +656,6 @@ mod tests {
 
     #[test]
     fn lower_whole_receiver_builtin_not_as_per_element_stage() {
-        assert!(lower_query("$.items.compact()").is_none());
         assert!(lower_query("$.items.join(\",\")").is_none());
     }
 
@@ -1397,7 +1397,7 @@ mod tests {
         let demand = p.source_demand();
         assert_eq!(
             demand.chain.pull,
-            crate::parse::chain_ir::PullDemand::FirstInput(2)
+            crate::plan::demand::PullDemand::FirstInput(2)
         );
         let out = p.run(&doc).unwrap();
         assert_eq!(out, Val::Null);
@@ -1418,7 +1418,7 @@ mod tests {
         let demand = p.source_demand();
         assert_eq!(
             demand.chain.pull,
-            crate::parse::chain_ir::PullDemand::UntilOutput(2)
+            crate::plan::demand::PullDemand::UntilOutput(2)
         );
         let out = p.run(&doc).unwrap();
         let out_json: serde_json::Value = out.into();
@@ -1442,7 +1442,7 @@ mod tests {
         let demand = p.source_demand();
         assert_eq!(
             demand.chain.pull,
-            crate::parse::chain_ir::PullDemand::LastInput(1)
+            crate::plan::demand::PullDemand::LastInput(1)
         );
         let out = p.run(&doc).unwrap();
         let out_json: serde_json::Value = out.into();
@@ -1464,7 +1464,7 @@ mod tests {
         let demand = p.source_demand();
         assert_eq!(
             demand.chain.pull,
-            crate::parse::chain_ir::PullDemand::NthInput(1)
+            crate::plan::demand::PullDemand::NthInput(1)
         );
         let out = p.run(&doc).unwrap();
         let out_json: serde_json::Value = out.into();
@@ -1485,10 +1485,76 @@ mod tests {
             .into();
         let p = lower_query("$.data.filter(score > 900).map(score).nth(1)").unwrap();
         let demand = p.source_demand();
-        assert_eq!(demand.chain.pull, crate::parse::chain_ir::PullDemand::All);
+        assert_eq!(demand.chain.pull, crate::plan::demand::PullDemand::All);
         let out = p.run(&doc).unwrap();
         let out_json: serde_json::Value = out.into();
         assert_eq!(out_json, json!(902));
+    }
+
+    #[test]
+    fn compact_first_and_last_are_filter_like() {
+        use serde_json::json;
+        let doc: Val = (&json!({"xs": [null, 10, null, 20]})).into();
+
+        let first = lower_query("$.xs.compact().first()").unwrap();
+        assert_eq!(
+            first.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::UntilOutput(1)
+        );
+        assert_eq!(first.run(&doc).unwrap(), Val::Int(10));
+
+        let last = lower_query("$.xs.compact().last()").unwrap();
+        assert_eq!(
+            last.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::LastInput(1)
+        );
+        assert_eq!(last.run(&doc).unwrap(), Val::Int(20));
+    }
+
+    #[test]
+    fn remove_first_and_last_are_filter_like() {
+        use serde_json::json;
+        let doc: Val = (&json!({"xs": [2, 1, 2, 3, 2]})).into();
+
+        let collect = lower_query("$.xs.remove(2)").unwrap();
+        let collect_json: serde_json::Value = collect.run(&doc).unwrap().into();
+        assert_eq!(collect_json, json!([1, 3]));
+
+        let first = lower_query("$.xs.remove(2).first()").unwrap();
+        assert_eq!(
+            first.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::UntilOutput(1)
+        );
+        assert_eq!(first.run(&doc).unwrap(), Val::Int(1));
+
+        let last = lower_query("$.xs.remove(2).last()").unwrap();
+        assert_eq!(
+            last.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::LastInput(1)
+        );
+        assert_eq!(last.run(&doc).unwrap(), Val::Int(3));
+    }
+
+    #[test]
+    fn find_first_lowers_to_filter_first_demand() {
+        use serde_json::json;
+        let doc: Val = (&json!({
+            "xs": [
+                {"score": 1},
+                {"score": 9},
+                {"score": 11}
+            ]
+        }))
+            .into();
+
+        let p = lower_query("$.xs.find_first(score > 5)").unwrap();
+        assert!(matches!(p.sink, Sink::Terminal(BuiltinMethod::First)));
+        assert_eq!(
+            p.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::UntilOutput(1)
+        );
+        let out_json: serde_json::Value = p.run(&doc).unwrap().into();
+        assert_eq!(out_json, json!({"score": 9}));
     }
 
     #[test]

--- a/jetro-core/src/exec/pipeline/capability.rs
+++ b/jetro-core/src/exec/pipeline/capability.rs
@@ -8,7 +8,7 @@ use crate::builtins::{
     BuiltinKeyedReducer, BuiltinSinkAccumulator, BuiltinSinkSpec, BuiltinViewInputMode,
     BuiltinViewOutputMode, BuiltinViewStage,
 };
-use crate::parse::chain_ir::PullDemand;
+use crate::plan::demand::PullDemand;
 
 use super::{PipelineBody, Stage};
 
@@ -41,7 +41,9 @@ impl SourceCapabilities {
     pub(crate) fn choose_access(self, demand: PullDemand) -> SourceAccessMode {
         match demand {
             PullDemand::NthInput(idx) if self.indexed_array_child => SourceAccessMode::Indexed(idx),
-            PullDemand::LastInput(n) if self.reverse_stream => SourceAccessMode::Reverse { outputs: n },
+            PullDemand::LastInput(n) if self.reverse_stream => {
+                SourceAccessMode::Reverse { outputs: n }
+            }
             PullDemand::FirstInput(n) if self.forward_stream => SourceAccessMode::ForwardBounded(n),
             _ if self.forward_stream => SourceAccessMode::Forward,
             _ => SourceAccessMode::MaterializedFallback,
@@ -344,15 +346,15 @@ pub(crate) fn view_prefix_capabilities(body: &PipelineBody) -> Option<ViewPrefix
 mod tests {
     use std::sync::Arc;
 
-    use crate::parse::ast::BinOp;
     use crate::builtins::{
         BuiltinMethod, BuiltinSelectionPosition, BuiltinSinkAccumulator, BuiltinViewStage,
     };
+    use crate::data::value::Val;
     use crate::exec::pipeline::{
         BodyKernel, NumOp, PipelineBody, ReducerOp, ReducerSpec, Sink, Stage, ViewInputMode,
         ViewMaterialization, ViewOutputMode, ViewSinkCapability, ViewStageCapability,
     };
-    use crate::data::value::Val;
+    use crate::parse::ast::BinOp;
 
     use super::{view_capabilities, view_prefix_capabilities};
 

--- a/jetro-core/src/exec/pipeline/composed.rs
+++ b/jetro-core/src/exec/pipeline/composed.rs
@@ -12,10 +12,10 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::builtins::{BuiltinNumericReducer, BuiltinSelectionPosition, BuiltinSinkAccumulator};
-use crate::parse::chain_ir::PullDemand;
-use crate::exec::composed as cmp;
 use crate::data::context::{Env, EvalError};
 use crate::data::value::Val;
+use crate::exec::composed as cmp;
+use crate::plan::demand::PullDemand;
 use crate::vm::Program;
 
 use super::{
@@ -87,6 +87,17 @@ impl<'a> ComposedStageBuilder<'a> {
             ) => Box::new(cmp::Skip {
                 remaining: Cell::new(*value),
             }),
+            (Stage::Builtin(call), _) if call.method == crate::builtins::BuiltinMethod::Compact => {
+                Box::new(cmp::CompactFilterStage)
+            }
+            (Stage::Builtin(call), _) if call.method == crate::builtins::BuiltinMethod::Remove => {
+                match &call.args {
+                    crate::builtins::BuiltinArgs::Val(target) => {
+                        Box::new(cmp::RemoveValueFilterStage::new(target.clone()))
+                    }
+                    _ => return None,
+                }
+            }
             (Stage::Builtin(call), _) => Box::new(cmp::BuiltinStage::new(call.clone())),
             (Stage::Filter(p, _), _) => Box::new(cmp::GenericFilter {
                 prog: Arc::clone(p),
@@ -111,7 +122,9 @@ impl<'a> ComposedStageBuilder<'a> {
         kernel: &BodyKernel,
     ) -> Box<dyn cmp::Stage> {
         match kernel {
-            BodyKernel::FieldCmpLit(field, op, lit) if matches!(op, crate::parse::ast::BinOp::Eq) => {
+            BodyKernel::FieldCmpLit(field, op, lit)
+                if matches!(op, crate::parse::ast::BinOp::Eq) =>
+            {
                 Box::new(cmp::FilterFieldEqLit {
                     field: Arc::clone(field),
                     target: lit.clone(),
@@ -319,12 +332,7 @@ macro_rules! run_composed_owned_sink {
 }
 
 /// Runs `chain` over `rows`, collecting into the sink; returns `None` for `ApproxCountDistinct`.
-fn run_sink(
-    sink: &Sink,
-    rows: &[Val],
-    chain: &dyn cmp::Stage,
-    demand: PullDemand,
-) -> Option<Val> {
+fn run_sink(sink: &Sink, rows: &[Val], chain: &dyn cmp::Stage, demand: PullDemand) -> Option<Val> {
     let out = match sink {
         Sink::Collect => cmp::run_pipeline_with_demand::<cmp::CollectSink>(rows, chain, demand),
         Sink::Nth(idx) => cmp::run_pipeline_nth_with_demand(rows, chain, demand, *idx),
@@ -446,7 +454,12 @@ pub(super) fn run(
         last_split = i + 1;
     }
 
-    let chain = build_chain(stages_ref, kernels, last_split..stages_ref.len(), &stage_builder)?;
+    let chain = build_chain(
+        stages_ref,
+        kernels,
+        last_split..stages_ref.len(),
+        &stage_builder,
+    )?;
     let final_demand = Pipeline::segment_source_demand(&stages_ref[last_split..], &eff_sink)
         .chain
         .pull;

--- a/jetro-core/src/exec/pipeline/composed.rs
+++ b/jetro-core/src/exec/pipeline/composed.rs
@@ -105,26 +105,32 @@ impl<'a> ComposedStageBuilder<'a> {
             // stack and opcode-dispatch overhead per row. The detector
             // accepts a leading `SetCurrent`/`PushCurrent` from lambda
             // binding so `.filter(match @ with {...})` matches.
-            (Stage::Filter(p, _), _) if let Some(cm) = program_match_only(p) => {
-                Box::new(cmp::MatchFilter {
-                    cm,
-                    ctx: self.vm_ctx(),
-                })
+            (Stage::Filter(p, _), _) => {
+                if let Some(cm) = program_match_only(p) {
+                    Box::new(cmp::MatchFilter {
+                        cm,
+                        ctx: self.vm_ctx(),
+                    })
+                } else {
+                    Box::new(cmp::GenericFilter {
+                        prog: Arc::clone(p),
+                        ctx: self.vm_ctx(),
+                    })
+                }
             }
-            (Stage::Map(p, _), _) if let Some(cm) = program_match_only(p) => {
-                Box::new(cmp::MatchMap {
-                    cm,
-                    ctx: self.vm_ctx(),
-                })
+            (Stage::Map(p, _), _) => {
+                if let Some(cm) = program_match_only(p) {
+                    Box::new(cmp::MatchMap {
+                        cm,
+                        ctx: self.vm_ctx(),
+                    })
+                } else {
+                    Box::new(cmp::GenericMap {
+                        prog: Arc::clone(p),
+                        ctx: self.vm_ctx(),
+                    })
+                }
             }
-            (Stage::Filter(p, _), _) => Box::new(cmp::GenericFilter {
-                prog: Arc::clone(p),
-                ctx: self.vm_ctx(),
-            }),
-            (Stage::Map(p, _), _) => Box::new(cmp::GenericMap {
-                prog: Arc::clone(p),
-                ctx: self.vm_ctx(),
-            }),
             (Stage::FlatMap(p, _), _) => Box::new(cmp::GenericFlatMap {
                 prog: Arc::clone(p),
                 ctx: self.vm_ctx(),

--- a/jetro-core/src/exec/pipeline/composed.rs
+++ b/jetro-core/src/exec/pipeline/composed.rs
@@ -18,6 +18,7 @@ use crate::exec::composed as cmp;
 use crate::plan::demand::PullDemand;
 use crate::vm::Program;
 
+use super::ir::program_match_only;
 use super::{
     compute_strategies_with_kernels, ordered_by_key_cmp, row_source, BodyKernel, Pipeline, Sink,
     Source, Stage, StageStrategy,
@@ -99,6 +100,23 @@ impl<'a> ComposedStageBuilder<'a> {
                 }
             }
             (Stage::Builtin(call), _) => Box::new(cmp::BuiltinStage::new(call.clone())),
+            // When a filter / map body is a single `match` expression we
+            // dispatch directly into the flat-IR runtime, skipping VM
+            // stack and opcode-dispatch overhead per row. The detector
+            // accepts a leading `SetCurrent`/`PushCurrent` from lambda
+            // binding so `.filter(match @ with {...})` matches.
+            (Stage::Filter(p, _), _) if let Some(cm) = program_match_only(p) => {
+                Box::new(cmp::MatchFilter {
+                    cm,
+                    ctx: self.vm_ctx(),
+                })
+            }
+            (Stage::Map(p, _), _) if let Some(cm) = program_match_only(p) => {
+                Box::new(cmp::MatchMap {
+                    cm,
+                    ctx: self.vm_ctx(),
+                })
+            }
             (Stage::Filter(p, _), _) => Box::new(cmp::GenericFilter {
                 prog: Arc::clone(p),
                 ctx: self.vm_ctx(),

--- a/jetro-core/src/exec/pipeline/indexed_exec.rs
+++ b/jetro-core/src/exec/pipeline/indexed_exec.rs
@@ -5,9 +5,8 @@
 use crate::{
     data::context::{Env, EvalError},
     data::value::Val,
+    plan::demand::PullDemand,
 };
-
-use crate::parse::chain_ir::PullDemand;
 
 use super::{row_source, Pipeline, Position, Stage};
 

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -8,20 +8,23 @@
 
 use std::sync::Arc;
 
-use crate::parse::ast::Expr;
 use crate::builtins::registry::{
-    participates_in_demand, pipeline_materialization, pipeline_order_effect,
-    pipeline_shape, BuiltinId,
+    participates_in_demand, pipeline_materialization, pipeline_order_effect, pipeline_shape,
+    BuiltinId,
 };
 use crate::builtins::{
-    BuiltinMethod, BuiltinPipelineMaterialization,
-    BuiltinPipelineOrderEffect, BuiltinSelectionPosition, BuiltinSinkAccumulator,
-    BuiltinSinkDemand, BuiltinSinkSpec, BuiltinSinkValueNeed, BuiltinViewStage,
+    BuiltinMethod, BuiltinPipelineMaterialization, BuiltinPipelineOrderEffect,
+    BuiltinSelectionPosition, BuiltinSinkAccumulator, BuiltinSinkDemand, BuiltinSinkSpec,
+    BuiltinSinkValueNeed, BuiltinViewStage,
 };
-use crate::parse::chain_ir::{ChainOp, Demand as ChainDemand, PullDemand, ValueNeed};
+use crate::parse::ast::Expr;
+use crate::parse::chain_ir::{Cardinality, ChainOp};
+use crate::plan::demand::{Demand as ChainDemand, PullDemand, ValueNeed};
 use crate::vm::{CompiledObjEntry, Opcode, Program};
 
-use super::{BodyKernel, Pipeline, PipelineBody, Sink, Stage, ViewSinkCapability, ViewStageCapability};
+use super::{
+    BodyKernel, Pipeline, PipelineBody, Sink, Stage, ViewSinkCapability, ViewStageCapability,
+};
 
 /// Indicates whether a positional terminal sink wants the first or the last qualifying element.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -211,7 +214,7 @@ pub enum StageStrategy {
 #[derive(Debug, Clone, Copy)]
 pub struct StageShape {
     /// Whether the stage emits one-to-one, fewer, more, or barrier-level output rows.
-    pub cardinality: crate::parse::chain_ir::Cardinality,
+    pub cardinality: Cardinality,
     /// `true` when the stage supports position-indexed execution (used for `IndexedDispatch`).
     pub can_indexed: bool,
     /// Estimated relative CPU cost per element passing through the stage.
@@ -380,7 +383,6 @@ impl<'a> StageDescriptor<'a> {
             .map(program_ok)
             .unwrap_or(self.receiver_safe_without_body)
     }
-
 }
 
 macro_rules! view_body_stage_descriptor {
@@ -495,9 +497,9 @@ impl Stage {
             }
             Stage::IntRangeBuiltin { method, .. } => Some(StageDescriptor::new(*method)),
             Stage::ExprBuiltin { method, body } => Some(StageDescriptor::new(*method).body(body)),
-            Stage::Builtin(call) => Some(
-                StageDescriptor::new(call.method).allow_one_to_one_order_fallback(),
-            ),
+            Stage::Builtin(call) => {
+                Some(StageDescriptor::new(call.method).allow_one_to_one_order_fallback())
+            }
             Stage::SortedDedup(prog) => {
                 let desc = StageDescriptor::special();
                 Some(if let Some(prog) = prog {
@@ -506,7 +508,9 @@ impl Stage {
                     desc
                 })
             }
-            Stage::CompiledMap(_) => Some(StageDescriptor::special().receiver_unsafe_without_body()),
+            Stage::CompiledMap(_) => {
+                Some(StageDescriptor::special().receiver_unsafe_without_body())
+            }
             _ => None,
         }
     }
@@ -604,10 +608,7 @@ impl Stage {
         let Some(desc) = self.descriptor() else {
             return false;
         };
-        if !matches!(
-            self.shape().cardinality,
-            crate::parse::chain_ir::Cardinality::OneToOne
-        ) {
+        if !matches!(self.shape().cardinality, Cardinality::OneToOne) {
             return false;
         }
         if desc.pipeline_order_effect() != BuiltinPipelineOrderEffect::Preserves {
@@ -661,10 +662,7 @@ impl Stage {
             Some(op) => op.propagate_demand(demand.chain),
             None => ChainDemand::RESULT,
         };
-        let positional = if matches!(
-            self.shape().cardinality,
-            crate::parse::chain_ir::Cardinality::OneToOne
-        ) {
+        let positional = if matches!(self.shape().cardinality, Cardinality::OneToOne) {
             demand.positional
         } else {
             None
@@ -702,7 +700,6 @@ impl Stage {
     /// Returns the static `StageShape` (cardinality, cost, selectivity, indexed flag) for this
     /// stage, used by the planner for strategy selection and filter reordering.
     pub fn shape(&self) -> StageShape {
-        use crate::parse::chain_ir::Cardinality;
         match self {
             Stage::CompiledMap(_) => StageShape {
                 cardinality: Cardinality::OneToOne,

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -878,7 +878,8 @@ pub(super) fn opcode_is_current_only(opcode: &Opcode) -> bool {
         | Opcode::ListComp(_)
         | Opcode::DictComp(_)
         | Opcode::SetComp(_)
-        | Opcode::PatchEval(_) => false,
+        | Opcode::PatchEval(_)
+        | Opcode::Match(_) => false,
         Opcode::DynIndex(prog)
         | Opcode::InlineFilter(prog)
         | Opcode::AndOp(prog)

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -921,7 +921,8 @@ pub(super) fn opcode_is_current_only(opcode: &Opcode) -> bool {
         | Opcode::SetComp(_)
         | Opcode::PatchEval(_)
         | Opcode::Match(_)
-        | Opcode::DeepMatchAll(_) => false,
+        | Opcode::DeepMatchAll(_)
+        | Opcode::DeepMatchFirst(_) => false,
         Opcode::DynIndex(prog)
         | Opcode::InlineFilter(prog)
         | Opcode::AndOp(prog)

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -638,6 +638,17 @@ impl Stage {
         match self {
             Stage::CompiledMap(_) => Some(ChainOp::builtin(BuiltinMethod::Map)),
             Stage::SortedDedup(_) => None,
+            // Filter and Map whose body is a single `match` expression
+            // are reported as `ChainOp::Match` so the demand model can
+            // reason about them with the role-specific propagation rules
+            // (`Predicate` widens upstream demand to scan-until-output;
+            // `Transform` is 1:1).
+            Stage::Filter(prog, _) if program_is_match_only(prog) => {
+                Some(ChainOp::match_role(crate::parse::chain_ir::MatchRole::Predicate))
+            }
+            Stage::Map(prog, _) if program_is_match_only(prog) => {
+                Some(ChainOp::match_role(crate::parse::chain_ir::MatchRole::Transform))
+            }
             _ => self.chain_demand_op(),
         }
     }
@@ -864,6 +875,36 @@ pub(super) fn stages_can_run_with_materialized_receiver(stages: &[Stage]) -> boo
     stages
         .iter()
         .all(|stage| stage.can_run_with_receiver_only(program_is_current_only))
+}
+
+/// Return the `CompiledMatch` payload when `program`'s op stream is a
+/// single `Opcode::Match` instruction (any leading `SetCurrent` /
+/// `PushCurrent` is permitted because the pipeline lowering wraps lambda
+/// bodies that bind the row to `@`). Returning the payload — rather than
+/// just a boolean — lets callers in `composed.rs` build a dedicated
+/// `MatchFilter` / `MatchMap` stage that dispatches directly into the
+/// flat-IR runtime, skipping VM opcode-dispatch overhead per row.
+pub(super) fn program_match_only(program: &Program) -> Option<Arc<crate::vm::CompiledMatch>> {
+    let mut ops = program.ops.iter();
+    while let Some(op) = ops.next() {
+        match op {
+            Opcode::SetCurrent | Opcode::PushCurrent => continue,
+            Opcode::Match(cm) => {
+                if ops.next().is_none() {
+                    return Some(Arc::clone(cm));
+                }
+                return None;
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// Boolean wrapper retained for the chain-IR demand classifier, which
+/// only needs to know whether a stage program *is* a match expression.
+fn program_is_match_only(program: &Program) -> bool {
+    program_match_only(program).is_some()
 }
 
 pub(super) fn program_is_current_only(program: &Program) -> bool {

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -920,7 +920,8 @@ pub(super) fn opcode_is_current_only(opcode: &Opcode) -> bool {
         | Opcode::DictComp(_)
         | Opcode::SetComp(_)
         | Opcode::PatchEval(_)
-        | Opcode::Match(_) => false,
+        | Opcode::Match(_)
+        | Opcode::DeepMatchAll(_) => false,
         Opcode::DynIndex(prog)
         | Opcode::InlineFilter(prog)
         | Opcode::AndOp(prog)

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -9,11 +9,11 @@
 
 use std::sync::Arc;
 
-use crate::parse::ast::Expr;
 use crate::builtins::registry::{pipeline_accepts_arity, pipeline_lowering, BuiltinId};
 use crate::builtins::{
     BuiltinMethod, BuiltinPipelineLowering, BuiltinSinkAccumulator, BuiltinViewStage,
 };
+use crate::parse::ast::Expr;
 use crate::{data::context::EvalError, data::value::Val};
 
 use super::{
@@ -90,7 +90,9 @@ impl Pipeline {
     }
 
     /// Decodes `trailing` steps into stages and a sink, runs rewrite passes, and classifies body kernels.
-    pub(crate) fn lower_body_from_steps(trailing: &[crate::parse::ast::Step]) -> Option<PipelineBody> {
+    pub(crate) fn lower_body_from_steps(
+        trailing: &[crate::parse::ast::Step],
+    ) -> Option<PipelineBody> {
         let (stages, stage_exprs, sink) = decode_method_chain(trailing)?;
         let mut p = PipelineBody {
             stages,
@@ -254,6 +256,15 @@ fn decode_method_chain(
                     continue;
                 }
                 let method = BuiltinMethod::from_name(name.as_str());
+                if matches!(method, BuiltinMethod::Compact | BuiltinMethod::Remove) {
+                    if let Some(call) =
+                        crate::builtins::BuiltinCall::from_literal_ast_args(name.as_str(), args)
+                    {
+                        stages.push(Stage::Builtin(call));
+                        stage_exprs.push(None);
+                        continue;
+                    }
+                }
                 lower_method_from_registry(
                     method,
                     args,
@@ -409,11 +420,15 @@ pub(super) fn compile_subexpr(arg: &crate::parse::ast::Arg) -> Option<Arc<crate:
         Expr::Chain(base, _) if matches!(base.as_ref(), Expr::Current) => inner.clone(),
         other => other.clone(),
     };
-    Some(Arc::new(crate::compile::compiler::Compiler::compile(&rooted, "")))
+    Some(Arc::new(crate::compile::compiler::Compiler::compile(
+        &rooted, "",
+    )))
 }
 
 /// Compiles a sort-key argument into a `SortSpec`, interpreting `UnaryNeg`-wrapping as descending order.
-pub(super) fn compile_sort_spec(arg: &crate::parse::ast::Arg) -> Option<(SortSpec, Option<Arc<Expr>>)> {
+pub(super) fn compile_sort_spec(
+    arg: &crate::parse::ast::Arg,
+) -> Option<(SortSpec, Option<Arc<Expr>>)> {
     use crate::parse::ast::{Arg, Expr};
     let expr = match arg {
         Arg::Pos(e) => e,
@@ -586,7 +601,10 @@ fn push_expr_stage(
     stage_exprs: &mut Vec<Option<Arc<Expr>>>,
 ) -> Option<()> {
     match method {
-        BuiltinMethod::Filter | BuiltinMethod::Find | BuiltinMethod::FindAll => {
+        BuiltinMethod::Filter
+        | BuiltinMethod::Find
+        | BuiltinMethod::FindAll
+        | BuiltinMethod::FindFirst => {
             stages.push(Stage::Filter(
                 compile_subexpr(arg)?,
                 BuiltinViewStage::Filter,
@@ -687,7 +705,10 @@ fn string_arg(arg: &crate::parse::ast::Arg) -> Option<Arc<str>> {
 }
 
 // Constructs the terminal `Sink` for `method`, handling count predicates, numeric reducers, and positional selects.
-fn terminal_sink_for_method(method: BuiltinMethod, args: &[crate::parse::ast::Arg]) -> Option<Sink> {
+fn terminal_sink_for_method(
+    method: BuiltinMethod,
+    args: &[crate::parse::ast::Arg],
+) -> Option<Sink> {
     let spec = method.spec();
     match spec.sink?.accumulator {
         BuiltinSinkAccumulator::ApproxDistinct if args.is_empty() => {

--- a/jetro-core/src/exec/pipeline/materialized_exec.rs
+++ b/jetro-core/src/exec/pipeline/materialized_exec.rs
@@ -22,7 +22,7 @@ use super::{
 };
 
 use crate::builtins::{replace_apply, slice_apply, split_apply, BuiltinMethod};
-use crate::parse::chain_ir::PullDemand;
+use crate::plan::demand::PullDemand;
 
 /// Runs the pipeline against `root`, materialising barrier stages then streaming the rest.
 pub(super) fn run(pipeline: &Pipeline, root: &Val, base_env: &Env) -> Result<Val, EvalError> {
@@ -225,7 +225,8 @@ where
             }
         }
 
-        if matches!(source_demand, PullDemand::NthInput(_)) && matches!(pipeline.sink, Sink::Nth(_)) {
+        if matches!(source_demand, PullDemand::NthInput(_)) && matches!(pipeline.sink, Sink::Nth(_))
+        {
             return Ok(item);
         }
 
@@ -277,7 +278,7 @@ fn apply_adapter_materialized(
             stage,
             strategy,
         };
-        use crate::builtins::{BuiltinMethod as M, builtin::Builtin, defs};
+        use crate::builtins::{builtin::Builtin, defs, BuiltinMethod as M};
         let trait_result = match method {
             M::Reverse => <defs::Reverse as Builtin>::apply_barrier(&mut ctx, buf, body),
             M::Sort => <defs::Sort as Builtin>::apply_barrier(&mut ctx, buf, body),
@@ -301,8 +302,12 @@ fn apply_adapter_materialized(
             M::IndicesWhere => <defs::IndicesWhere as Builtin>::apply_barrier(&mut ctx, buf, body),
             M::MaxBy => <defs::MaxBy as Builtin>::apply_barrier(&mut ctx, buf, body),
             M::MinBy => <defs::MinBy as Builtin>::apply_barrier(&mut ctx, buf, body),
-            M::TransformKeys => <defs::TransformKeys as Builtin>::apply_barrier(&mut ctx, buf, body),
-            M::TransformValues => <defs::TransformValues as Builtin>::apply_barrier(&mut ctx, buf, body),
+            M::TransformKeys => {
+                <defs::TransformKeys as Builtin>::apply_barrier(&mut ctx, buf, body)
+            }
+            M::TransformValues => {
+                <defs::TransformValues as Builtin>::apply_barrier(&mut ctx, buf, body)
+            }
             M::FilterKeys => <defs::FilterKeys as Builtin>::apply_barrier(&mut ctx, buf, body),
             M::FilterValues => <defs::FilterValues as Builtin>::apply_barrier(&mut ctx, buf, body),
             _ => None,
@@ -314,6 +319,16 @@ fn apply_adapter_materialized(
     // Remaining barrier dispatch by Stage variant — all other variants are handled
     // above by Builtin::apply_barrier trait dispatch and never reach this point.
     match stage {
+        Stage::Builtin(call) if call.method == BuiltinMethod::Compact => {
+            buf.retain(|v| !matches!(v, Val::Null));
+            Some(Ok(()))
+        }
+        Stage::Builtin(call) if call.method == BuiltinMethod::Remove => {
+            if let crate::builtins::BuiltinArgs::Val(target) = &call.args {
+                buf.retain(|v| !crate::util::vals_eq(v, target));
+            }
+            Some(Ok(()))
+        }
         // Element-wise scalar (Slice, Replace, ReplaceAll, BuiltinCall::apply).
         Stage::Builtin(_) | Stage::IntRangeBuiltin { .. } | Stage::StringPairBuiltin { .. } => {
             let mut out: Vec<Val> = Vec::with_capacity(buf.len());
@@ -399,7 +414,6 @@ fn apply_expanding_adapter(stage: &Stage, v: &Val, out: &mut Vec<Val>) {
         }
     }
 }
-
 
 impl Iterator for LegacyPreIter {
     type Item = Val;

--- a/jetro-core/src/exec/pipeline/plan.rs
+++ b/jetro-core/src/exec/pipeline/plan.rs
@@ -6,14 +6,12 @@
 
 use std::sync::Arc;
 
-use crate::parse::ast::{BinOp, Expr};
-use crate::parse::chain_ir::PullDemand;
 use crate::builtins::BuiltinViewStage;
+use crate::parse::ast::{BinOp, Expr};
+use crate::plan::demand::PullDemand;
 use crate::vm::{Opcode, Program};
 
-use super::{
-    symbolic::normalize_symbolic, BodyKernel, Sink, Stage,
-};
+use super::{symbolic::normalize_symbolic, BodyKernel, Sink, Stage};
 
 pub use super::ir::{PhysicalExecPath, Plan, Position, StageStrategy, Strategy};
 
@@ -443,9 +441,9 @@ pub fn select_exec_path(stages: &[Stage], sink: &Sink) -> PhysicalExecPath {
 
     // Columnar: at least one stage has a BuiltinColumnarStage variant, meaning an ObjVec /
     // IntVec / StrVec / FloatVec fast path exists for it.
-    let columnar_eligible = stages.iter().any(|s| {
-        s.descriptor().is_some_and(|d| d.columnar_stage().is_some())
-    });
+    let columnar_eligible = stages
+        .iter()
+        .any(|s| s.descriptor().is_some_and(|d| d.columnar_stage().is_some()));
     if columnar_eligible {
         return PhysicalExecPath::Columnar;
     }

--- a/jetro-core/src/exec/pipeline/symbolic.rs
+++ b/jetro-core/src/exec/pipeline/symbolic.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use crate::parse::ast::{Arg, ArrayElem, Expr, FStringPart, ObjField, PatchOp, PathStep, PipeStep, Step};
+use crate::parse::ast::{Arg, ArrayElem, Expr, FStringPart, MatchArm, ObjField, PatchOp, PathStep, PipeStep, Step};
 
 use super::{BodyKernel, ReducerOp, Sink, Stage};
 
@@ -545,6 +545,17 @@ fn substitute_current(expr: &Expr, replacement: &Expr) -> Expr {
         | Expr::Root
         | Expr::Ident(_)
         | Expr::DeleteMark => expr.clone(),
+        Expr::Match { scrutinee, arms } => Expr::Match {
+            scrutinee: Box::new(substitute_current(scrutinee, replacement)),
+            arms: arms
+                .iter()
+                .map(|a| MatchArm {
+                    pat: a.pat.clone(),
+                    guard: a.guard.as_ref().map(|g| substitute_current(g, replacement)),
+                    body: substitute_current(&a.body, replacement),
+                })
+                .collect(),
+        },
         Expr::FString(parts) => Expr::FString(
             parts
                 .iter()
@@ -767,6 +778,9 @@ fn substitute_current_path_step(step: &PathStep, replacement: &Expr) -> PathStep
 fn is_pure_expr(expr: &Expr) -> bool {
     match expr {
         Expr::Patch { .. } | Expr::DeleteMark => false,
+        // Match runtime not yet implemented; treat as impure for symbolic purposes
+        // until the dedicated dispatch path lands in P2.
+        Expr::Match { .. } => false,
         Expr::Lambda { body, .. } => is_pure_expr(body),
         Expr::GlobalCall { .. } => false,
         Expr::Chain(base, steps) => {

--- a/jetro-core/src/exec/pipeline/val_stage_flow.rs
+++ b/jetro-core/src/exec/pipeline/val_stage_flow.rs
@@ -36,14 +36,18 @@ pub(super) fn apply_adapter_streaming<'a>(
             terminal_map_idx,
             terminal_map_collect,
         };
-        use crate::builtins::{BuiltinMethod as M, builtin::Builtin, defs};
+        use crate::builtins::{builtin::Builtin, defs, BuiltinMethod as M};
         match method {
             M::Filter | M::Find | M::FindAll => {
                 return <defs::Filter as Builtin>::apply_stream(&mut ctx, item, body);
             }
             M::Map => return <defs::Map as Builtin>::apply_stream(&mut ctx, item, body),
-            M::TakeWhile => return <defs::TakeWhile as Builtin>::apply_stream(&mut ctx, item, body),
-            M::DropWhile => return <defs::DropWhile as Builtin>::apply_stream(&mut ctx, item, body),
+            M::TakeWhile => {
+                return <defs::TakeWhile as Builtin>::apply_stream(&mut ctx, item, body)
+            }
+            M::DropWhile => {
+                return <defs::DropWhile as Builtin>::apply_stream(&mut ctx, item, body)
+            }
             M::Take => return <defs::Take as Builtin>::apply_stream(&mut ctx, item, body),
             M::Skip => return <defs::Skip as Builtin>::apply_stream(&mut ctx, item, body),
             M::TransformKeys => {
@@ -52,7 +56,9 @@ pub(super) fn apply_adapter_streaming<'a>(
             M::TransformValues => {
                 return <defs::TransformValues as Builtin>::apply_stream(&mut ctx, item, body)
             }
-            M::FilterKeys => return <defs::FilterKeys as Builtin>::apply_stream(&mut ctx, item, body),
+            M::FilterKeys => {
+                return <defs::FilterKeys as Builtin>::apply_stream(&mut ctx, item, body)
+            }
             M::FilterValues => {
                 return <defs::FilterValues as Builtin>::apply_stream(&mut ctx, item, body)
             }
@@ -62,9 +68,26 @@ pub(super) fn apply_adapter_streaming<'a>(
     // ElementBuiltin: element-wise scalar apply via Stage variant match.
     // All other variants pass through (barriers handled by materialised path).
     match stage {
-        Stage::Builtin(_) | Stage::IntRangeBuiltin { .. } | Stage::StringPairBuiltin { .. } => {
-            Ok(StageFlow::Continue(materialized_exec::apply_element_adapter(stage, item)))
+        Stage::Builtin(call) if call.method == crate::builtins::BuiltinMethod::Compact => {
+            if matches!(item, Val::Null) {
+                Ok(StageFlow::SkipRow)
+            } else {
+                Ok(StageFlow::Continue(item))
+            }
         }
+        Stage::Builtin(call) if call.method == crate::builtins::BuiltinMethod::Remove => {
+            match &call.args {
+                crate::builtins::BuiltinArgs::Val(target)
+                    if crate::util::vals_eq(&item, target) =>
+                {
+                    Ok(StageFlow::SkipRow)
+                }
+                _ => Ok(StageFlow::Continue(item)),
+            }
+        }
+        Stage::Builtin(_) | Stage::IntRangeBuiltin { .. } | Stage::StringPairBuiltin { .. } => Ok(
+            StageFlow::Continue(materialized_exec::apply_element_adapter(stage, item)),
+        ),
         _ => Ok(StageFlow::Continue(item)),
     }
 }

--- a/jetro-core/src/exec/router.rs
+++ b/jetro-core/src/exec/router.rs
@@ -451,6 +451,61 @@ mod tests {
 
     #[cfg(feature = "simd-json")]
     #[test]
+    fn deep_match_obj_keys_routes_through_structural_index() {
+        // `$..match { {role: "admin"} -> ..., ... }` is lowered to a
+        // `StructuralPlan::DeepMatch` whose candidate enumeration draws
+        // on the bitmap index, so the body of the document never has
+        // to be materialised end-to-end.
+        let j = Jetro::from_bytes(
+            br#"{"u":[{"role":"admin","id":1},{"role":"user","id":2},{"name":"none"}]}"#.to_vec(),
+        )
+        .unwrap();
+
+        let out = j
+            .collect(
+                r#"$..match {
+                    {role: "admin", id: i} -> {tag: "a", n: i},
+                    {role: "user",  id: i} -> {tag: "u", n: i},
+                    _                      -> false
+                }"#,
+            )
+            .unwrap();
+
+        assert_eq!(
+            out,
+            serde_json::json!([
+                {"tag": "a", "n": 1},
+                {"tag": "u", "n": 2}
+            ])
+        );
+        assert!(j.structural_index_is_built());
+    }
+
+    #[cfg(feature = "simd-json")]
+    #[test]
+    fn deep_match_first_obj_keys_via_structural_index() {
+        // The early-stop variant returns the first truthy arm body
+        // without walking the rest of the document.
+        let j = Jetro::from_bytes(
+            br#"{"events":[{"role":"viewer"},{"role":"admin","id":7},{"role":"editor"}]}"#.to_vec(),
+        )
+        .unwrap();
+
+        let out = j
+            .collect(
+                r#"$..match! {
+                    {role: "admin", id: i} -> i,
+                    _                      -> false
+                }"#,
+            )
+            .unwrap();
+
+        assert_eq!(out, serde_json::json!(7));
+        assert!(j.structural_index_is_built());
+    }
+
+    #[cfg(feature = "simd-json")]
+    #[test]
     fn deep_shape_reads_from_structural_index_without_tape_or_root_val() {
         let j = Jetro::from_bytes(
             br#"{"users":[{"email":"a@x","role":"lead"},{"name":"missing"},{"team":{"email":"b@x","role":"dev"}}]}"#.to_vec(),

--- a/jetro-core/src/exec/structural.rs
+++ b/jetro-core/src/exec/structural.rs
@@ -47,6 +47,24 @@ pub(crate) enum StructuralPlan {
         /// Key/literal pairs that must all match on each candidate object.
         patterns: Arc<[(Arc<str>, StructuralLiteral)]>,
     },
+    /// Bitmap-narrowed `..match` dispatch. Uses the compile-time
+    /// shape summary on `cm` to enumerate candidate descendant tokens
+    /// from the structural index, materialises each into a `Val`, and
+    /// runs the compiled match against it. Truthy arm-body results
+    /// are accumulated into an array (or returned directly when
+    /// `early_stop` is set, mirroring the `..match!` runtime).
+    DeepMatch {
+        /// Path from the document root to the subtree to search.
+        anchor: Arc<[StructuralPathStep]>,
+        /// Object keys used to seed the candidate enumeration. Drawn
+        /// from `MatchShapeSummary::ObjAnyOfKeys`; the planner only
+        /// emits this variant when the summary admits bitmap dispatch.
+        candidate_keys: Arc<[Arc<str>]>,
+        /// The compiled match program executed against each candidate.
+        cm: Arc<crate::vm::CompiledMatch>,
+        /// `true` for the `..match! { ... }` early-stop variant.
+        early_stop: bool,
+    },
 }
 
 /// One step along the anchor path from the document root to the search subtree.
@@ -106,12 +124,86 @@ impl StructuralPlan {
 
     /// Execute the plan against `idx` (pre-built structural index) and the raw
     /// `bytes` of the JSON document, returning a `Val::Arr` of matching objects.
+    /// Returns an error for variants that require a runtime VM (`DeepMatch`);
+    /// those callers must use `run_with_vm` instead.
     pub(crate) fn run(&self, idx: &StructuralIndex, bytes: &[u8]) -> Result<Val, EvalError> {
         match self {
             Self::DeepFind { anchor, predicates } => run_deep_find(idx, bytes, anchor, predicates),
             Self::DeepShape { anchor, keys } => run_deep_shape(idx, bytes, anchor, keys),
             Self::DeepLike { anchor, patterns } => run_deep_like(idx, bytes, anchor, patterns),
+            Self::DeepMatch { .. } => Err(EvalError(
+                "DeepMatch requires a VM; use run_with_vm".to_string(),
+            )),
         }
+    }
+
+    /// VM-aware execution entry. Runs `Self::DeepMatch` against the
+    /// supplied `vm`/`env` so per-candidate guard and body programs can
+    /// evaluate; delegates to `run` for non-VM variants.
+    pub(crate) fn run_with_vm(
+        &self,
+        idx: &StructuralIndex,
+        bytes: &[u8],
+        vm: &mut crate::vm::VM,
+        env: &crate::data::context::Env,
+    ) -> Result<Val, EvalError> {
+        match self {
+            Self::DeepMatch {
+                anchor,
+                candidate_keys,
+                cm,
+                early_stop,
+            } => run_deep_match(idx, bytes, anchor, candidate_keys, cm, *early_stop, vm, env),
+            other => other.run(idx, bytes),
+        }
+    }
+}
+
+/// Walk the structural index for object descendants whose keys overlap
+/// `candidate_keys` (the union of leading keys across the match's
+/// typed arms), materialise each candidate, and run the compiled
+/// match against it. Truthy arm-body results accumulate into a
+/// `Val::Arr`; when `early_stop` is set, the first truthy result is
+/// returned directly (or `Val::Null` when nothing matches).
+fn run_deep_match(
+    idx: &StructuralIndex,
+    bytes: &[u8],
+    anchor: &[StructuralPathStep],
+    candidate_keys: &[Arc<str>],
+    cm: &Arc<crate::vm::CompiledMatch>,
+    early_stop: bool,
+    vm: &mut crate::vm::VM,
+    env: &crate::data::context::Env,
+) -> Result<Val, EvalError> {
+    let Some(anchor_tok) = anchor_token(idx, anchor) else {
+        return Ok(if early_stop { Val::Null } else { Val::arr(Vec::new()) });
+    };
+    let mut seen = HashSet::new();
+    let mut hits: Vec<Val> = Vec::new();
+    for key in candidate_keys.iter() {
+        for key_tok in idx.keys_named_in(key.as_ref(), anchor_tok) {
+            let Some(parent) = idx.parent(key_tok) else {
+                continue;
+            };
+            if idx.kind(parent) != TokenKind::Object || !seen.insert(parent.raw()) {
+                continue;
+            }
+            let candidate = materialize_token(idx, bytes, parent)?;
+            match vm.exec_match(cm, &candidate, env) {
+                Ok(v) if crate::util::is_truthy(&v) => {
+                    if early_stop {
+                        return Ok(v);
+                    }
+                    hits.push(v);
+                }
+                Ok(_) | Err(_) => {}
+            }
+        }
+    }
+    if early_stop {
+        Ok(Val::Null)
+    } else {
+        Ok(Val::arr(hits))
     }
 }
 

--- a/jetro-core/src/exec/view.rs
+++ b/jetro-core/src/exec/view.rs
@@ -8,11 +8,11 @@
 
 use std::sync::Arc;
 
-use crate::parse::chain_ir::PullDemand;
 use crate::data::context::{Env, EvalError};
-use crate::exec::pipeline;
 use crate::data::value::Val;
 use crate::data::view::{scalar_view_to_owned_val, ValueView};
+use crate::exec::pipeline;
+use crate::plan::demand::PullDemand;
 use crate::util::JsonView;
 
 mod key;
@@ -1000,12 +1000,12 @@ mod tests {
     use std::rc::Rc;
     use std::sync::Arc;
 
-    use crate::parse::ast::BinOp;
     use crate::data::context::Env;
-    use crate::exec::pipeline::{BodyKernel, PipelineBody, Sink, Stage, ViewStageCapability};
-    use crate::util::JsonView;
     use crate::data::value::Val;
     use crate::data::view::{ValView, ValueView};
+    use crate::exec::pipeline::{BodyKernel, PipelineBody, Sink, Stage, ViewStageCapability};
+    use crate::parse::ast::BinOp;
+    use crate::util::JsonView;
 
     #[derive(Clone)]
     struct CountingView {

--- a/jetro-core/src/grammar.pest
+++ b/jetro-core/src/grammar.pest
@@ -24,11 +24,14 @@ kw_patch  = @{ "patch"  ~ !ident_char }
 kw_delete = @{ "DELETE" ~ !ident_char }
 kw_try    = @{ "try"    ~ !ident_char }
 kw_has    = @{ "has"    ~ !ident_char }
+kw_match  = @{ "match"  ~ !ident_char }
+kw_with   = @{ "with"   ~ !ident_char }
 
 reserved = _{
     ("true" | "false" | "null" | "and" | "or" | "not"
      | "for" | "in" | "if" | "else" | "let" | "lambda" | "kind"
-     | "is" | "as" | "when" | "patch" | "DELETE" | "try" | "has") ~ !ident_char
+     | "is" | "as" | "when" | "patch" | "DELETE" | "try" | "has"
+     | "match" | "with") ~ !ident_char
 }
 
 ident      = @{ !reserved ~ (ASCII_ALPHA | "_") ~ ident_char* }
@@ -190,6 +193,53 @@ arr_construct = { "[" ~ (arr_elem ~ ("," ~ arr_elem)* ~ ","?)? ~ "]" }
 // ── Global function calls ─────────────────────────────────────────────────────
 global_call = { ident ~ "(" ~ arg_list? ~ ")" }
 
+// ── Match expression ──────────────────────────────────────────────────────────
+// Pattern grammar.  Object/array patterns are recognised inside arm heads only,
+// so `{k: pat}` does not collide with `{k: expr}` object literals (those parse
+// as `obj_construct` in expression position).
+//
+// Pattern precedence: `pat_or` > `pat_atom`.  Or-patterns at the top of an
+// arm head; everything else is atom or object/array.
+pat_lit_null  = @{ "null"  ~ !ident_char }
+pat_lit_true  = @{ "true"  ~ !ident_char }
+pat_lit_false = @{ "false" ~ !ident_char }
+pat_lit_float = @{ "-"? ~ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
+pat_lit_int   = @{ "-"? ~ ASCII_DIGIT+ }
+pat_lit_str   = { lit_str_dq | lit_str_sq }
+pat_literal   = { pat_lit_null | pat_lit_true | pat_lit_false | pat_lit_float | pat_lit_int | pat_lit_str }
+
+pat_wild      = @{ "_" ~ !ident_char }
+pat_kind_bind = { ident ~ ":" ~ kind_type }
+pat_kind_only = { kind_type }
+pat_bind      = { ident }
+
+pat_obj_open  = { "..." }
+pat_obj_field = { ident ~ ":" ~ pat_or }
+pat_obj       = { "{" ~ (pat_obj_field ~ ("," ~ pat_obj_field)* ~ ("," ~ pat_obj_open)? ~ ","?)? ~ "}" }
+
+pat_arr_rest_named = { "..." ~ ident }
+pat_arr_rest_anon  = { "..." }
+pat_arr_rest       = { pat_arr_rest_named | pat_arr_rest_anon }
+pat_arr            = { "[" ~ (pat_or ~ ("," ~ pat_or)* ~ ("," ~ pat_arr_rest)? ~ ","?)? ~ "]" }
+
+pat_atom = {
+    pat_wild     |
+    pat_literal  |
+    pat_kind_bind|
+    pat_kind_only|
+    pat_obj      |
+    pat_arr      |
+    pat_bind     |
+    "(" ~ pat_or ~ ")"
+}
+pat_or  = { pat_atom ~ ("|" ~ pat_atom)* }
+
+match_arm = { pat_or ~ (kw_when ~ expr)? ~ "->" ~ expr }
+// `match scrutinee with { arms }` — `with` separator avoids ambiguity with
+// `expr { inline_filter }` postfix. Without it, `match $.x { v -> v }` parses
+// the `{ v -> v }` as inline_filter (since `v -> v` is a valid pipe-bind expr).
+match_expr = { kw_match ~ expr ~ kw_with ~ "{" ~ match_arm ~ ("," ~ match_arm)* ~ ","? ~ "}" }
+
 // ── Patch block ───────────────────────────────────────────────────────────────
 pp_wild_filter = { "[" ~ "*" ~ kw_if ~ expr ~ "]" }
 pp_wild        = { "[" ~ "*" ~ "]" }
@@ -203,6 +253,7 @@ patch_block    = { kw_patch ~ coalesce_expr ~ "{" ~ (patch_field ~ ("," ~ patch_
 
 // ── Primary ───────────────────────────────────────────────────────────────────
 primary = {
+    match_expr    |
     patch_block   |
     let_expr      |
     lambda_expr   |

--- a/jetro-core/src/grammar.pest
+++ b/jetro-core/src/grammar.pest
@@ -208,6 +208,15 @@ pat_lit_int   = @{ "-"? ~ ASCII_DIGIT+ }
 pat_lit_str   = { lit_str_dq | lit_str_sq }
 pat_literal   = { pat_lit_null | pat_lit_true | pat_lit_false | pat_lit_float | pat_lit_int | pat_lit_str }
 
+// Numeric range patterns. `1..10` is half-open `[1, 10)`; `1..=10` is
+// closed `[1, 10]`. Bounds are integer or float literals; mixing the two
+// is allowed (compared as `f64` at runtime). Listed before `pat_literal`
+// in `pat_atom` so the parser does not commit to the leading numeric
+// literal before checking for a range operator.
+pat_range_num    = @{ "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
+pat_range_op     = @{ "..=" | ".." }
+pat_range        = { pat_range_num ~ pat_range_op ~ pat_range_num }
+
 pat_wild      = @{ "_" ~ !ident_char }
 pat_kind_bind = { ident ~ ":" ~ kind_type }
 pat_kind_only = { kind_type }
@@ -224,6 +233,7 @@ pat_arr            = { "[" ~ (pat_or ~ ("," ~ pat_or)* ~ ("," ~ pat_arr_rest)? ~
 
 pat_atom = {
     pat_wild     |
+    pat_range    |
     pat_literal  |
     pat_kind_bind|
     pat_kind_only|

--- a/jetro-core/src/grammar.pest
+++ b/jetro-core/src/grammar.pest
@@ -179,10 +179,15 @@ obj_field_dyn    = { "[" ~ expr ~ "]" ~ ":" ~ expr }
 obj_field_opt_v  = { obj_key_expr ~ "?" ~ ":" ~ expr }
 obj_field_opt    = { obj_key_expr ~ "?" }
 obj_field_spread_deep = { "...**" ~ expr }
+// `...*expr` is a shallow spread synonym used by object rest patterns
+// for symmetry with the `{...*rest}` capture form. Same semantics as
+// `...expr`. Listed before `obj_field_spread` so it wins the leading
+// `...*` prefix without backtracking.
+obj_field_spread_star = { "...*" ~ expr }
 obj_field_spread      = { "..." ~ expr }
 obj_field_kv          = { obj_key_expr ~ ":" ~ expr ~ (kw_when ~ expr)? }
 obj_field_short       = { ident }
-obj_field             = { obj_field_dyn | obj_field_opt_v | obj_field_opt | obj_field_spread_deep | obj_field_spread | obj_field_kv | obj_field_short }
+obj_field             = { obj_field_dyn | obj_field_opt_v | obj_field_opt | obj_field_spread_deep | obj_field_spread_star | obj_field_spread | obj_field_kv | obj_field_short }
 obj_construct    = { "{" ~ (obj_field ~ ("," ~ obj_field)* ~ ","?)? ~ "}" }
 
 // ── Array construction ─────────────────────────────────────────────────────────
@@ -222,9 +227,11 @@ pat_kind_bind = { ident ~ ":" ~ kind_type }
 pat_kind_only = { kind_type }
 pat_bind      = { ident }
 
-pat_obj_open  = { "..." }
+pat_obj_rest_named = { "...*" ~ ident }
+pat_obj_rest_anon  = { "...*" }
+pat_obj_rest       = { pat_obj_rest_named | pat_obj_rest_anon }
 pat_obj_field = { ident ~ ":" ~ pat_or }
-pat_obj       = { "{" ~ (pat_obj_field ~ ("," ~ pat_obj_field)* ~ ("," ~ pat_obj_open)? ~ ","?)? ~ "}" }
+pat_obj       = { "{" ~ (pat_obj_field ~ ("," ~ pat_obj_field)* ~ ("," ~ pat_obj_rest)? ~ ","?)? ~ "}" }
 
 pat_arr_rest_named = { "..." ~ ident }
 pat_arr_rest_anon  = { "..." }

--- a/jetro-core/src/grammar.pest
+++ b/jetro-core/src/grammar.pest
@@ -234,7 +234,10 @@ pat_atom = {
 }
 pat_or  = { pat_atom ~ ("|" ~ pat_atom)* }
 
-match_arm = { pat_or ~ (kw_when ~ expr)? ~ "->" ~ expr }
+// Guard expression sits below pipe precedence so a trailing `->` belongs to
+// the arm separator rather than being eaten as a `pipe_bind` step inside
+// the guard. Arm bodies use the full `expr` grammar.
+match_arm = { pat_or ~ (kw_when ~ coalesce_expr)? ~ "->" ~ expr }
 // `match scrutinee with { arms }` — `with` separator avoids ambiguity with
 // `expr { inline_filter }` postfix. Without it, `match $.x { v -> v }` parses
 // the `{ v -> v }` as inline_filter (since `v -> v` is a valid pipe-bind expr).

--- a/jetro-core/src/grammar.pest
+++ b/jetro-core/src/grammar.pest
@@ -97,7 +97,7 @@ inline_filter  = { "{" ~ expr ~ "}" }
 // (e.g. `..services?.name`, `.a?.b?`).  Still reject `?|` to avoid
 // conflict with pipe, and `??` which is coalesce.
 quantifier     = { ("?" ~ !("|" | "?")) | "!" }
-postfix = { deep_method | descendant | method_call | dyn_field | map_into_shape | field_access | index_access | inline_filter | quantifier }
+postfix = { deep_match | deep_method | descendant | method_call | dyn_field | map_into_shape | field_access | index_access | inline_filter | quantifier }
 
 // ── Expression hierarchy ──────────────────────────────────────────────────────
 expr = { cond_expr }
@@ -252,6 +252,11 @@ match_arm = { pat_or ~ (kw_when ~ coalesce_expr)? ~ "->" ~ expr }
 // `expr { inline_filter }` postfix. Without it, `match $.x { v -> v }` parses
 // the `{ v -> v }` as inline_filter (since `v -> v` is a valid pipe-bind expr).
 match_expr = { kw_match ~ expr ~ kw_with ~ "{" ~ match_arm ~ ("," ~ match_arm)* ~ ","? ~ "}" }
+// `..match { arms }` walks every descendant in DFS pre-order, runs the
+// match against each, and collects truthy arm-body results into an
+// array. Falsy bodies and unmatched values are silently dropped — the
+// shape is "find all descendants whose pattern fires non-falsy".
+deep_match = { ".." ~ kw_match ~ "{" ~ match_arm ~ ("," ~ match_arm)* ~ ","? ~ "}" }
 
 // ── Patch block ───────────────────────────────────────────────────────────────
 pp_wild_filter = { "[" ~ "*" ~ kw_if ~ expr ~ "]" }

--- a/jetro-core/src/grammar.pest
+++ b/jetro-core/src/grammar.pest
@@ -256,7 +256,13 @@ match_expr = { kw_match ~ expr ~ kw_with ~ "{" ~ match_arm ~ ("," ~ match_arm)* 
 // match against each, and collects truthy arm-body results into an
 // array. Falsy bodies and unmatched values are silently dropped — the
 // shape is "find all descendants whose pattern fires non-falsy".
-deep_match = { ".." ~ kw_match ~ "{" ~ match_arm ~ ("," ~ match_arm)* ~ ","? ~ "}" }
+//
+// The `!` suffix (`..match! { arms }`) selects the early-stop variant:
+// the runtime returns the first truthy arm-body result without walking
+// the rest of the tree. Useful for "find any descendant satisfying the
+// pattern" queries.
+deep_match_op = @{ "..match!" | "..match" }
+deep_match = { deep_match_op ~ "{" ~ match_arm ~ ("," ~ match_arm)* ~ ","? ~ "}" }
 
 // ── Patch block ───────────────────────────────────────────────────────────────
 pp_wild_filter = { "[" ~ "*" ~ kw_if ~ expr ~ "]" }

--- a/jetro-core/src/lib.rs
+++ b/jetro-core/src/lib.rs
@@ -159,6 +159,12 @@ pub struct JetroEngine {
     plan_cache_limit: usize,
     /// The shared `VM` used by all `collect*` calls on this engine instance.
     vm: Mutex<VM>,
+    /// Engine-owned JSON object-key intern cache. Used by [`JetroEngine::parse_value`]
+    /// and [`JetroEngine::parse_bytes`] (and the `collect_*` shortcuts that go through
+    /// them) so each engine instance has an isolated key cache. Documents built via
+    /// the standalone `Jetro::from_bytes`/`From<serde_json::Value>` paths use the
+    /// process-wide [`crate::data::intern::default_cache`] instead.
+    keys: Arc<crate::data::intern::KeyCache>,
 }
 
 /// Error returned by `JetroEngine::collect_bytes` and similar methods that
@@ -223,12 +229,45 @@ impl JetroEngine {
             plan_cache: Mutex::new(HashMap::new()),
             plan_cache_limit,
             vm: Mutex::new(VM::new()),
+            keys: crate::data::intern::KeyCache::new(),
         }
     }
 
-    /// Discard all cached query plans, forcing re-compilation on the next call.
+    /// Borrow this engine's JSON key-intern cache.
+    pub fn keys(&self) -> &Arc<crate::data::intern::KeyCache> {
+        &self.keys
+    }
+
+    /// Discard all cached query plans and the engine's key-intern cache,
+    /// forcing re-compilation and re-interning on the next call.
     pub fn clear_cache(&self) {
         self.plan_cache.lock().expect("plan cache poisoned").clear();
+        self.keys.clear();
+    }
+
+    /// Build a `Jetro` document from a `serde_json::Value` with object keys
+    /// interned into this engine's key cache. Use this in place of
+    /// `Jetro::from(...)` / the `From<serde_json::Value>` impl when
+    /// per-engine key isolation is required.
+    pub fn parse_value(&self, document: Value) -> Jetro {
+        let root = Val::from_value_with(&self.keys, &document);
+        Jetro::from_val_and_value(root, document)
+    }
+
+    /// Parse raw JSON bytes into a `Jetro` document with object keys
+    /// interned into this engine's key cache. With `simd-json`, the tape
+    /// is materialised eagerly so interning happens once at parse time
+    /// (subsequent `collect` calls reuse the cached `Val` tree).
+    pub fn parse_bytes(
+        &self,
+        bytes: Vec<u8>,
+    ) -> std::result::Result<Jetro, JetroEngineError> {
+        let document = Jetro::from_bytes(bytes)?;
+        // Force materialisation so keys are interned through this
+        // engine's cache rather than the default thread-local one when
+        // `collect` later asks for `root_val`.
+        let _ = document.root_val_with(&self.keys)?;
+        Ok(document)
     }
 
     /// Evaluate a Jetro expression against an already-constructed `Jetro` document,
@@ -244,23 +283,27 @@ impl JetroEngine {
     }
 
     /// Convenience wrapper: wrap a `serde_json::Value` in a `Jetro` and evaluate `expr`.
+    /// Routes through [`JetroEngine::parse_value`] so the document's object keys are
+    /// interned into this engine's key cache.
     pub fn collect_value<S: AsRef<str>>(
         &self,
         document: Value,
         expr: S,
     ) -> std::result::Result<Value, EvalError> {
-        let document = Jetro::from(document);
+        let document = self.parse_value(document);
         self.collect(&document, expr)
     }
 
     /// Parse raw JSON bytes into a `Jetro` document and evaluate `expr`,
     /// returning a `JetroEngineError` on either parse or evaluation failure.
+    /// Routes through [`JetroEngine::parse_bytes`] so the document's object keys
+    /// are interned into this engine's key cache.
     pub fn collect_bytes<S: AsRef<str>>(
         &self,
         bytes: Vec<u8>,
         expr: S,
     ) -> std::result::Result<Value, JetroEngineError> {
-        let document = Jetro::from_bytes(bytes)?;
+        let document = self.parse_bytes(bytes)?;
         Ok(self.collect(&document, expr)?)
     }
 
@@ -346,6 +389,52 @@ impl Jetro {
             tape: OnceCell::new(),
             structural_index: OnceCell::new(),
         }
+    }
+
+    /// Build a `Jetro` whose `root_val` is pre-cached with `root` (constructed by the
+    /// caller, typically via [`Val::from_value_with`] using an engine-owned key cache).
+    /// `document` is retained for back-compat with non-`simd-json` callers and tests
+    /// that read the original `serde_json::Value`.
+    pub(crate) fn from_val_and_value(root: Val, document: Value) -> Self {
+        let root_val = OnceCell::new();
+        let _ = root_val.set(root);
+        Self {
+            document,
+            root_val,
+            objvec_cache: Default::default(),
+            raw_bytes: None,
+            tape: OnceCell::new(),
+            structural_index: OnceCell::new(),
+        }
+    }
+
+    /// Like [`Jetro::root_val`] but interns object keys through `keys` instead of the
+    /// process-wide default. Used by [`JetroEngine::parse_bytes`] to materialise the
+    /// `Val` tree once at parse time so subsequent `collect` calls find a populated
+    /// `root_val` cache and skip re-interning.
+    pub(crate) fn root_val_with(
+        &self,
+        keys: &crate::data::intern::KeyCache,
+    ) -> std::result::Result<Val, EvalError> {
+        if let Some(root) = self.root_val.get() {
+            return Ok(root.clone());
+        }
+        let root = {
+            #[cfg(feature = "simd-json")]
+            {
+                if let Some(tape) = self.lazy_tape()? {
+                    Val::from_tape_data_with(keys, tape)
+                } else {
+                    Val::from_value_with(keys, &self.document)
+                }
+            }
+            #[cfg(not(feature = "simd-json"))]
+            {
+                Val::from_value_with(keys, &self.document)
+            }
+        };
+        let _ = self.root_val.set(root);
+        Ok(self.root_val.get().expect("root val initialized").clone())
     }
 
     /// Parse raw JSON bytes and build a `Jetro` query handle.

--- a/jetro-core/src/parse/ast.rs
+++ b/jetro-core/src/parse/ast.rs
@@ -176,6 +176,71 @@ pub enum Expr {
     /// Sentinel emitted by the parser for `.delete()` / `.unset()` terminals.
     /// Reaching the evaluator is a hard error; the compiler must consume it during patch lowering.
     DeleteMark,
+
+    /// Pattern-match expression `match scrutinee { pat when guard -> body, ... }`.
+    /// Arms are tested top to bottom; first match wins.
+    Match {
+        /// Value being matched against the arm patterns.
+        scrutinee: Box<Expr>,
+        /// Ordered list of `pat -> body` arms with optional guards.
+        arms: Vec<MatchArm>,
+    },
+}
+
+/// One arm of a `Match` expression: a pattern, optional guard, and body.
+#[derive(Debug, Clone)]
+pub struct MatchArm {
+    /// Pattern that the scrutinee must satisfy.
+    pub pat: Pat,
+    /// Optional `when <expr>` guard evaluated with arm bindings in scope.
+    pub guard: Option<Expr>,
+    /// Body expression evaluated when this arm fires.
+    pub body: Expr,
+}
+
+/// Pattern node used in `Match` arms. Patterns describe the shape of a value
+/// and may bind subterms into the arm's scope.
+#[derive(Debug, Clone)]
+pub enum Pat {
+    /// Wildcard `_` — matches any value, no binding.
+    Wild,
+    /// Literal pattern — matches by structural equality with `Lit`.
+    Lit(PatLit),
+    /// Identifier binding `name` — captures the whole value into `name`.
+    Bind(String),
+    /// Or-pattern `a | b | c` — matches if any sub-pattern matches.
+    Or(Vec<Pat>),
+    /// Object pattern `{k: pat, ...}` — every listed key must match. The
+    /// runtime always permits extra keys; the `open` flag is currently
+    /// informational and left in the AST so future passes can opt into
+    /// strict closed-object matching without a grammar change.
+    Obj {
+        /// Listed key/sub-pattern pairs that must all match.
+        fields: Vec<(String, Pat)>,
+        /// `true` when the source spelled the trailing `...` rest marker.
+        #[allow(dead_code)]
+        open: bool,
+    },
+    /// Array pattern `[a, b, ...rest]` — fixed prefix with optional rest binding.
+    Arr { elems: Vec<Pat>, rest: Option<Option<String>> },
+    /// Type-kind pattern `name: kind` (e.g. `s: str`) — matches a kind, binds the value.
+    Kind { name: Option<String>, kind: KindType },
+}
+
+/// Literal sub-form of `Pat::Lit`. Restricted to scalar literals; arbitrary
+/// expressions are not allowed in pattern position.
+#[derive(Debug, Clone)]
+pub enum PatLit {
+    /// `null` literal.
+    Null,
+    /// Boolean literal.
+    Bool(bool),
+    /// Integer literal.
+    Int(i64),
+    /// Float literal.
+    Float(f64),
+    /// String literal.
+    Str(String),
 }
 
 

--- a/jetro-core/src/parse/ast.rs
+++ b/jetro-core/src/parse/ast.rs
@@ -211,15 +211,18 @@ pub enum Pat {
     /// Or-pattern `a | b | c` — matches if any sub-pattern matches.
     Or(Vec<Pat>),
     /// Object pattern `{k: pat, ...}` — every listed key must match. The
-    /// runtime always permits extra keys; the `open` flag is currently
-    /// informational and left in the AST so future passes can opt into
-    /// strict closed-object matching without a grammar change.
+    /// runtime always permits extra keys; an explicit `...` marker
+    /// signals the source spelled the rest marker, and a named
+    /// `...rest` captures every unlisted key into `rest` as a freshly
+    /// built `Val::Obj`.
     Obj {
         /// Listed key/sub-pattern pairs that must all match.
         fields: Vec<(String, Pat)>,
-        /// `true` when the source spelled the trailing `...` rest marker.
-        #[allow(dead_code)]
-        open: bool,
+        /// Rest behaviour mirrors `Pat::Arr`:
+        /// - `None`             → no rest marker (default; extras silently allowed)
+        /// - `Some(None)`       → anonymous `...` marker; same semantics, explicit
+        /// - `Some(Some(name))` → `...name` capture into a named binding
+        rest: Option<Option<String>>,
     },
     /// Array pattern `[a, b, ...rest]` — fixed prefix with optional rest binding.
     Arr { elems: Vec<Pat>, rest: Option<Option<String>> },

--- a/jetro-core/src/parse/ast.rs
+++ b/jetro-core/src/parse/ast.rs
@@ -397,7 +397,14 @@ pub enum Step {
     Quantifier(QuantifierKind),
     /// `..match { arms }` — recursive descent that runs the arm list
     /// against every descendant and collects truthy arm-body results.
-    DeepMatch(Vec<MatchArm>),
+    /// `early_stop` is `true` for the `..match! { ... }` form, which
+    /// returns the first truthy result and aborts the walk.
+    DeepMatch {
+        /// Arm list applied against every descendant.
+        arms: Vec<MatchArm>,
+        /// `true` for the early-stop `..match!` form.
+        early_stop: bool,
+    },
 }
 
 

--- a/jetro-core/src/parse/ast.rs
+++ b/jetro-core/src/parse/ast.rs
@@ -225,6 +225,17 @@ pub enum Pat {
     Arr { elems: Vec<Pat>, rest: Option<Option<String>> },
     /// Type-kind pattern `name: kind` (e.g. `s: str`) — matches a kind, binds the value.
     Kind { name: Option<String>, kind: KindType },
+    /// Numeric range pattern `lo..hi` (exclusive) or `lo..=hi` (inclusive).
+    /// Both bounds are stored as `f64` and compared as floating-point at
+    /// runtime; integer scrutinees are widened transparently.
+    Range {
+        /// Lower bound (inclusive).
+        lo: f64,
+        /// Upper bound (exclusive when `inclusive == false`, inclusive otherwise).
+        hi: f64,
+        /// Whether the upper bound is inclusive.
+        inclusive: bool,
+    },
 }
 
 /// Literal sub-form of `Pat::Lit`. Restricted to scalar literals; arbitrary

--- a/jetro-core/src/parse/ast.rs
+++ b/jetro-core/src/parse/ast.rs
@@ -395,6 +395,9 @@ pub enum Step {
     InlineFilter(Box<Expr>),
     /// `.first` / `.one` — quantifier that collapses an array to a scalar.
     Quantifier(QuantifierKind),
+    /// `..match { arms }` — recursive descent that runs the arm list
+    /// against every descendant and collects truthy arm-body results.
+    DeepMatch(Vec<MatchArm>),
 }
 
 

--- a/jetro-core/src/parse/chain_ir.rs
+++ b/jetro-core/src/parse/chain_ir.rs
@@ -1,16 +1,20 @@
-//! Operator cardinality and demand-flow metadata for the chain IR.
+//! Operator cardinality metadata and demand-flow adapters for the chain IR.
 //!
-//! This module is metadata-first: each operator declares how downstream
-//! demand propagates to its input, rather than encoding pairwise rewrites.
-//! Executors use `PullDemand` to stop pull loops early without needing a
-//! fused operator for every adjacent pair.
+//! The shared demand model lives in `plan::demand`; this module adapts the
+//! parser-facing chain operator representation to that model.
 
 #![allow(dead_code)]
 
 use crate::{
-    builtins::registry::{propagate_demand as propagate_builtin_demand, BuiltinDemandArg, BuiltinId},
+    builtins::registry::{
+        propagate_demand as propagate_builtin_demand, BuiltinDemandArg, BuiltinId,
+    },
     builtins::BuiltinMethod,
+    plan::demand::{Demand, DemandOperator},
 };
+
+#[cfg(test)]
+use crate::plan::demand::{propagate_demands, source_demand, PullDemand, ValueNeed};
 
 /// Describes whether a pipeline slot carries a homogeneous stream, a single
 /// scalar result, or an unconstrained mix of values.
@@ -54,115 +58,6 @@ impl From<crate::builtins::BuiltinCardinality> for Cardinality {
             crate::builtins::BuiltinCardinality::Bounded => Self::Bounded,
             crate::builtins::BuiltinCardinality::Reducing => Self::Reducing,
             crate::builtins::BuiltinCardinality::Barrier => Self::Barrier,
-        }
-    }
-}
-
-/// Describes how much of each element's content a pipeline stage actually
-/// needs to read, used to skip deserialisation or evaluation work.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ValueNeed {
-    /// The stage only needs to know the element exists; payload can be skipped.
-    None,
-    /// The stage evaluates a predicate and needs enough of the value to test it.
-    Predicate,
-    /// The stage only needs fields used by a projection.
-    Projection,
-    /// The full element value is required.
-    Whole,
-    /// Only the numeric interpretation of the element is needed (e.g. for `sum`).
-    Numeric,
-}
-
-impl ValueNeed {
-    /// Return the stricter of two `ValueNeed` values; `Whole` dominates all others.
-    pub(crate) fn merge(self, other: Self) -> Self {
-        use ValueNeed::*;
-        match (self, other) {
-            (Whole, _) | (_, Whole) => Whole,
-            (Numeric, _) | (_, Numeric) => Numeric,
-            (Projection, _) | (_, Projection) => Projection,
-            (Predicate, _) | (_, Predicate) => Predicate,
-            (None, None) => None,
-        }
-    }
-}
-
-
-/// Specifies how many input elements a stage must pull from its source to
-/// satisfy a downstream consumer's limit.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PullDemand {
-    /// Pull all available input elements without any limit.
-    All,
-    /// Pull at most the first `n` input elements regardless of how many outputs they produce.
-    FirstInput(usize),
-    /// Pull from the end of the input until `n` outputs have been produced.
-    LastInput(usize),
-    /// Pull the input element at zero-based index `i` when the source can seek to it.
-    NthInput(usize),
-    /// Pull input until exactly `n` output elements have been produced.
-    UntilOutput(usize),
-}
-
-impl PullDemand {
-    /// Return a `PullDemand` capped to at most `n` input elements,
-    /// converting `All` or `UntilOutput` variants to `FirstInput(n)`.
-    pub(crate) fn cap_inputs(self, n: usize) -> Self {
-        match self {
-            PullDemand::All | PullDemand::UntilOutput(_) | PullDemand::LastInput(_) => {
-                PullDemand::FirstInput(n)
-            }
-            PullDemand::FirstInput(m) => PullDemand::FirstInput(m.min(n)),
-            PullDemand::NthInput(i) => {
-                if i < n {
-                    PullDemand::NthInput(i)
-                } else {
-                    PullDemand::FirstInput(n)
-                }
-            }
-        }
-    }
-}
-
-/// Combined downstream demand annotation: how much to pull, what payload is
-/// needed, and whether the consumer requires stable input ordering.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Demand {
-    /// How many upstream elements must be consumed.
-    pub pull: PullDemand,
-    /// How much of each element's payload is required.
-    pub value: ValueNeed,
-    /// Whether the consumer depends on elements arriving in their original order.
-    pub order: bool,
-}
-
-impl Demand {
-    /// The terminal demand used at the sink of a pipeline: pull everything,
-    /// need whole values, and require ordering.
-    pub const RESULT: Demand = Demand {
-        pull: PullDemand::All,
-        value: ValueNeed::Whole,
-        order: true,
-    };
-
-    /// Construct a demand that pulls all input with the given value need and
-    /// order requirement.
-    pub fn all(value: ValueNeed) -> Self {
-        Self {
-            pull: PullDemand::All,
-            value,
-            order: true,
-        }
-    }
-
-    /// Construct a demand that pulls only the first input element with the
-    /// given value need, and no ordering requirement.
-    pub fn first(value: ValueNeed) -> Self {
-        Self {
-            pull: PullDemand::FirstInput(1),
-            value,
-            order: false,
         }
     }
 }
@@ -258,53 +153,20 @@ impl ChainOp {
         }
     }
 
-    /// Propagate `downstream` demand through this operator, returning the
-    /// upstream demand that its source must satisfy.
+    /// Propagate demand using the shared planner demand model.
     pub fn propagate_demand(&self, downstream: Demand) -> Demand {
+        <Self as DemandOperator>::propagate_demand(self, downstream)
+    }
+}
+
+impl DemandOperator for ChainOp {
+    fn propagate_demand(&self, downstream: Demand) -> Demand {
         match self {
             ChainOp::Builtin { id, demand_arg } => {
                 propagate_builtin_demand(*id, *demand_arg, downstream)
             }
         }
     }
-}
-
-/// A single annotated step produced by `propagate_demands`, recording an
-/// operator alongside the demand it receives and the demand it places upstream.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DemandStep {
-    /// The operator at this position in the chain.
-    pub op: ChainOp,
-    /// Demand flowing into this operator from the downstream consumer.
-    pub downstream: Demand,
-    /// Demand this operator forwards to its upstream source.
-    pub upstream: Demand,
-}
-
-/// Walk `ops` in reverse and compute each operator's upstream demand given
-/// `final_demand` at the sink, returning annotated `DemandStep`s in forward order.
-pub fn propagate_demands(ops: &[ChainOp], final_demand: Demand) -> Vec<DemandStep> {
-    let mut demand = final_demand;
-    let mut out = Vec::with_capacity(ops.len());
-    for op in ops.iter().rev() {
-        let upstream = op.propagate_demand(demand);
-        out.push(DemandStep {
-            op: op.clone(),
-            downstream: demand,
-            upstream,
-        });
-        demand = upstream;
-    }
-    out.reverse();
-    out
-}
-
-/// Fold demand propagation over `ops` from sink to source and return only
-/// the final upstream demand without allocating intermediate `DemandStep`s.
-pub fn source_demand(ops: &[ChainOp], final_demand: Demand) -> Demand {
-    ops.iter()
-        .rev()
-        .fold(final_demand, |demand, op| op.propagate_demand(demand))
 }
 
 #[cfg(test)]
@@ -346,10 +208,7 @@ mod tests {
 
     #[test]
     fn map_nth_requests_nth_input() {
-        let ops = [
-            op(BuiltinMethod::Map),
-            op_usize(BuiltinMethod::Nth, 2),
-        ];
+        let ops = [op(BuiltinMethod::Map), op_usize(BuiltinMethod::Nth, 2)];
         let demand = source_demand(&ops, Demand::RESULT);
         assert_eq!(demand.pull, PullDemand::NthInput(2));
         assert_eq!(demand.value, ValueNeed::Whole);
@@ -357,10 +216,7 @@ mod tests {
 
     #[test]
     fn filter_nth_falls_back_to_all_input() {
-        let ops = [
-            op(BuiltinMethod::Filter),
-            op_usize(BuiltinMethod::Nth, 2),
-        ];
+        let ops = [op(BuiltinMethod::Filter), op_usize(BuiltinMethod::Nth, 2)];
         let demand = source_demand(&ops, Demand::RESULT);
         assert_eq!(demand.pull, PullDemand::All);
         assert_eq!(demand.value, ValueNeed::Whole);
@@ -387,6 +243,27 @@ mod tests {
         let ops = [op(BuiltinMethod::Filter), op_usize(BuiltinMethod::Take, 3)];
         let demand = source_demand(&ops, Demand::RESULT);
         assert_eq!(demand.pull, PullDemand::UntilOutput(3));
+    }
+
+    #[test]
+    fn compact_and_remove_are_filter_like() {
+        let ops = [op(BuiltinMethod::Compact), op(BuiltinMethod::First)];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::UntilOutput(1));
+        assert_eq!(demand.value, ValueNeed::Whole);
+
+        let ops = [op(BuiltinMethod::Remove), op(BuiltinMethod::Last)];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::LastInput(1));
+        assert_eq!(demand.value, ValueNeed::Whole);
+    }
+
+    #[test]
+    fn find_first_is_filter_like_before_first_sink() {
+        let ops = [op(BuiltinMethod::FindFirst)];
+        let demand = source_demand(&ops, Demand::first(ValueNeed::Whole));
+        assert_eq!(demand.pull, PullDemand::UntilOutput(1));
+        assert_eq!(demand.value, ValueNeed::Whole);
     }
 
     #[test]

--- a/jetro-core/src/parse/chain_ir.rs
+++ b/jetro-core/src/parse/chain_ir.rs
@@ -73,6 +73,34 @@ pub enum ChainOp {
         /// Optional count argument used by demand-propagation for `take`/`skip`.
         demand_arg: BuiltinDemandArg,
     },
+    /// A `match` expression participating in a streaming chain. Match
+    /// behaves as one of three shapes depending on how the surrounding
+    /// pipeline uses its result, captured here as `MatchRole`. Demand
+    /// propagation treats each role like its closest builtin analogue
+    /// (`Filter`, `Map`, `FlatMap`).
+    Match {
+        /// How the surrounding chain consumes match output.
+        role: MatchRole,
+    },
+}
+
+/// The shape a `match` expression takes when embedded in a streaming
+/// pipeline. The role determines its demand-flow behaviour and selects
+/// the streaming analogue (filter / map / flat-map) used during planning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchRole {
+    /// Boolean predicate: arm bodies are `true` / `false`. Drops rows that
+    /// do not match (or whose arm body is falsy). Demand law is
+    /// `Cardinality::Filtering`.
+    Predicate,
+    /// Single-value transform: every input row yields exactly one output.
+    /// Demand law is `Cardinality::OneToOne`.
+    Transform,
+    /// Each input row produces zero or more output rows (an arm body
+    /// returns an iterable). Demand law is `Cardinality::Expanding`.
+    /// Reserved for future pipeline integration; current arm bodies
+    /// always produce a single value, so this role is not yet emitted.
+    Multi,
 }
 
 /// Static specification describing the kind of values a `ChainOp` consumes
@@ -106,10 +134,28 @@ impl ChainOp {
         }
     }
 
+    /// Construct a `ChainOp::Match` for the given `role`.
+    pub fn match_role(role: MatchRole) -> Self {
+        Self::Match { role }
+    }
+
     /// Derive the static `OpSpec` for this operator by consulting the builtin
     /// category registry.
     pub fn spec(&self) -> OpSpec {
         match self {
+            ChainOp::Match { role } => {
+                let cardinality = match role {
+                    MatchRole::Predicate => Cardinality::Filtering,
+                    MatchRole::Transform => Cardinality::OneToOne,
+                    MatchRole::Multi => Cardinality::Expanding,
+                };
+                OpSpec {
+                    input: ValueKind::Stream,
+                    output: ValueKind::Stream,
+                    cardinality,
+                    preserves_order: true,
+                }
+            }
             ChainOp::Builtin { id, .. } => {
                 use crate::builtins::BuiltinCategory as Cat;
 
@@ -162,6 +208,44 @@ impl ChainOp {
 impl DemandOperator for ChainOp {
     fn propagate_demand(&self, downstream: Demand) -> Demand {
         match self {
+            ChainOp::Match { role } => match role {
+                // Predicate match drops rows: downstream demand of N
+                // outputs requires scanning until N pass the predicate,
+                // matching `Filter` semantics. The value need passes
+                // through unchanged because the body re-emits the
+                // matched element (or maps it to a body value when
+                // used as a Transform).
+                MatchRole::Predicate => Demand {
+                    pull: match downstream.pull {
+                        crate::plan::demand::PullDemand::FirstInput(n) => {
+                            // Filter cannot guarantee N outputs from N
+                            // inputs; widen to scan-until-output.
+                            crate::plan::demand::PullDemand::UntilOutput(n)
+                        }
+                        crate::plan::demand::PullDemand::UntilOutput(n) => {
+                            crate::plan::demand::PullDemand::UntilOutput(n)
+                        }
+                        other => other,
+                    },
+                    value: downstream.value,
+                    order: downstream.order,
+                },
+                // Transform match is 1:1 — demand passes through.
+                MatchRole::Transform => downstream,
+                // Multi match expands rows; widen `FirstInput(n)` to
+                // `All` since one input may produce many outputs.
+                MatchRole::Multi => Demand {
+                    pull: match downstream.pull {
+                        crate::plan::demand::PullDemand::FirstInput(_)
+                        | crate::plan::demand::PullDemand::UntilOutput(_) => {
+                            crate::plan::demand::PullDemand::All
+                        }
+                        other => other,
+                    },
+                    value: downstream.value,
+                    order: downstream.order,
+                },
+            },
             ChainOp::Builtin { id, demand_arg } => {
                 propagate_builtin_demand(*id, *demand_arg, downstream)
             }
@@ -179,6 +263,65 @@ mod tests {
 
     fn op_usize(method: BuiltinMethod, n: usize) -> ChainOp {
         ChainOp::builtin_usize(method, n)
+    }
+
+    fn match_op(role: MatchRole) -> ChainOp {
+        ChainOp::match_role(role)
+    }
+
+    #[test]
+    fn match_predicate_classifies_as_filter() {
+        let spec = match_op(MatchRole::Predicate).spec();
+        assert_eq!(spec.cardinality, Cardinality::Filtering);
+        assert_eq!(spec.input, ValueKind::Stream);
+        assert_eq!(spec.output, ValueKind::Stream);
+        assert!(spec.preserves_order);
+    }
+
+    #[test]
+    fn match_transform_classifies_as_map() {
+        let spec = match_op(MatchRole::Transform).spec();
+        assert_eq!(spec.cardinality, Cardinality::OneToOne);
+    }
+
+    #[test]
+    fn match_multi_classifies_as_flat_map() {
+        let spec = match_op(MatchRole::Multi).spec();
+        assert_eq!(spec.cardinality, Cardinality::Expanding);
+    }
+
+    #[test]
+    fn match_predicate_first_scans_until_one_output() {
+        // `match (Predicate) | first` ≡ `filter | first`: scan until one
+        // output is produced.
+        let ops = [match_op(MatchRole::Predicate), op(BuiltinMethod::First)];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::UntilOutput(1));
+        assert_eq!(demand.value, ValueNeed::Whole);
+    }
+
+    #[test]
+    fn match_transform_take_caps_upstream() {
+        // `match (Transform) | take(3)` is 1:1 from match's POV, so the
+        // upstream cap propagates exactly.
+        let ops = [
+            match_op(MatchRole::Transform),
+            op_usize(BuiltinMethod::Take, 3),
+        ];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::FirstInput(3));
+    }
+
+    #[test]
+    fn match_predicate_take_widens_to_scan() {
+        // `match (Predicate) | take(3)`: cannot bound input by 3 since
+        // some rows are dropped. Widens to `UntilOutput(3)`.
+        let ops = [
+            match_op(MatchRole::Predicate),
+            op_usize(BuiltinMethod::Take, 3),
+        ];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::UntilOutput(3));
     }
 
     #[test]

--- a/jetro-core/src/parse/parser.rs
+++ b/jetro-core/src/parse/parser.rs
@@ -71,6 +71,9 @@ fn is_kw(rule: Rule) -> bool {
             | Rule::kw_is
             | Rule::kw_as
             | Rule::kw_try
+            | Rule::kw_when
+            | Rule::kw_match
+            | Rule::kw_with
     )
 }
 
@@ -768,8 +771,144 @@ fn parse_primary(pair: Pair<Rule>) -> Expr {
         Rule::global_call => parse_global_call(inner),
         Rule::expr => parse_expr(inner),
         Rule::patch_block => parse_patch(inner),
+        Rule::match_expr => parse_match_expr(inner),
         Rule::kw_delete => Expr::DeleteMark,
         r => panic!("unexpected primary rule: {:?}", r),
+    }
+}
+
+/// Parse a `match scrutinee { pat when guard -> body, ... }` expression.
+fn parse_match_expr(pair: Pair<Rule>) -> Expr {
+    let mut inner = pair.into_inner().filter(|p| !is_kw(p.as_rule()));
+    let scrutinee = parse_expr(inner.next().expect("match scrutinee"));
+    let mut arms: Vec<MatchArm> = Vec::new();
+    for arm_pair in inner {
+        if arm_pair.as_rule() != Rule::match_arm {
+            continue;
+        }
+        let mut ai = arm_pair.into_inner().filter(|p| !is_kw(p.as_rule()));
+        let pat_pair = ai.next().expect("match arm pattern");
+        let pat = parse_pat(pat_pair);
+        // Remaining: optional guard expr, then body expr.
+        let rest: Vec<_> = ai.collect();
+        let (guard, body) = match rest.len() {
+            1 => (None, parse_expr(rest.into_iter().next().unwrap())),
+            2 => {
+                let mut it = rest.into_iter();
+                let g = parse_expr(it.next().unwrap());
+                let b = parse_expr(it.next().unwrap());
+                (Some(g), b)
+            }
+            _ => panic!("match arm: expected 1 or 2 trailing exprs (guard?, body)"),
+        };
+        arms.push(MatchArm { pat, guard, body });
+    }
+    Expr::Match {
+        scrutinee: Box::new(scrutinee),
+        arms,
+    }
+}
+
+/// Parse a `pat_or` / `pat_atom` rule into a `Pat` AST node.
+fn parse_pat(pair: Pair<Rule>) -> Pat {
+    match pair.as_rule() {
+        Rule::pat_or => {
+            let mut alts: Vec<Pat> = pair.into_inner().map(parse_pat).collect();
+            if alts.len() == 1 {
+                alts.pop().unwrap()
+            } else {
+                Pat::Or(alts)
+            }
+        }
+        Rule::pat_atom => {
+            let inner = pair.into_inner().next().expect("pat_atom inner");
+            parse_pat(inner)
+        }
+        Rule::pat_wild => Pat::Wild,
+        Rule::pat_literal => Pat::Lit(parse_pat_literal(pair)),
+        Rule::pat_kind_bind => {
+            let mut it = pair.into_inner();
+            let name = it.next().unwrap().as_str().to_string();
+            let kind = parse_kind_type(it.next().unwrap().as_str());
+            Pat::Kind { name: Some(name), kind }
+        }
+        Rule::pat_kind_only => {
+            let kt = pair.into_inner().next().unwrap().as_str();
+            Pat::Kind { name: None, kind: parse_kind_type(kt) }
+        }
+        Rule::pat_bind => Pat::Bind(pair.as_str().to_string()),
+        Rule::pat_obj => {
+            let mut fields: Vec<(String, Pat)> = Vec::new();
+            let mut open = false;
+            for p in pair.into_inner() {
+                match p.as_rule() {
+                    Rule::pat_obj_field => {
+                        let mut fi = p.into_inner();
+                        let k = fi.next().unwrap().as_str().to_string();
+                        let v = parse_pat(fi.next().unwrap());
+                        fields.push((k, v));
+                    }
+                    Rule::pat_obj_open => open = true,
+                    _ => {}
+                }
+            }
+            Pat::Obj { fields, open }
+        }
+        Rule::pat_arr => {
+            let mut elems: Vec<Pat> = Vec::new();
+            let mut rest: Option<Option<String>> = None;
+            for p in pair.into_inner() {
+                match p.as_rule() {
+                    Rule::pat_or | Rule::pat_atom => elems.push(parse_pat(p)),
+                    Rule::pat_arr_rest => {
+                        let inner = p.into_inner().next().unwrap();
+                        match inner.as_rule() {
+                            Rule::pat_arr_rest_named => {
+                                let nm = inner.into_inner().next().unwrap().as_str().to_string();
+                                rest = Some(Some(nm));
+                            }
+                            Rule::pat_arr_rest_anon => rest = Some(None),
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Pat::Arr { elems, rest }
+        }
+        r => panic!("unexpected pattern rule: {:?}", r),
+    }
+}
+
+/// Decode a `pat_literal` rule into a `PatLit`.
+fn parse_pat_literal(pair: Pair<Rule>) -> PatLit {
+    let inner = pair.into_inner().next().expect("pat_literal inner");
+    match inner.as_rule() {
+        Rule::pat_lit_null => PatLit::Null,
+        Rule::pat_lit_true => PatLit::Bool(true),
+        Rule::pat_lit_false => PatLit::Bool(false),
+        Rule::pat_lit_int => PatLit::Int(inner.as_str().parse().expect("pat int")),
+        Rule::pat_lit_float => PatLit::Float(inner.as_str().parse().expect("pat float")),
+        Rule::pat_lit_str => {
+            let raw = inner.as_str();
+            // Strip surrounding quotes.
+            let stripped = &raw[1..raw.len() - 1];
+            PatLit::Str(stripped.to_string())
+        }
+        r => panic!("unexpected pat literal rule: {:?}", r),
+    }
+}
+
+/// Map a kind type name (`number`, `string`, ...) to `KindType`.
+fn parse_kind_type(name: &str) -> KindType {
+    match name {
+        "number" => KindType::Number,
+        "string" => KindType::Str,
+        "array" => KindType::Array,
+        "object" => KindType::Object,
+        "bool" => KindType::Bool,
+        "null" => KindType::Null,
+        other => panic!("unknown kind type: {other}"),
     }
 }
 

--- a/jetro-core/src/parse/parser.rs
+++ b/jetro-core/src/parse/parser.rs
@@ -152,9 +152,12 @@ fn validate_pattern_linearity(expr: &Expr) -> Result<(), ParseError> {
                     collect_binds(alt, out);
                 }
             }
-            Pat::Obj { fields, .. } => {
+            Pat::Obj { fields, rest } => {
                 for (_, sub) in fields {
                     collect_binds(sub, out);
+                }
+                if let Some(Some(name)) = rest {
+                    out.insert(name.clone());
                 }
             }
             Pat::Arr { elems, rest } => {
@@ -1104,7 +1107,7 @@ fn parse_pat(pair: Pair<Rule>) -> Pat {
         Rule::pat_bind => Pat::Bind(pair.as_str().to_string()),
         Rule::pat_obj => {
             let mut fields: Vec<(String, Pat)> = Vec::new();
-            let mut open = false;
+            let mut rest: Option<Option<String>> = None;
             for p in pair.into_inner() {
                 match p.as_rule() {
                     Rule::pat_obj_field => {
@@ -1113,11 +1116,26 @@ fn parse_pat(pair: Pair<Rule>) -> Pat {
                         let v = parse_pat(fi.next().unwrap());
                         fields.push((k, v));
                     }
-                    Rule::pat_obj_open => open = true,
+                    Rule::pat_obj_rest => {
+                        let inner = p.into_inner().next().unwrap();
+                        match inner.as_rule() {
+                            Rule::pat_obj_rest_named => {
+                                let nm = inner
+                                    .into_inner()
+                                    .next()
+                                    .unwrap()
+                                    .as_str()
+                                    .to_string();
+                                rest = Some(Some(nm));
+                            }
+                            Rule::pat_obj_rest_anon => rest = Some(None),
+                            _ => {}
+                        }
+                    }
                     _ => {}
                 }
             }
-            Pat::Obj { fields, open }
+            Pat::Obj { fields, rest }
         }
         Rule::pat_arr => {
             let mut elems: Vec<Pat> = Vec::new();
@@ -1479,7 +1497,7 @@ fn parse_obj_field(pair: Pair<Rule>) -> ObjField {
                 cond: None,
             }
         }
-        Rule::obj_field_spread => {
+        Rule::obj_field_spread | Rule::obj_field_spread_star => {
             let expr = parse_expr(inner.into_inner().next().unwrap());
             ObjField::Spread(expr)
         }

--- a/jetro-core/src/parse/parser.rs
+++ b/jetro-core/src/parse/parser.rs
@@ -210,7 +210,20 @@ fn validate_pattern_linearity(expr: &Expr) -> Result<(), ParseError> {
                     walk(&arm.body)?;
                 }
             }
-            Expr::Chain(base, _) => walk(base)?,
+            Expr::Chain(base, steps) => {
+                walk(base)?;
+                for step in steps {
+                    if let Step::DeepMatch(arms) = step {
+                        for arm in arms {
+                            walk_pat(&arm.pat)?;
+                            if let Some(g) = arm.guard.as_ref() {
+                                walk(g)?;
+                            }
+                            walk(&arm.body)?;
+                        }
+                    }
+                }
+            }
             Expr::BinOp(l, _, r) | Expr::Coalesce(l, r) => {
                 walk(l)?;
                 walk(r)?;
@@ -857,6 +870,30 @@ fn parse_postfix_step(pair: Pair<Rule>) -> Vec<Step> {
                 other => format!("deep_{}", other),
             };
             vec![Step::Method(mapped, args)]
+        }
+        Rule::deep_match => {
+            // `$..match { arms }` — recursive descent variant of `match`.
+            let mut arms: Vec<MatchArm> = Vec::new();
+            for child in inner_pair.into_inner().filter(|p| !is_kw(p.as_rule())) {
+                if child.as_rule() != Rule::match_arm {
+                    continue;
+                }
+                let mut ai = child.into_inner().filter(|p| !is_kw(p.as_rule()));
+                let pat = parse_pat(ai.next().expect("match arm pattern"));
+                let rest: Vec<_> = ai.collect();
+                let (guard, body) = match rest.len() {
+                    1 => (None, parse_expr(rest.into_iter().next().unwrap())),
+                    2 => {
+                        let mut it = rest.into_iter();
+                        let g = parse_expr(it.next().unwrap());
+                        let b = parse_expr(it.next().unwrap());
+                        (Some(g), b)
+                    }
+                    _ => panic!("deep_match arm: expected 1 or 2 trailing exprs (guard?, body)"),
+                };
+                arms.push(MatchArm { pat, guard, body });
+            }
+            vec![Step::DeepMatch(arms)]
         }
         Rule::inline_filter => {
             let expr = parse_expr(inner_pair.into_inner().next().unwrap());

--- a/jetro-core/src/parse/parser.rs
+++ b/jetro-core/src/parse/parser.rs
@@ -228,7 +228,7 @@ fn validate_pattern_linearity(expr: &Expr) -> Result<(), ParseError> {
             Expr::Chain(base, steps) => {
                 walk(base)?;
                 for step in steps {
-                    if let Step::DeepMatch(arms) = step {
+                    if let Step::DeepMatch { arms, .. } = step {
                         for arm in arms {
                             walk_pat(&arm.pat)?;
                             if let Some(g) = arm.guard.as_ref() {
@@ -887,28 +887,36 @@ fn parse_postfix_step(pair: Pair<Rule>) -> Vec<Step> {
             vec![Step::Method(mapped, args)]
         }
         Rule::deep_match => {
-            // `$..match { arms }` — recursive descent variant of `match`.
+            // `$..match { arms }` (collect all) and `$..match! { arms }`
+            // (early-stop on first truthy match) share the parsing path.
+            // The `deep_match_op` token spelling distinguishes the two.
             let mut arms: Vec<MatchArm> = Vec::new();
+            let mut early_stop = false;
             for child in inner_pair.into_inner().filter(|p| !is_kw(p.as_rule())) {
-                if child.as_rule() != Rule::match_arm {
-                    continue;
-                }
-                let mut ai = child.into_inner().filter(|p| !is_kw(p.as_rule()));
-                let pat = parse_pat(ai.next().expect("match arm pattern"));
-                let rest: Vec<_> = ai.collect();
-                let (guard, body) = match rest.len() {
-                    1 => (None, parse_expr(rest.into_iter().next().unwrap())),
-                    2 => {
-                        let mut it = rest.into_iter();
-                        let g = parse_expr(it.next().unwrap());
-                        let b = parse_expr(it.next().unwrap());
-                        (Some(g), b)
+                match child.as_rule() {
+                    Rule::deep_match_op => {
+                        early_stop = child.as_str().ends_with('!');
                     }
-                    _ => panic!("deep_match arm: expected 1 or 2 trailing exprs (guard?, body)"),
-                };
-                arms.push(MatchArm { pat, guard, body });
+                    Rule::match_arm => {
+                        let mut ai = child.into_inner().filter(|p| !is_kw(p.as_rule()));
+                        let pat = parse_pat(ai.next().expect("match arm pattern"));
+                        let rest: Vec<_> = ai.collect();
+                        let (guard, body) = match rest.len() {
+                            1 => (None, parse_expr(rest.into_iter().next().unwrap())),
+                            2 => {
+                                let mut it = rest.into_iter();
+                                let g = parse_expr(it.next().unwrap());
+                                let b = parse_expr(it.next().unwrap());
+                                (Some(g), b)
+                            }
+                            _ => panic!("deep_match arm: expected 1 or 2 trailing exprs (guard?, body)"),
+                        };
+                        arms.push(MatchArm { pat, guard, body });
+                    }
+                    _ => {}
+                }
             }
-            vec![Step::DeepMatch(arms)]
+            vec![Step::DeepMatch { arms, early_stop }]
         }
         Rule::inline_filter => {
             let expr = parse_expr(inner_pair.into_inner().next().unwrap());

--- a/jetro-core/src/parse/parser.rs
+++ b/jetro-core/src/parse/parser.rs
@@ -45,11 +45,148 @@ impl From<pest::error::Error<Rule>> for ParseError {
 
 /// Parse a Jetro query string into an `Expr` AST. This is the primary public
 /// entry point; all other `parse_*` functions are internal helpers.
+///
+/// In addition to grammar-level parsing, this entry point runs post-parse
+/// semantic validation passes (currently or-pattern linearity for `match`
+/// expressions) so callers see structural errors before the expression
+/// reaches the compiler.
 pub fn parse(input: &str) -> Result<Expr, ParseError> {
     let mut pairs = V2Parser::parse(Rule::program, input)?;
     let program = pairs.next().unwrap();
     let expr_pair = program.into_inner().next().unwrap();
-    Ok(parse_expr(expr_pair))
+    let expr = parse_expr(expr_pair);
+    validate_pattern_linearity(&expr)?;
+    Ok(expr)
+}
+
+/// Walk the `Expr` tree and validate that every `match` arm's pattern
+/// satisfies the linearity rule for or-patterns: each alternative inside
+/// an `Or` must bind exactly the same set of variable names. This rules
+/// out arms whose body cannot consistently reference a captured value
+/// (e.g. `{a: x} | {b: y} -> x` would be ambiguous).
+fn validate_pattern_linearity(expr: &Expr) -> Result<(), ParseError> {
+    use std::collections::BTreeSet;
+
+    fn collect_binds(pat: &Pat, out: &mut BTreeSet<String>) {
+        match pat {
+            Pat::Wild | Pat::Lit(_) => {}
+            Pat::Bind(name) => {
+                out.insert(name.clone());
+            }
+            Pat::Kind { name, .. } => {
+                if let Some(n) = name.as_deref() {
+                    out.insert(n.to_string());
+                }
+            }
+            Pat::Or(alts) => {
+                for alt in alts {
+                    collect_binds(alt, out);
+                }
+            }
+            Pat::Obj { fields, .. } => {
+                for (_, sub) in fields {
+                    collect_binds(sub, out);
+                }
+            }
+            Pat::Arr { elems, rest } => {
+                for sub in elems {
+                    collect_binds(sub, out);
+                }
+                if let Some(Some(name)) = rest {
+                    out.insert(name.clone());
+                }
+            }
+        }
+    }
+
+    fn walk_pat(pat: &Pat) -> Result<(), ParseError> {
+        if let Pat::Or(alts) = pat {
+            let mut first: Option<BTreeSet<String>> = None;
+            for alt in alts {
+                let mut names = BTreeSet::new();
+                collect_binds(alt, &mut names);
+                match &first {
+                    None => first = Some(names),
+                    Some(existing) if existing == &names => {}
+                    Some(existing) => {
+                        return Err(ParseError(format!(
+                            "or-pattern arms must bind the same variables; \
+                             got {{{}}} vs {{{}}}",
+                            existing.iter().cloned().collect::<Vec<_>>().join(", "),
+                            names.iter().cloned().collect::<Vec<_>>().join(", "),
+                        )));
+                    }
+                }
+            }
+        }
+        match pat {
+            Pat::Wild | Pat::Lit(_) | Pat::Bind(_) | Pat::Kind { .. } => {}
+            Pat::Or(alts) => {
+                for alt in alts {
+                    walk_pat(alt)?;
+                }
+            }
+            Pat::Obj { fields, .. } => {
+                for (_, sub) in fields {
+                    walk_pat(sub)?;
+                }
+            }
+            Pat::Arr { elems, .. } => {
+                for sub in elems {
+                    walk_pat(sub)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn walk(e: &Expr) -> Result<(), ParseError> {
+        match e {
+            Expr::Match { scrutinee, arms } => {
+                walk(scrutinee)?;
+                for arm in arms {
+                    walk_pat(&arm.pat)?;
+                    if let Some(g) = arm.guard.as_ref() {
+                        walk(g)?;
+                    }
+                    walk(&arm.body)?;
+                }
+            }
+            Expr::Chain(base, _) => walk(base)?,
+            Expr::BinOp(l, _, r) | Expr::Coalesce(l, r) => {
+                walk(l)?;
+                walk(r)?;
+            }
+            Expr::UnaryNeg(e) | Expr::Not(e) | Expr::Cast { expr: e, .. } => walk(e)?,
+            Expr::Kind { expr, .. } => walk(expr)?,
+            Expr::Object(_)
+            | Expr::Array(_)
+            | Expr::Pipeline { .. }
+            | Expr::ListComp { .. }
+            | Expr::DictComp { .. }
+            | Expr::SetComp { .. }
+            | Expr::GenComp { .. }
+            | Expr::Lambda { .. }
+            | Expr::Let { .. }
+            | Expr::IfElse { .. }
+            | Expr::Try { .. }
+            | Expr::GlobalCall { .. }
+            | Expr::Patch { .. }
+            | Expr::FString(_)
+            | Expr::Null
+            | Expr::Bool(_)
+            | Expr::Int(_)
+            | Expr::Float(_)
+            | Expr::Str(_)
+            | Expr::Root
+            | Expr::Current
+            | Expr::Ident(_)
+            | Expr::DeleteMark => {}
+        }
+        Ok(())
+    }
+
+    walk(expr)
 }
 
 

--- a/jetro-core/src/parse/parser.rs
+++ b/jetro-core/src/parse/parser.rs
@@ -70,25 +70,40 @@ fn strict_match_lint_enabled() -> bool {
     std::env::var_os("JETRO_STRICT_MATCH").is_some()
 }
 
+/// Recognise irrefutable patterns — those that match every value
+/// regardless of shape and therefore qualify as a catch-all arm in the
+/// exhaustiveness analysis. Beyond the trivial `Wild` and bare `Bind`
+/// cases, this also accepts `Or` patterns whose alternative list
+/// contains an irrefutable alt (since at least one alt fires for every
+/// value) and `Kind`-bound patterns whose kind covers all runtime
+/// types (currently never, but the structure is in place for future
+/// extension to a `_: any` form).
+fn pat_is_irrefutable(pat: &Pat) -> bool {
+    match pat {
+        Pat::Wild | Pat::Bind(_) => true,
+        Pat::Or(alts) => alts.iter().any(pat_is_irrefutable),
+        _ => false,
+    }
+}
+
 /// Walk the `Expr` tree and reject any `match` whose arms cannot prove
-/// exhaustiveness — that is, when no arm has an unconditional catch-all
-/// (`Pat::Wild` or a bare `Pat::Bind`) without a guard. Triggered only
-/// when the `JETRO_STRICT_MATCH` environment variable is set; the
-/// default behaviour is to surface non-exhaustive matches as a runtime
-/// `EvalError` when no arm fires.
+/// exhaustiveness — that is, when no arm has an unguarded catch-all
+/// (`Pat::Wild`, a bare `Pat::Bind`, or an `Or`-pattern containing one).
+/// Triggered only when the `JETRO_STRICT_MATCH` environment variable
+/// is set; the default behaviour is to surface non-exhaustive matches
+/// as a runtime `EvalError` when no arm fires.
 fn validate_match_exhaustiveness(expr: &Expr) -> Result<(), ParseError> {
     fn check(e: &Expr) -> Result<(), ParseError> {
         match e {
             Expr::Match { scrutinee, arms } => {
                 check(scrutinee)?;
-                let exhaustive = arms.iter().any(|a| {
-                    a.guard.is_none()
-                        && matches!(a.pat, Pat::Wild | Pat::Bind(_))
-                });
+                let exhaustive = arms
+                    .iter()
+                    .any(|a| a.guard.is_none() && pat_is_irrefutable(&a.pat));
                 if !exhaustive {
                     return Err(ParseError(
-                        "non-exhaustive match: no unconditional catch-all arm \
-                         (`_` or a bare bind without `when`)"
+                        "non-exhaustive match: no unguarded catch-all arm \
+                         (`_`, a bare bind, or an or-pattern containing one)"
                             .to_string(),
                     ));
                 }

--- a/jetro-core/src/parse/parser.rs
+++ b/jetro-core/src/parse/parser.rs
@@ -56,7 +56,61 @@ pub fn parse(input: &str) -> Result<Expr, ParseError> {
     let expr_pair = program.into_inner().next().unwrap();
     let expr = parse_expr(expr_pair);
     validate_pattern_linearity(&expr)?;
+    if strict_match_lint_enabled() {
+        validate_match_exhaustiveness(&expr)?;
+    }
     Ok(expr)
+}
+
+/// Read the `JETRO_STRICT_MATCH` environment variable on every parse.
+/// Toggling the flag at runtime is rare in practice, and reading it per
+/// call lets tooling and tests flip the lint without restarting the
+/// process.
+fn strict_match_lint_enabled() -> bool {
+    std::env::var_os("JETRO_STRICT_MATCH").is_some()
+}
+
+/// Walk the `Expr` tree and reject any `match` whose arms cannot prove
+/// exhaustiveness — that is, when no arm has an unconditional catch-all
+/// (`Pat::Wild` or a bare `Pat::Bind`) without a guard. Triggered only
+/// when the `JETRO_STRICT_MATCH` environment variable is set; the
+/// default behaviour is to surface non-exhaustive matches as a runtime
+/// `EvalError` when no arm fires.
+fn validate_match_exhaustiveness(expr: &Expr) -> Result<(), ParseError> {
+    fn check(e: &Expr) -> Result<(), ParseError> {
+        match e {
+            Expr::Match { scrutinee, arms } => {
+                check(scrutinee)?;
+                let exhaustive = arms.iter().any(|a| {
+                    a.guard.is_none()
+                        && matches!(a.pat, Pat::Wild | Pat::Bind(_))
+                });
+                if !exhaustive {
+                    return Err(ParseError(
+                        "non-exhaustive match: no unconditional catch-all arm \
+                         (`_` or a bare bind without `when`)"
+                            .to_string(),
+                    ));
+                }
+                for arm in arms {
+                    if let Some(g) = arm.guard.as_ref() {
+                        check(g)?;
+                    }
+                    check(&arm.body)?;
+                }
+                Ok(())
+            }
+            Expr::Chain(base, _) => check(base),
+            Expr::BinOp(l, _, r) | Expr::Coalesce(l, r) => {
+                check(l)?;
+                check(r)
+            }
+            Expr::UnaryNeg(e) | Expr::Not(e) | Expr::Cast { expr: e, .. } => check(e),
+            Expr::Kind { expr, .. } => check(expr),
+            _ => Ok(()),
+        }
+    }
+    check(expr)
 }
 
 /// Walk the `Expr` tree and validate that every `match` arm's pattern
@@ -69,7 +123,7 @@ fn validate_pattern_linearity(expr: &Expr) -> Result<(), ParseError> {
 
     fn collect_binds(pat: &Pat, out: &mut BTreeSet<String>) {
         match pat {
-            Pat::Wild | Pat::Lit(_) => {}
+            Pat::Wild | Pat::Lit(_) | Pat::Range { .. } => {}
             Pat::Bind(name) => {
                 out.insert(name.clone());
             }
@@ -120,7 +174,11 @@ fn validate_pattern_linearity(expr: &Expr) -> Result<(), ParseError> {
             }
         }
         match pat {
-            Pat::Wild | Pat::Lit(_) | Pat::Bind(_) | Pat::Kind { .. } => {}
+            Pat::Wild
+            | Pat::Lit(_)
+            | Pat::Bind(_)
+            | Pat::Kind { .. }
+            | Pat::Range { .. } => {}
             Pat::Or(alts) => {
                 for alt in alts {
                     walk_pat(alt)?;
@@ -960,6 +1018,16 @@ fn parse_pat(pair: Pair<Rule>) -> Pat {
         Rule::pat_atom => {
             let inner = pair.into_inner().next().expect("pat_atom inner");
             parse_pat(inner)
+        }
+        Rule::pat_range => {
+            let mut it = pair.into_inner();
+            let lo_pair = it.next().expect("pat_range: lo");
+            let op_pair = it.next().expect("pat_range: op");
+            let hi_pair = it.next().expect("pat_range: hi");
+            let lo: f64 = lo_pair.as_str().parse().expect("range lo as f64");
+            let hi: f64 = hi_pair.as_str().parse().expect("range hi as f64");
+            let inclusive = op_pair.as_str() == "..=";
+            Pat::Range { lo, hi, inclusive }
         }
         Rule::pat_wild => Pat::Wild,
         Rule::pat_literal => Pat::Lit(parse_pat_literal(pair)),

--- a/jetro-core/src/plan/analysis.rs
+++ b/jetro-core/src/plan/analysis.rs
@@ -387,6 +387,7 @@ fn apply_op(op: &Opcode, stack: &mut Vec<AbstractVal>) {
         }
         Opcode::PipelineRun { .. } => stack.push(AbstractVal::UNKNOWN),
         Opcode::DeleteMarkErr => stack.push(AbstractVal::UNKNOWN),
+        Opcode::Match(_) => stack.push(AbstractVal::UNKNOWN),
     }
 }
 
@@ -902,6 +903,13 @@ pub fn expr_uses_ident(expr: &crate::parse::ast::Expr, name: &str) -> bool {
             })
         }
         Expr::DeleteMark => false,
+        Expr::Match { scrutinee, arms } => {
+            expr_uses_ident(scrutinee, name)
+                || arms.iter().any(|a| {
+                    a.guard.as_ref().is_some_and(|g| expr_uses_ident(g, name))
+                        || expr_uses_ident(&a.body, name)
+                })
+        }
     }
 }
 
@@ -1192,6 +1200,7 @@ pub fn opcode_cost(op: &Opcode) -> u32 {
         Opcode::CastOp(_) => 2,
         Opcode::PatchEval(_) => 50,
         Opcode::DeleteMarkErr => 1,
+        Opcode::Match(_) => 1,
         Opcode::PipelineRun { base, steps } => {
             program_cost(base)
                 + steps

--- a/jetro-core/src/plan/analysis.rs
+++ b/jetro-core/src/plan/analysis.rs
@@ -1100,10 +1100,12 @@ fn rewrite_call(
 ) -> Arc<crate::vm::CompiledCall> {
     use crate::vm::CompiledCall;
     let new_subs: Vec<Arc<Program>> = c.sub_progs.iter().map(|p| dedup_rec(p, cache)).collect();
+    let new_kernels = crate::compile::compiler::classify_sub_kernels(&new_subs);
     Arc::new(CompiledCall {
         method: c.method,
         name: c.name.clone(),
         sub_progs: new_subs.into(),
+        sub_kernels: new_kernels,
         orig_args: c.orig_args.clone(),
         demand_max_keep: c.demand_max_keep,
     })

--- a/jetro-core/src/plan/analysis.rs
+++ b/jetro-core/src/plan/analysis.rs
@@ -388,6 +388,7 @@ fn apply_op(op: &Opcode, stack: &mut Vec<AbstractVal>) {
         Opcode::PipelineRun { .. } => stack.push(AbstractVal::UNKNOWN),
         Opcode::DeleteMarkErr => stack.push(AbstractVal::UNKNOWN),
         Opcode::Match(_) => stack.push(AbstractVal::UNKNOWN),
+        Opcode::DeepMatchAll(_) => stack.push(AbstractVal::UNKNOWN),
     }
 }
 
@@ -1201,6 +1202,7 @@ pub fn opcode_cost(op: &Opcode) -> u32 {
         Opcode::PatchEval(_) => 50,
         Opcode::DeleteMarkErr => 1,
         Opcode::Match(_) => 1,
+        Opcode::DeepMatchAll(_) => 1,
         Opcode::PipelineRun { base, steps } => {
             program_cost(base)
                 + steps

--- a/jetro-core/src/plan/analysis.rs
+++ b/jetro-core/src/plan/analysis.rs
@@ -389,6 +389,7 @@ fn apply_op(op: &Opcode, stack: &mut Vec<AbstractVal>) {
         Opcode::DeleteMarkErr => stack.push(AbstractVal::UNKNOWN),
         Opcode::Match(_) => stack.push(AbstractVal::UNKNOWN),
         Opcode::DeepMatchAll(_) => stack.push(AbstractVal::UNKNOWN),
+        Opcode::DeepMatchFirst(_) => stack.push(AbstractVal::UNKNOWN),
     }
 }
 
@@ -1203,6 +1204,7 @@ pub fn opcode_cost(op: &Opcode) -> u32 {
         Opcode::DeleteMarkErr => 1,
         Opcode::Match(_) => 1,
         Opcode::DeepMatchAll(_) => 1,
+        Opcode::DeepMatchFirst(_) => 1,
         Opcode::PipelineRun { base, steps } => {
             program_cost(base)
                 + steps

--- a/jetro-core/src/plan/demand.rs
+++ b/jetro-core/src/plan/demand.rs
@@ -1,0 +1,167 @@
+//! Shared demand model and backward propagation helpers.
+//!
+//! Demand is a planning concern, not parser syntax: sinks describe how much
+//! input and value payload they need, and stage/operator adapters translate
+//! that demand backward toward the source.
+
+#![allow(dead_code)]
+
+/// Describes how much of each element's content a pipeline stage actually
+/// needs to read, used to skip deserialisation or evaluation work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueNeed {
+    /// The stage only needs to know the element exists; payload can be skipped.
+    None,
+    /// The stage evaluates a predicate and needs enough of the value to test it.
+    Predicate,
+    /// The stage only needs fields used by a projection.
+    Projection,
+    /// The full element value is required.
+    Whole,
+    /// Only the numeric interpretation of the element is needed (e.g. for `sum`).
+    Numeric,
+}
+
+impl ValueNeed {
+    /// Return the stricter of two `ValueNeed` values; `Whole` dominates all others.
+    pub(crate) fn merge(self, other: Self) -> Self {
+        use ValueNeed::*;
+        match (self, other) {
+            (Whole, _) | (_, Whole) => Whole,
+            (Numeric, _) | (_, Numeric) => Numeric,
+            (Projection, _) | (_, Projection) => Projection,
+            (Predicate, _) | (_, Predicate) => Predicate,
+            (None, None) => None,
+        }
+    }
+}
+
+/// Specifies how many input elements a stage must pull from its source to
+/// satisfy a downstream consumer's limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PullDemand {
+    /// Pull all available input elements without any limit.
+    All,
+    /// Pull at most the first `n` input elements regardless of how many outputs they produce.
+    FirstInput(usize),
+    /// Pull from the end of the input until `n` outputs have been produced.
+    LastInput(usize),
+    /// Pull the input element at zero-based index `i` when the source can seek to it.
+    NthInput(usize),
+    /// Pull input until exactly `n` output elements have been produced.
+    UntilOutput(usize),
+}
+
+impl PullDemand {
+    /// Return a `PullDemand` capped to at most `n` input elements,
+    /// converting `All` or `UntilOutput` variants to `FirstInput(n)`.
+    pub(crate) fn cap_inputs(self, n: usize) -> Self {
+        match self {
+            PullDemand::All | PullDemand::UntilOutput(_) | PullDemand::LastInput(_) => {
+                PullDemand::FirstInput(n)
+            }
+            PullDemand::FirstInput(m) => PullDemand::FirstInput(m.min(n)),
+            PullDemand::NthInput(i) => {
+                if i < n {
+                    PullDemand::NthInput(i)
+                } else {
+                    PullDemand::FirstInput(n)
+                }
+            }
+        }
+    }
+}
+
+/// Combined downstream demand annotation: how much to pull, what payload is
+/// needed, and whether the consumer requires stable input ordering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Demand {
+    /// How many upstream elements must be consumed.
+    pub pull: PullDemand,
+    /// How much of each element's payload is required.
+    pub value: ValueNeed,
+    /// Whether the consumer depends on elements arriving in their original order.
+    pub order: bool,
+}
+
+impl Demand {
+    /// The terminal demand used at the sink of a pipeline: pull everything,
+    /// need whole values, and require ordering.
+    pub const RESULT: Demand = Demand {
+        pull: PullDemand::All,
+        value: ValueNeed::Whole,
+        order: true,
+    };
+
+    /// Construct a demand that pulls all input with the given value need and
+    /// order requirement.
+    pub fn all(value: ValueNeed) -> Self {
+        Self {
+            pull: PullDemand::All,
+            value,
+            order: true,
+        }
+    }
+
+    /// Construct a demand that pulls only the first input element with the
+    /// given value need, and no ordering requirement.
+    pub fn first(value: ValueNeed) -> Self {
+        Self {
+            pull: PullDemand::FirstInput(1),
+            value,
+            order: false,
+        }
+    }
+}
+
+/// Adapter trait implemented by whichever operator representation a planner
+/// uses for demand propagation.
+pub trait DemandOperator {
+    /// Propagate `downstream` demand through this operator, returning the
+    /// upstream demand that its source must satisfy.
+    fn propagate_demand(&self, downstream: Demand) -> Demand;
+}
+
+/// A single annotated step produced by `propagate_demands`, recording an
+/// operator alongside the demand it receives and the demand it places upstream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DemandStep<Op> {
+    /// The operator at this position in the chain.
+    pub op: Op,
+    /// Demand flowing into this operator from the downstream consumer.
+    pub downstream: Demand,
+    /// Demand this operator forwards to its upstream source.
+    pub upstream: Demand,
+}
+
+/// Walk `ops` in reverse and compute each operator's upstream demand given
+/// `final_demand` at the sink, returning annotated `DemandStep`s in forward order.
+pub fn propagate_demands<Op>(ops: &[Op], final_demand: Demand) -> Vec<DemandStep<Op>>
+where
+    Op: DemandOperator + Clone,
+{
+    let mut demand = final_demand;
+    let mut out = Vec::with_capacity(ops.len());
+    for op in ops.iter().rev() {
+        let upstream = op.propagate_demand(demand);
+        out.push(DemandStep {
+            op: op.clone(),
+            downstream: demand,
+            upstream,
+        });
+        demand = upstream;
+    }
+    out.reverse();
+    out
+}
+
+/// Fold demand propagation over `ops` from sink to source and return only
+/// the final upstream demand without allocating intermediate `DemandStep`s.
+pub fn source_demand<Op>(ops: &[Op], final_demand: Demand) -> Demand
+where
+    Op: DemandOperator,
+{
+    ops.iter()
+        .rev()
+        .fold(final_demand, |demand, op| op.propagate_demand(demand))
+}

--- a/jetro-core/src/plan/mod.rs
+++ b/jetro-core/src/plan/mod.rs
@@ -5,6 +5,7 @@
 //! `analysis` provides shared shape, nullability, and selectivity passes.
 
 pub(crate) mod analysis;
+pub(crate) mod demand;
 pub(crate) mod logical;
 pub(crate) mod optimize;
 pub(crate) mod patch_fusion;

--- a/jetro-core/src/plan/patch_fusion.rs
+++ b/jetro-core/src/plan/patch_fusion.rs
@@ -205,6 +205,19 @@ impl EffectAnalyzer {
             | Expr::Str(_)
             | Expr::DeleteMark => EffectSummary::default(),
 
+            // Match: opaque to fusion until P2 ships runtime; treat as a black-box
+            // expression that may read/write anything reachable from its sub-exprs.
+            Expr::Match { scrutinee, arms } => {
+                let mut s = self.visit(scrutinee);
+                for a in arms {
+                    if let Some(g) = a.guard.as_ref() {
+                        s.merge(self.visit(g));
+                    }
+                    s.merge(self.visit(&a.body));
+                }
+                s
+            }
+
             // Root references: one read, no writes.
             Expr::Root => {
                 let mut s = EffectSummary::default();
@@ -818,6 +831,20 @@ fn fuse_recursive(expr: Expr, ctx: &mut FuseCtx) -> Expr {
         | Expr::Current
         | Expr::Ident(_)
         | Expr::DeleteMark => expr,
+
+        // Match: recurse into sub-exprs, leave structure intact. P2 will land
+        // a real fusion-aware lowering that can move writes through arms.
+        Expr::Match { scrutinee, arms } => Expr::Match {
+            scrutinee: Box::new(fuse_recursive(*scrutinee, ctx)),
+            arms: arms
+                .into_iter()
+                .map(|a| crate::parse::ast::MatchArm {
+                    pat: a.pat,
+                    guard: a.guard.map(|g| fuse_recursive(g, ctx)),
+                    body: fuse_recursive(a.body, ctx),
+                })
+                .collect(),
+        },
 
         Expr::FString(parts) => Expr::FString(
             parts

--- a/jetro-core/src/plan/patch_fusion.rs
+++ b/jetro-core/src/plan/patch_fusion.rs
@@ -494,7 +494,7 @@ impl EffectAnalyzer {
                 }
                 s
             }
-            Step::DeepMatch(arms) => {
+            Step::DeepMatch { arms, .. } => {
                 let mut s = EffectSummary::default();
                 for arm in arms {
                     if let Some(g) = arm.guard.as_ref() {

--- a/jetro-core/src/plan/patch_fusion.rs
+++ b/jetro-core/src/plan/patch_fusion.rs
@@ -494,6 +494,16 @@ impl EffectAnalyzer {
                 }
                 s
             }
+            Step::DeepMatch(arms) => {
+                let mut s = EffectSummary::default();
+                for arm in arms {
+                    if let Some(g) = arm.guard.as_ref() {
+                        s.merge(self.visit(g));
+                    }
+                    s.merge(self.visit(&arm.body));
+                }
+                s
+            }
         }
     }
 

--- a/jetro-core/src/plan/physical.rs
+++ b/jetro-core/src/plan/physical.rs
@@ -532,6 +532,31 @@ fn lower_structural_prefix(
                 let fallback = Arc::new(Compiler::compile(&fallback_expr, "<structural-fallback>"));
                 return Some((plan, fallback, idx + 1));
             }
+            Step::DeepMatch { arms, early_stop } => {
+                // Lower `..match { ... }` to a structural plan when the
+                // compile-time shape summary admits bitmap candidate
+                // enumeration (currently `ObjAnyOfKeys`). All other
+                // shape summaries fall through to the VM tree-walk
+                // runtime by returning `None` here.
+                let cm = Arc::new(crate::compile::compiler::compile_match(
+                    &Expr::Current,
+                    arms,
+                    &crate::compile::compiler::VarCtx::default(),
+                ));
+                let candidate_keys = match cm.shape_summary.as_ref()? {
+                    crate::vm::MatchShapeSummary::ObjAnyOfKeys(keys) => Arc::clone(keys),
+                    _ => return None,
+                };
+                let plan = StructuralPlan::DeepMatch {
+                    anchor: Arc::from(anchor),
+                    candidate_keys,
+                    cm,
+                    early_stop: *early_stop,
+                };
+                let fallback_expr = base.clone().maybe_chain(steps[..=idx].to_vec());
+                let fallback = Arc::new(Compiler::compile(&fallback_expr, "<structural-fallback>"));
+                return Some((plan, fallback, idx + 1));
+            }
             _ => return None,
         }
     }

--- a/jetro-core/src/tests/mod.rs
+++ b/jetro-core/src/tests/mod.rs
@@ -23,4 +23,6 @@ mod patch_fusion_soundness;
 #[cfg(test)]
 mod examples;
 #[cfg(test)]
+mod pattern_match;
+#[cfg(test)]
 mod regression;

--- a/jetro-core/src/tests/pattern_match.rs
+++ b/jetro-core/src/tests/pattern_match.rs
@@ -1,0 +1,233 @@
+//! Pattern-match parser and runtime tests.
+
+use crate::parse::ast::{Expr, KindType, Pat, PatLit};
+use crate::parse::parser::parse;
+use crate::Jetro;
+use serde_json::json;
+
+fn run(json_src: &[u8], expr: &str) -> serde_json::Value {
+    let j = Jetro::from_bytes(json_src.to_vec()).expect("json parse");
+    j.collect(expr).expect("eval")
+}
+
+fn run_err(json_src: &[u8], expr: &str) -> String {
+    let j = Jetro::from_bytes(json_src.to_vec()).expect("json parse");
+    j.collect(expr).err().expect("expected error").to_string()
+}
+
+fn parse_match(src: &str) -> (Expr, Vec<crate::parse::ast::MatchArm>) {
+    match parse(src).expect("parse ok") {
+        Expr::Match { scrutinee, arms } => (*scrutinee, arms),
+        other => panic!("expected Match, got {other:?}"),
+    }
+}
+
+#[test]
+fn parses_wildcard_arm() {
+    let (_, arms) = parse_match("match $.x with { _ -> 1 }");
+    assert_eq!(arms.len(), 1);
+    assert!(matches!(arms[0].pat, Pat::Wild));
+    assert!(arms[0].guard.is_none());
+}
+
+#[test]
+fn parses_literal_arms() {
+    let (_, arms) = parse_match(
+        r#"match $.k with {
+            null    -> 0,
+            true    -> 1,
+            "x"     -> 2,
+            42      -> 3,
+            3.14    -> 4,
+            _       -> 5
+        }"#,
+    );
+    assert_eq!(arms.len(), 6);
+    assert!(matches!(arms[0].pat, Pat::Lit(PatLit::Null)));
+    assert!(matches!(arms[1].pat, Pat::Lit(PatLit::Bool(true))));
+    assert!(matches!(arms[2].pat, Pat::Lit(PatLit::Str(ref s)) if s == "x"));
+    assert!(matches!(arms[3].pat, Pat::Lit(PatLit::Int(42))));
+    assert!(matches!(arms[4].pat, Pat::Lit(PatLit::Float(_))));
+    assert!(matches!(arms[5].pat, Pat::Wild));
+}
+
+#[test]
+fn parses_object_pattern() {
+    let (_, arms) = parse_match(r#"match $.u with { {role: "admin"} -> 1, _ -> 0 }"#);
+    let Pat::Obj { fields, open } = &arms[0].pat else {
+        panic!("expected Obj pattern");
+    };
+    assert!(!open);
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].0, "role");
+    assert!(matches!(fields[0].1, Pat::Lit(PatLit::Str(ref s)) if s == "admin"));
+}
+
+#[test]
+fn parses_object_open_pattern() {
+    let (_, arms) = parse_match(r#"match $.u with { {role: "admin", ...} -> 1, _ -> 0 }"#);
+    let Pat::Obj { open, .. } = &arms[0].pat else {
+        panic!("expected Obj pattern");
+    };
+    assert!(*open);
+}
+
+#[test]
+fn parses_array_pattern_with_rest() {
+    let (_, arms) = parse_match(r#"match $.xs with { [a, b, ...rest] -> a, _ -> 0 }"#);
+    let Pat::Arr { elems, rest } = &arms[0].pat else {
+        panic!("expected Arr pattern");
+    };
+    assert_eq!(elems.len(), 2);
+    assert!(matches!(rest, Some(Some(ref s)) if s == "rest"));
+}
+
+#[test]
+fn parses_or_pattern() {
+    let (_, arms) = parse_match(r#"match $.m with { "GET" | "HEAD" -> 1, _ -> 0 }"#);
+    let Pat::Or(alts) = &arms[0].pat else {
+        panic!("expected Or pattern");
+    };
+    assert_eq!(alts.len(), 2);
+}
+
+#[test]
+fn parses_kind_bind_pattern() {
+    let (_, arms) = parse_match(r#"match $.v with { s: string -> s, _ -> "no" }"#);
+    let Pat::Kind { name, kind } = &arms[0].pat else {
+        panic!("expected Kind pattern");
+    };
+    assert!(matches!(name, Some(ref n) if n == "s"));
+    assert!(matches!(kind, KindType::Str));
+}
+
+#[test]
+fn parses_guard_arm() {
+    let (_, arms) =
+        parse_match(r#"match $.x with { n when n > 10 -> "big", _ -> "small" }"#);
+    assert!(arms[0].guard.is_some());
+    assert!(arms[1].guard.is_none());
+}
+
+#[test]
+fn parses_bind_only_pattern() {
+    let (_, arms) = parse_match(r#"match $.x with { v -> v }"#);
+    assert!(matches!(arms[0].pat, Pat::Bind(ref n) if n == "v"));
+}
+
+#[test]
+fn runtime_wildcard_returns_body() {
+    let v = run(br#"{"x": 1}"#, r#"match $.x with { _ -> "any" }"#);
+    assert_eq!(v, json!("any"));
+}
+
+#[test]
+fn runtime_literal_dispatch() {
+    let src = br#"{"k": "ok"}"#;
+    assert_eq!(
+        run(src, r#"match $.k with { "ok" -> 1, _ -> 0 }"#),
+        json!(1)
+    );
+    assert_eq!(
+        run(src, r#"match $.k with { "no" -> 1, _ -> 0 }"#),
+        json!(0)
+    );
+}
+
+#[test]
+fn runtime_int_literal_dispatch() {
+    let src = br#"{"n": 42}"#;
+    assert_eq!(
+        run(src, r#"match $.n with { 1 -> "one", 42 -> "answer", _ -> "?" }"#),
+        json!("answer")
+    );
+}
+
+#[test]
+fn runtime_or_pattern() {
+    let src = br#"{"m": "HEAD"}"#;
+    assert_eq!(
+        run(
+            src,
+            r#"match $.m with { "GET" | "HEAD" -> "safe", _ -> "other" }"#
+        ),
+        json!("safe")
+    );
+}
+
+#[test]
+fn runtime_object_pattern_partial_match() {
+    let src = br#"{"u": {"role": "admin", "id": 9}}"#;
+    let v = run(
+        src,
+        r#"match $.u with { {role: "admin"} -> "ok", _ -> "no" }"#,
+    );
+    assert_eq!(v, json!("ok"));
+}
+
+#[test]
+fn runtime_array_rest_binding() {
+    let src = br#"{"xs": [1, 2, 3, 4]}"#;
+    let v = run(
+        src,
+        r#"match $.xs with { [a, b, ...rest] -> rest, _ -> [] }"#,
+    );
+    assert_eq!(v, json!([3, 4]));
+}
+
+#[test]
+fn runtime_kind_bind() {
+    let src = br#"{"v": "hello"}"#;
+    let v = run(
+        src,
+        r#"match $.v with { s: string -> s, _ -> "other" }"#,
+    );
+    assert_eq!(v, json!("hello"));
+}
+
+#[test]
+fn runtime_guard_filters_arm() {
+    let src = br#"{"x": 5}"#;
+    assert_eq!(
+        run(
+            src,
+            r#"match $.x with { n when n > 10 -> "big", n -> "small" }"#
+        ),
+        json!("small")
+    );
+    let src = br#"{"x": 50}"#;
+    assert_eq!(
+        run(
+            src,
+            r#"match $.x with { n when n > 10 -> "big", n -> "small" }"#
+        ),
+        json!("big")
+    );
+}
+
+#[test]
+fn runtime_bind_captures_value() {
+    let src = br#"{"x": 7}"#;
+    assert_eq!(run(src, "match $.x with { v -> v }"), json!(7));
+}
+
+#[test]
+fn runtime_no_arm_match_is_error() {
+    let err = run_err(br#"{"x": 1}"#, r#"match $.x with { 99 -> 0 }"#);
+    assert!(err.contains("match"), "got: {err}");
+    assert!(err.contains("no arm matched") || err.contains("no arm"), "got: {err}");
+}
+
+#[test]
+fn runtime_nested_object_pattern() {
+    let src = br#"{"e": {"type": "click", "target": {"tag": "a"}}}"#;
+    let v = run(
+        src,
+        r#"match $.e with {
+            {type: "click", target: {tag: "a"}} -> "anchor",
+            {type: "click"} -> "click",
+            _ -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("anchor"));
+}

--- a/jetro-core/src/tests/pattern_match.rs
+++ b/jetro-core/src/tests/pattern_match.rs
@@ -1068,6 +1068,39 @@ fn runtime_deep_match_with_range_pattern() {
 }
 
 #[test]
+fn runtime_deep_match_first_returns_first_truthy() {
+    // `..match! { arms }` aborts the descent at the first truthy
+    // arm-body and returns it directly (not wrapped in an array).
+    let src = br#"{
+        "events": [
+            {"tag": "view", "id": "a"},
+            {"tag": "click", "id": "b"},
+            {"tag": "click", "id": "c"}
+        ]
+    }"#;
+    let v = run(
+        src,
+        r#"$..match! {
+            {tag: "click", id: i} -> i,
+            _                     -> false
+        }"#,
+    );
+    assert_eq!(v, json!("b"));
+}
+
+#[test]
+fn runtime_deep_match_first_returns_null_when_nothing_matches() {
+    let v = run(
+        br#"{"a": 1, "b": "x"}"#,
+        r#"$..match! {
+            {role: "admin"} -> "found",
+            _               -> false
+        }"#,
+    );
+    assert_eq!(v, json!(null));
+}
+
+#[test]
 fn runtime_deep_match_no_matches_returns_empty() {
     let v = run(
         br#"{"a": 1, "b": 2}"#,

--- a/jetro-core/src/tests/pattern_match.rs
+++ b/jetro-core/src/tests/pattern_match.rs
@@ -54,10 +54,10 @@ fn parses_literal_arms() {
 #[test]
 fn parses_object_pattern() {
     let (_, arms) = parse_match(r#"match $.u with { {role: "admin"} -> 1, _ -> 0 }"#);
-    let Pat::Obj { fields, open } = &arms[0].pat else {
+    let Pat::Obj { fields, rest } = &arms[0].pat else {
         panic!("expected Obj pattern");
     };
-    assert!(!open);
+    assert!(rest.is_none());
     assert_eq!(fields.len(), 1);
     assert_eq!(fields[0].0, "role");
     assert!(matches!(fields[0].1, Pat::Lit(PatLit::Str(ref s)) if s == "admin"));
@@ -65,11 +65,12 @@ fn parses_object_pattern() {
 
 #[test]
 fn parses_object_open_pattern() {
-    let (_, arms) = parse_match(r#"match $.u with { {role: "admin", ...} -> 1, _ -> 0 }"#);
-    let Pat::Obj { open, .. } = &arms[0].pat else {
+    let (_, arms) =
+        parse_match(r#"match $.u with { {role: "admin", ...*} -> 1, _ -> 0 }"#);
+    let Pat::Obj { rest, .. } = &arms[0].pat else {
         panic!("expected Obj pattern");
     };
-    assert!(*open);
+    assert!(matches!(rest, Some(None)));
 }
 
 #[test]
@@ -1206,6 +1207,60 @@ fn match_runtimes_agree_on_canonical_corpus() {
             (a, b) => panic!("domains disagreed (one errored) on `{src}`: {a:?} vs {b:?}"),
         }
     }
+}
+
+#[test]
+fn parses_object_pattern_with_named_rest() {
+    let (_, arms) = parse_match(
+        r#"match $.u with { {a: x, c: y, ...*rest} -> rest, _ -> {} }"#,
+    );
+    let Pat::Obj { fields, rest } = &arms[0].pat else {
+        panic!("expected Obj pattern");
+    };
+    assert_eq!(fields.len(), 2);
+    assert!(matches!(rest, Some(Some(ref s)) if s == "rest"));
+}
+
+#[test]
+fn runtime_object_rest_captures_unlisted_keys() {
+    // Named `...*rest` builds a `Val::Obj` of every key not listed in
+    // the pattern's explicit fields, in source order.
+    let v = run(
+        br#"{"u": {"a": "alpha", "b": "beta", "c": "gamma", "d": "delta"}}"#,
+        r#"match $.u with {
+            {a: x, c: y, ...*rest} -> rest,
+            _                      -> {}
+        }"#,
+    );
+    assert_eq!(v, json!({"b": "beta", "d": "delta"}));
+}
+
+#[test]
+fn runtime_object_rest_then_splat_produces_merged_object() {
+    // The rest-capture binding can be splatted back into a fresh
+    // object literal via `...*rest`, mirroring the spread sigil. The
+    // shallow-spread synonym treats `...*` and `...` identically.
+    let v = run(
+        br#"{"u": {"a": "old", "c": "x", "extra": 1}}"#,
+        r#"match $.u with {
+            {a: a_old, c: c_old, ...*rest} -> {...*rest, a: "new value", c: c_old},
+            _                              -> @
+        }"#,
+    );
+    assert_eq!(v, json!({"extra": 1, "a": "new value", "c": "x"}));
+}
+
+#[test]
+fn runtime_object_anonymous_rest_does_not_bind() {
+    // Anonymous `...*` is informational; no binding is introduced.
+    let v = run(
+        br#"{"u": {"a": 1, "b": 2}}"#,
+        r#"match $.u with {
+            {a: x, ...*} -> x,
+            _            -> -1
+        }"#,
+    );
+    assert_eq!(v, json!(1));
 }
 
 #[test]

--- a/jetro-core/src/tests/pattern_match.rs
+++ b/jetro-core/src/tests/pattern_match.rs
@@ -1113,6 +1113,102 @@ fn runtime_deep_match_no_matches_returns_empty() {
 }
 
 #[test]
+fn match_runtimes_agree_on_canonical_corpus() {
+    // Cross-check the `Val`-domain and view-domain runtimes against a
+    // shared corpus of inputs. The two paths are structurally distinct
+    // (one materialises sub-`Val`s eagerly, the other walks borrowed
+    // views) so any divergence on these inputs would point to a
+    // semantic regression.
+    use crate::compile::compiler::Compiler;
+    use crate::data::context::Env;
+    use crate::data::value::Val as DVal;
+    use crate::data::view::ValView;
+    use crate::parse::parser::parse;
+    use crate::vm::{Opcode, VM};
+
+    let cases = [
+        // (match expression, scrutinee JSON)
+        (
+            r#"match @ with {
+                {role: "admin"} -> "a",
+                {role: "user"}  -> "u",
+                _               -> "x"
+            }"#,
+            json!({"role": "admin", "id": 1}),
+        ),
+        (
+            r#"match @ with {
+                {role: "admin"} -> "a",
+                {role: "user"}  -> "u",
+                _               -> "x"
+            }"#,
+            json!({"name": "alice"}),
+        ),
+        (
+            r#"match @ with {
+                [a, b]    -> {ok: a},
+                [a, b, c] -> {ok: c},
+                _         -> {none: true}
+            }"#,
+            json!([1, 2, 3]),
+        ),
+        (
+            r#"match @ with {
+                n: number when n > 100 -> "big",
+                _                       -> "small"
+            }"#,
+            json!(250),
+        ),
+        (
+            r#"match @ with {
+                "GET" | "HEAD" -> "safe",
+                _              -> "other"
+            }"#,
+            json!("HEAD"),
+        ),
+        (
+            r#"match @ with {
+                1..=10  -> "lo",
+                11..=99 -> "mid",
+                _       -> "hi"
+            }"#,
+            json!(7),
+        ),
+    ];
+
+    for (src, scrutinee_json) in cases {
+        let expr = parse(src).unwrap_or_else(|e| panic!("parse {src}: {e}"));
+        let prog = Compiler::compile(&expr, src);
+        let cm = prog
+            .ops
+            .iter()
+            .find_map(|op| match op {
+                Opcode::Match(cm) => Some(cm.clone()),
+                _ => None,
+            })
+            .expect("compiled match opcode");
+
+        let scrutinee_val = DVal::from(&scrutinee_json);
+        let mut vm = VM::new();
+        let env = Env::new(scrutinee_val.clone());
+
+        let val_result = vm.exec_match(&cm, &scrutinee_val, &env);
+        let view_result =
+            crate::vm::exec::exec_match_view(&mut vm, &cm, ValView::new(&scrutinee_val), &env);
+
+        match (val_result, view_result) {
+            (Ok(a), Ok(b)) => {
+                let aj: serde_json::Value = a.into();
+                let bj: serde_json::Value = b.into();
+                assert_eq!(aj, bj, "domains diverged on `{src}`");
+            }
+            (Err(_), Err(_)) => {}
+            (a, b) => panic!("domains disagreed (one errored) on `{src}`: {a:?} vs {b:?}"),
+        }
+    }
+}
+
+#[test]
 fn runtime_match_chained_with_postfix() {
     // Result of a match flows into a subsequent method call.
     let src = br#"{"xs": [1, 2, 3]}"#;

--- a/jetro-core/src/tests/pattern_match.rs
+++ b/jetro-core/src/tests/pattern_match.rs
@@ -715,6 +715,253 @@ fn parse_accepts_literal_only_or_pattern() {
 }
 
 #[test]
+fn runtime_filter_match_take_demand_cuts_through() {
+    // Pipeline: `.filter(match @ ...) | take(3)` should emit only the
+    // first three matches without exhausting the source. The chain IR
+    // recognises `Stage::Filter` whose body is a single `Opcode::Match`
+    // as `ChainOp::Match { Predicate }` so demand widens to
+    // `UntilOutput(3)` instead of bounded `FirstInput`.
+    let src = br#"{"xs": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}"#;
+    let v = run(
+        src,
+        r#"$.xs.filter(match @ with {
+            n when n > 2 -> true,
+            _            -> false
+        }).take(3)"#,
+    );
+    assert_eq!(v, json!([3, 4, 5]));
+}
+
+#[test]
+fn runtime_map_match_passthrough() {
+    // Pipeline: `.map(match @ ...)` is 1:1 — every input row produces
+    // exactly one output. Used as a tagged-decoder over an array.
+    let src = br#"{"events": [
+        {"tag": "view", "p": "/home"},
+        {"tag": "click", "id": "btn"},
+        {"tag": "error", "code": 500}
+    ]}"#;
+    let v = run(
+        src,
+        r#"$.events.map(match @ with {
+            {tag: "view",  p: x}    -> {sort: "view",  v: x},
+            {tag: "click", id: x}   -> {sort: "click", v: x},
+            {tag: "error", code: x} -> {sort: "error", v: x},
+            _                       -> {sort: "other"}
+        })"#,
+    );
+    assert_eq!(
+        v,
+        json!([
+            {"sort": "view",  "v": "/home"},
+            {"sort": "click", "v": "btn"},
+            {"sort": "error", "v": 500}
+        ])
+    );
+}
+
+#[test]
+fn runtime_range_pattern_inclusive() {
+    // `1..=10` matches integers 1 through 10 inclusive.
+    let cases = [
+        (1, "low"),
+        (5, "low"),
+        (10, "low"),
+        (11, "high"),
+        (0, "high"),
+    ];
+    for (n, expected) in cases {
+        let v = run(
+            format!(r#"{{"x": {n}}}"#).as_bytes(),
+            r#"match $.x with {
+                1..=10 -> "low",
+                _      -> "high"
+            }"#,
+        );
+        assert_eq!(v, json!(expected), "n={n}");
+    }
+}
+
+#[test]
+fn runtime_range_pattern_exclusive() {
+    // `1..10` matches integers 1 through 9; 10 falls into the catch-all.
+    let cases = [(1, "lo"), (9, "lo"), (10, "hi")];
+    for (n, expected) in cases {
+        let v = run(
+            format!(r#"{{"x": {n}}}"#).as_bytes(),
+            r#"match $.x with {
+                1..10 -> "lo",
+                _     -> "hi"
+            }"#,
+        );
+        assert_eq!(v, json!(expected), "n={n}");
+    }
+}
+
+#[test]
+fn runtime_range_pattern_float() {
+    // Floats accepted as bounds and as scrutinees.
+    let v = run(
+        br#"{"x": 0.5}"#,
+        r#"match $.x with {
+            0.0..=1.0 -> "unit",
+            _         -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("unit"));
+}
+
+#[test]
+fn runtime_range_pattern_int_widens_to_float() {
+    // Integer scrutinee widens to f64 for range comparison.
+    let v = run(
+        br#"{"x": 3}"#,
+        r#"match $.x with {
+            0.0..5.0 -> "in",
+            _        -> "out"
+        }"#,
+    );
+    assert_eq!(v, json!("in"));
+}
+
+#[test]
+fn runtime_range_pattern_inside_or() {
+    // Range patterns compose with or-patterns via the tree-walker path.
+    let v = run(
+        br#"{"x": 7}"#,
+        r#"match $.x with {
+            1..=3 | 5..=10 -> "ok",
+            _              -> "no"
+        }"#,
+    );
+    assert_eq!(v, json!("ok"));
+}
+
+#[test]
+fn runtime_range_pattern_non_numeric_skipped() {
+    // String scrutinee falls through to catch-all because RangeCheck
+    // requires a numeric value.
+    let v = run(
+        br#"{"x": "hello"}"#,
+        r#"match $.x with {
+            1..=10 -> "num",
+            _      -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("other"));
+}
+
+#[test]
+fn runtime_range_pattern_inside_object() {
+    // Range patterns work inside object sub-pattern positions.
+    let v = run(
+        br#"{"u": {"age": 65}}"#,
+        r#"match $.u with {
+            {age: 0..=17}    -> "minor",
+            {age: 18..=64}   -> "adult",
+            {age: 65..=120}  -> "senior",
+            _                -> "unknown"
+        }"#,
+    );
+    assert_eq!(v, json!("senior"));
+}
+
+#[test]
+fn runtime_shared_kind_dispatch() {
+    // Every typed arm is a `Pat::Kind` testing the same scalar kind, so
+    // the compiler hoists the `KindCheck` into a single prelude. Each
+    // arm just pushes its binding then runs the guard / body.
+    let v = run(
+        br#"{"x": "hello"}"#,
+        r#"match $.x with {
+            s: string when s.len() > 3 -> "long",
+            s: string                  -> "short",
+            _                          -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("long"));
+    let v = run(
+        br#"{"x": "hi"}"#,
+        r#"match $.x with {
+            s: string when s.len() > 3 -> "long",
+            s: string                  -> "short",
+            _                          -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("short"));
+    let v = run(
+        br#"{"x": 42}"#,
+        r#"match $.x with {
+            s: string when s.len() > 3 -> "long",
+            s: string                  -> "short",
+            _                          -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("other"));
+}
+
+#[test]
+fn runtime_range_pattern_negative_bounds() {
+    let cases = [(-5, "neg"), (-1, "neg"), (0, "zero"), (10, "pos")];
+    for (n, expected) in cases {
+        let v = run(
+            format!(r#"{{"x": {n}}}"#).as_bytes(),
+            r#"match $.x with {
+                -10..0 -> "neg",
+                0      -> "zero",
+                _      -> "pos"
+            }"#,
+        );
+        assert_eq!(v, json!(expected), "n={n}");
+    }
+}
+
+#[test]
+fn view_domain_runtime_runs_against_borrowed_view() {
+    // Compile a match expression, then dispatch the view-domain runtime
+    // (`exec_match_view`) directly against a `ValView` borrow of the
+    // scrutinee. This exercises the pattern test path that runs against
+    // borrowed scalars / sub-projections without materialising the
+    // missed-arm subtree.
+    use crate::compile::compiler::Compiler;
+    use crate::data::context::Env;
+    use crate::data::value::Val as DVal;
+    use crate::data::view::ValView;
+    use crate::parse::parser::parse;
+    use crate::vm::{Opcode, VM};
+
+    // Build the AST and locate the embedded `Match` opcode by compiling
+    // the expression and inspecting its op stream.
+    let expr = parse(r#"match @ with {
+        {role: "admin", id: i} -> {sort: "admin", n: i},
+        {role: "user", id: i}  -> {sort: "user", n: i},
+        {role: r}              -> {sort: r, n: 0}
+    }"#)
+    .expect("parse");
+    let prog = Compiler::compile(&expr, "match-view-test");
+    let cm = prog
+        .ops
+        .iter()
+        .find_map(|op| match op {
+            Opcode::Match(cm) => Some(cm.clone()),
+            _ => None,
+        })
+        .expect("compiled match opcode");
+
+    // Drive `exec_match_view` directly against a borrowed view of the
+    // input object. The runtime should pick the first arm and produce
+    // the corresponding output object.
+    let scrutinee_val: DVal = DVal::from(&json!({"role": "admin", "id": 9}));
+    let view = ValView::new(&scrutinee_val);
+    let mut vm = VM::new();
+    let env = Env::new(scrutinee_val.clone());
+    let result = crate::vm::exec::exec_match_view(&mut vm, &cm, view, &env)
+        .expect("view-domain match should succeed");
+    let as_json: serde_json::Value = result.into();
+    assert_eq!(as_json, json!({"sort": "admin", "n": 9}));
+}
+
+#[test]
 fn runtime_match_chained_with_postfix() {
     // Result of a match flows into a subsequent method call.
     let src = br#"{"xs": [1, 2, 3]}"#;

--- a/jetro-core/src/tests/pattern_match.rs
+++ b/jetro-core/src/tests/pattern_match.rs
@@ -219,6 +219,119 @@ fn runtime_no_arm_match_is_error() {
 }
 
 #[test]
+fn runtime_first_arm_wins() {
+    // Earlier arms shadow later ones even when both would match.
+    let v = run(
+        br#"{"x": 1}"#,
+        r#"match $.x with { _ -> "first", _ -> "second" }"#,
+    );
+    assert_eq!(v, json!("first"));
+}
+
+#[test]
+fn runtime_object_pattern_shadowing_keys() {
+    // Arms that share a prefix key still run independently; first match wins.
+    let src = br#"{"u": {"role": "user", "id": 9}}"#;
+    let v = run(
+        src,
+        r#"match $.u with {
+            {role: "admin"} -> "admin",
+            {role: "user"}  -> "user",
+            _               -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("user"));
+}
+
+#[test]
+fn runtime_array_exact_length() {
+    // No rest pattern means length must match exactly.
+    let v = run(
+        br#"{"xs": [1, 2]}"#,
+        r#"match $.xs with { [a, b] -> a, _ -> 0 }"#,
+    );
+    assert_eq!(v, json!(1));
+    let v = run(
+        br#"{"xs": [1, 2, 3]}"#,
+        r#"match $.xs with { [a, b] -> a, _ -> 99 }"#,
+    );
+    assert_eq!(v, json!(99));
+}
+
+#[test]
+fn runtime_or_pattern_inside_object() {
+    let src = br#"{"r": {"method": "POST"}}"#;
+    let v = run(
+        src,
+        r#"match $.r with {
+            {method: "GET" | "HEAD"}        -> "safe",
+            {method: "POST" | "PUT"}        -> "write",
+            _                               -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("write"));
+}
+
+#[test]
+fn runtime_kind_only_pattern() {
+    let v = run(
+        br#"{"v": 42}"#,
+        r#"match $.v with { number -> "num", _ -> "other" }"#,
+    );
+    assert_eq!(v, json!("num"));
+    let v = run(
+        br#"{"v": "x"}"#,
+        r#"match $.v with { number -> "num", _ -> "other" }"#,
+    );
+    assert_eq!(v, json!("other"));
+}
+
+#[test]
+fn runtime_wildcard_inside_array() {
+    let v = run(
+        br#"{"xs": [1, 2, 3]}"#,
+        r#"match $.xs with { [_, mid, _] -> mid, _ -> 0 }"#,
+    );
+    assert_eq!(v, json!(2));
+}
+
+#[test]
+fn runtime_int_to_float_literal_coerces() {
+    // Integer pattern literal should match a Val::Float with the same value.
+    let v = run(
+        br#"{"n": 1.0}"#,
+        r#"match $.n with { 1 -> "one", _ -> "other" }"#,
+    );
+    assert_eq!(v, json!("one"));
+}
+
+#[test]
+fn runtime_guard_sees_arm_bindings() {
+    // Guard expressions can reference bindings introduced by the pattern.
+    let v = run(
+        br#"{"u": {"name": "alice", "age": 31}}"#,
+        r#"match $.u with {
+            {name: n, age: a} when a >= 18 -> n,
+            _                              -> "minor"
+        }"#,
+    );
+    assert_eq!(v, json!("alice"));
+}
+
+#[test]
+fn runtime_bindings_reset_between_arms() {
+    // A failed arm must not leak its bindings into later arm bodies.
+    let v = run(
+        br#"{"x": 5}"#,
+        r#"match $.x with {
+            n when n > 100 -> n,
+            v              -> v
+        }"#,
+    );
+    assert_eq!(v, json!(5));
+}
+
+#[test]
 fn runtime_nested_object_pattern() {
     let src = br#"{"e": {"type": "click", "target": {"tag": "a"}}}"#;
     let v = run(
@@ -230,4 +343,228 @@ fn runtime_nested_object_pattern() {
         }"#,
     );
     assert_eq!(v, json!("anchor"));
+}
+
+#[test]
+fn runtime_match_inside_map() {
+    // Match used as the body of a `.map` lambda over an array.
+    // Field `kind` is a reserved keyword in the jetro grammar, so the
+    // events here use `tag` instead.
+    let src = br#"{"events": [
+        {"tag": "view", "path": "/home"},
+        {"tag": "click", "id": "btn"},
+        {"tag": "error", "code": 500}
+    ]}"#;
+    let v = run(
+        src,
+        r#"$.events.map(match @ with {
+            {tag: "view", path: p}  -> p,
+            {tag: "click", id: i}   -> i,
+            {tag: "error", code: c} -> c,
+            _                       -> null
+        })"#,
+    );
+    assert_eq!(v, json!(["/home", "btn", 500]));
+}
+
+#[test]
+fn runtime_match_inside_filter_predicate() {
+    // Match used as a boolean predicate inside `.filter`.
+    let src = br#"{"reqs": [
+        {"method": "GET"},
+        {"method": "POST"},
+        {"method": "DELETE"}
+    ]}"#;
+    let v = run(
+        src,
+        r#"$.reqs.filter(match @ with {
+            {method: "GET" | "HEAD"} -> true,
+            _                        -> false
+        })"#,
+    );
+    assert_eq!(v, json!([{"method": "GET"}]));
+}
+
+#[test]
+fn runtime_match_inside_pipeline() {
+    // Match used as the right-hand side of a `|` pipeline step.
+    let v = run(
+        br#"{"x": 7}"#,
+        r#"$.x | (match @ with { n when n > 5 -> "big", _ -> "small" })"#,
+    );
+    assert_eq!(v, json!("big"));
+}
+
+#[test]
+fn runtime_match_returns_object() {
+    let src = br#"{"u": {"name": "alice", "role": "admin"}}"#;
+    let v = run(
+        src,
+        r#"match $.u with {
+            {role: "admin", name: n} -> {tag: "admin", name: n},
+            _                        -> {tag: "other"}
+        }"#,
+    );
+    assert_eq!(v, json!({"tag": "admin", "name": "alice"}));
+}
+
+#[test]
+fn runtime_shared_first_key_dispatch() {
+    // Tagged-union dispatch: every arm tests the same first object key.
+    // The compiler hoists the `ObjCheck + LoadField` for that key out of
+    // every per-arm prologue; correctness here exercises the shared path.
+    let cases = [
+        (br#"{"u": {"role": "admin", "id": 1}}"# as &[u8], json!({"k": "admin", "n": 1})),
+        (br#"{"u": {"role": "user",  "id": 2}}"#, json!({"k": "user", "n": 2})),
+        (br#"{"u": {"role": "guest", "id": 3}}"#, json!({"k": "guest", "n": 0})),
+    ];
+    for (src, expected) in cases {
+        let v = run(
+            src,
+            r#"match $.u with {
+                {role: "admin", id: i} -> {k: "admin", n: i},
+                {role: "user", id: i}  -> {k: "user",  n: i},
+                {role: r}              -> {k: r, n: 0}
+            }"#,
+        );
+        assert_eq!(v, expected, "src={}", std::str::from_utf8(src).unwrap());
+    }
+}
+
+#[test]
+fn runtime_shared_key_preserves_arm_bindings() {
+    // The key value loaded by the shared prelude (slot 1) must remain
+    // addressable inside per-arm bodies via the K-field sub-pattern.
+    let v = run(
+        br#"{"u": {"role": "admin", "level": 9}}"#,
+        r#"match $.u with {
+            {role: r, level: l} when l > 5 -> r,
+            {role: r}                      -> r
+        }"#,
+    );
+    assert_eq!(v, json!("admin"));
+}
+
+#[test]
+fn runtime_shared_key_no_arm_match_falls_through_to_fail() {
+    // No arm tests "missing" so a value with that role hits the trailing
+    // `Fail` op via the per-arm miss path (not the prelude's else_pc).
+    let err = run_err(
+        br#"{"u": {"role": "missing"}}"#,
+        r#"match $.u with {
+            {role: "admin"} -> 1,
+            {role: "user"}  -> 2
+        }"#,
+    );
+    assert!(err.contains("no arm matched"), "{err}");
+}
+
+#[test]
+fn runtime_shared_key_prelude_failure_when_not_object() {
+    // Scrutinee is not an object, so the shared prelude's `ObjCheck`
+    // jumps directly to `Fail` without entering any arm.
+    let err = run_err(
+        br#"{"u": 42}"#,
+        r#"match $.u with {
+            {role: "admin"} -> 1,
+            {role: "user"}  -> 2
+        }"#,
+    );
+    assert!(err.contains("no arm matched"), "{err}");
+}
+
+#[test]
+fn runtime_shared_key_prelude_failure_when_key_missing() {
+    // Scrutinee is an object but the shared key is absent — prelude's
+    // `LoadField` jumps to `Fail`.
+    let err = run_err(
+        br#"{"u": {"name": "alice"}}"#,
+        r#"match $.u with {
+            {role: "admin"} -> 1,
+            {role: "user"}  -> 2
+        }"#,
+    );
+    assert!(err.contains("no arm matched"), "{err}");
+}
+
+#[test]
+fn parse_rejects_or_pattern_with_inconsistent_bindings() {
+    let err = parse(r#"match $.x with { {a: x} | {b: y} -> x }"#)
+        .err()
+        .expect("expected linearity error");
+    let s = err.to_string();
+    assert!(s.contains("or-pattern arms must bind"), "got: {s}");
+}
+
+#[test]
+fn parse_accepts_or_pattern_with_matching_bindings() {
+    // Both alts bind `n`; linearity holds.
+    let v = run(
+        br#"{"e": {"warn": 5}}"#,
+        r#"match $.e with {
+            {warn: n} | {error: n} -> n,
+            _                      -> 0
+        }"#,
+    );
+    assert_eq!(v, json!(5));
+}
+
+#[test]
+fn runtime_or_of_literals_cascade_three_alts() {
+    // Three-way or-pattern over literals exercises the flat cascade path
+    // (LitEq + Jump + LitEq + Jump + LitEq) emitted by the compiler when
+    // every alt is a `Pat::Lit`.
+    let cases = [
+        ("a", json!("first")),
+        ("b", json!("first")),
+        ("c", json!("first")),
+        ("d", json!("other")),
+    ];
+    for (k, expected) in cases {
+        let v = run(
+            format!(r#"{{"k": "{k}"}}"#).as_bytes(),
+            r#"match $.k with {
+                "a" | "b" | "c" -> "first",
+                _               -> "other"
+            }"#,
+        );
+        assert_eq!(v, expected, "k={k}");
+    }
+}
+
+#[test]
+fn runtime_or_of_literals_with_int_alts() {
+    let v = run(
+        br#"{"n": 2}"#,
+        r#"match $.n with {
+            1 | 2 | 3 -> "small",
+            _         -> "big"
+        }"#,
+    );
+    assert_eq!(v, json!("small"));
+}
+
+#[test]
+fn parse_accepts_literal_only_or_pattern() {
+    // Linearity is trivial when no alt binds anything.
+    let v = run(
+        br#"{"m": "PUT"}"#,
+        r#"match $.m with {
+            "GET" | "HEAD"   -> "safe",
+            "POST" | "PUT"   -> "write",
+            _                -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("write"));
+}
+
+#[test]
+fn runtime_match_chained_with_postfix() {
+    // Result of a match flows into a subsequent method call.
+    let src = br#"{"xs": [1, 2, 3]}"#;
+    let v = run(
+        src,
+        r#"(match $.xs with { [_, ...rest] -> rest, _ -> [] }).len()"#,
+    );
+    assert_eq!(v, json!(2));
 }

--- a/jetro-core/src/tests/pattern_match.rs
+++ b/jetro-core/src/tests/pattern_match.rs
@@ -446,6 +446,162 @@ fn runtime_shared_key_preserves_arm_bindings() {
 }
 
 #[test]
+fn runtime_shared_two_key_prefix_dispatch() {
+    // Every arm tests the same two leading keys (`tag` then `target`) in
+    // the same order. The compiler hoists `ObjCheck` + two `LoadField`
+    // ops out of the per-arm prologue.
+    let v = run(
+        br#"{"e": {"tag": "click", "target": "btn-a"}}"#,
+        r#"match $.e with {
+            {tag: "click", target: t} -> {sort: "click", t: t},
+            {tag: "view",  target: t} -> {sort: "view",  t: t},
+            _                         -> {sort: "other"}
+        }"#,
+    );
+    assert_eq!(v, json!({"sort": "click", "t": "btn-a"}));
+    let v = run(
+        br#"{"e": {"tag": "view", "target": "/home"}}"#,
+        r#"match $.e with {
+            {tag: "click", target: t} -> {sort: "click", t: t},
+            {tag: "view",  target: t} -> {sort: "view",  t: t},
+            _                         -> {sort: "other"}
+        }"#,
+    );
+    assert_eq!(v, json!({"sort": "view", "t": "/home"}));
+}
+
+#[test]
+fn runtime_shared_arr_len_dispatch() {
+    // Every arm is a fixed-length array pattern of the same length, so
+    // the compiler hoists the `LenCheck` into a single match-level
+    // prelude and emits only `LoadIndex` ops per arm.
+    let v = run(
+        br#"{"p": [1, 2]}"#,
+        r#"match $.p with {
+            [0, x] -> {tag: "zero", x: x},
+            [1, x] -> {tag: "one",  x: x},
+            [_, x] -> {tag: "any",  x: x}
+        }"#,
+    );
+    assert_eq!(v, json!({"tag": "one", "x": 2}));
+}
+
+#[test]
+fn runtime_shared_arr_len_disabled_when_lengths_differ() {
+    // Arm 0 has length 2, arm 1 has length 3 — sharing is disabled and
+    // each arm runs its own `LenCheck`.
+    let v = run(
+        br#"{"p": [1, 2, 3]}"#,
+        r#"match $.p with {
+            [a, b]    -> {tag: "two", a: a},
+            [a, b, c] -> {tag: "three", c: c},
+            _         -> {tag: "other"}
+        }"#,
+    );
+    assert_eq!(v, json!({"tag": "three", "c": 3}));
+}
+
+#[test]
+fn runtime_shared_prefix_with_trailing_catchall_routes_prelude_failure() {
+    // Mixing typed `Pat::Obj` arms with a trailing wildcard catch-all
+    // still enables shared-prefix sharing; prelude failures route to
+    // the catch-all arm rather than the global `Fail` op.
+    // Scrutinee is not an object — `ObjCheck` in the prelude fails and
+    // jumps to the catch-all body.
+    let v = run(
+        br#"{"u": 42}"#,
+        r#"match $.u with {
+            {role: "admin"} -> "admin",
+            {role: "user"}  -> "user",
+            _               -> "fallback"
+        }"#,
+    );
+    assert_eq!(v, json!("fallback"));
+
+    // Object missing the shared key — prelude `LoadField` fails and
+    // routes to the catch-all arm.
+    let v = run(
+        br#"{"u": {"name": "alice"}}"#,
+        r#"match $.u with {
+            {role: "admin"} -> "admin",
+            {role: "user"}  -> "user",
+            _               -> "fallback"
+        }"#,
+    );
+    assert_eq!(v, json!("fallback"));
+
+    // Object with shared key but no typed arm matches — last typed arm's
+    // miss routes to the catch-all (via the standard pending-else patch).
+    let v = run(
+        br#"{"u": {"role": "guest"}}"#,
+        r#"match $.u with {
+            {role: "admin"} -> "admin",
+            {role: "user"}  -> "user",
+            _               -> "fallback"
+        }"#,
+    );
+    assert_eq!(v, json!("fallback"));
+}
+
+#[test]
+fn runtime_arr_length_share_with_trailing_catchall() {
+    // Same idea for the array-length sharing path: a trailing wildcard
+    // catch-all participates without disabling the shared `LenCheck`.
+    let v = run(
+        br#"{"p": [1, 2, 3]}"#,
+        r#"match $.p with {
+            [a, b]    -> {tag: "two", a: a},
+            [a, b, _] -> {tag: "three", a: a},
+            _         -> {tag: "other"}
+        }"#,
+    );
+    // First two arms have lengths 2 and 3 — sharing disabled. Catch-all
+    // present but not used. Test exercises the no-sharing-with-catchall
+    // path for completeness.
+    assert_eq!(v, json!({"tag": "three", "a": 1}));
+
+    // All typed arms agree on length 3, plus a trailing catch-all.
+    let v = run(
+        br#"{"p": [1, 2]}"#,
+        r#"match $.p with {
+            [a, _, _] -> {tag: "first",  a: a},
+            [_, b, _] -> {tag: "second", b: b},
+            _         -> {tag: "other"}
+        }"#,
+    );
+    // Scrutinee has length 2, prelude `LenCheck { len: 3, exact: true }`
+    // fails and routes to the catch-all.
+    assert_eq!(v, json!({"tag": "other"}));
+}
+
+#[test]
+fn runtime_non_exhaustive_error_includes_value_snippet() {
+    // The trailing `Fail` op renders a short snippet of the scrutinee
+    // alongside its kind so users can spot the offending value.
+    let err = run_err(
+        br#"{"x": 7}"#,
+        r#"match $.x with { 1 -> "a", 2 -> "b" }"#,
+    );
+    assert!(err.contains("no arm matched"), "{err}");
+    assert!(err.contains("7"), "expected scrutinee value in error: {err}");
+}
+
+#[test]
+fn runtime_shared_prefix_disabled_on_key_order_divergence() {
+    // The two arms list the same keys but in different orders. The
+    // shared-prefix optimization is disabled (common prefix length 0)
+    // and per-arm codegen handles every key independently.
+    let v = run(
+        br#"{"u": {"role": "admin", "id": 9}}"#,
+        r#"match $.u with {
+            {role: r, id: i} -> {r: r, i: i},
+            {id: i, role: r} -> {r: r, i: i}
+        }"#,
+    );
+    assert_eq!(v, json!({"r": "admin", "i": 9}));
+}
+
+#[test]
 fn runtime_shared_key_no_arm_match_falls_through_to_fail() {
     // No arm tests "missing" so a value with that role hits the trailing
     // `Fail` op via the per-arm miss path (not the prelude's else_pc).

--- a/jetro-core/src/tests/pattern_match.rs
+++ b/jetro-core/src/tests/pattern_match.rs
@@ -962,6 +962,68 @@ fn view_domain_runtime_runs_against_borrowed_view() {
 }
 
 #[test]
+fn runtime_partial_shared_prefix_with_mixed_suffix() {
+    // The first two arms share a leading object key (`role`); the
+    // remaining arms have unrelated shapes (length-2 array, raw int,
+    // catch-all). Cross-arm sharing now hoists the `ObjCheck +
+    // LoadField` for the leading run while later arms run their own
+    // standard codegen.
+    //
+    // Object scrutinee — admin: shared run hits arm 0.
+    let v = run(
+        br#"{"x": {"role": "admin", "id": 1}}"#,
+        r#"match $.x with {
+            {role: "admin"} -> "admin",
+            {role: "user"}  -> "user",
+            [a, b]          -> "pair",
+            42              -> "answer",
+            _               -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("admin"));
+
+    // Array scrutinee — prelude `LoadField` would fail; jumps to arm 2
+    // (first non-shared arm) which matches.
+    let v = run(
+        br#"{"x": [1, 2]}"#,
+        r#"match $.x with {
+            {role: "admin"} -> "admin",
+            {role: "user"}  -> "user",
+            [a, b]          -> "pair",
+            42              -> "answer",
+            _               -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("pair"));
+
+    // Integer scrutinee — falls through past arrays to arm 3.
+    let v = run(
+        br#"{"x": 42}"#,
+        r#"match $.x with {
+            {role: "admin"} -> "admin",
+            {role: "user"}  -> "user",
+            [a, b]          -> "pair",
+            42              -> "answer",
+            _               -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("answer"));
+
+    // String scrutinee — falls through to wildcard catch-all.
+    let v = run(
+        br#"{"x": "hello"}"#,
+        r#"match $.x with {
+            {role: "admin"} -> "admin",
+            {role: "user"}  -> "user",
+            [a, b]          -> "pair",
+            42              -> "answer",
+            _               -> "other"
+        }"#,
+    );
+    assert_eq!(v, json!("other"));
+}
+
+#[test]
 fn runtime_match_chained_with_postfix() {
     // Result of a match flows into a subsequent method call.
     let src = br#"{"xs": [1, 2, 3]}"#;

--- a/jetro-core/src/tests/pattern_match.rs
+++ b/jetro-core/src/tests/pattern_match.rs
@@ -1264,6 +1264,42 @@ fn runtime_object_anonymous_rest_does_not_bind() {
 }
 
 #[test]
+fn runtime_array_head_tail_pattern() {
+    // The standard `[head, ...tail]` shape extracts the first element
+    // and binds the remainder as a fresh `Val::Arr`. Empty arrays and
+    // non-arrays fall through to subsequent arms.
+    let v = run(
+        br#"{"xs": [10, 20, 30, 40]}"#,
+        r#"match $.xs with {
+            [head, ...tail] -> {h: head, t: tail},
+            []              -> {empty: true},
+            _               -> @
+        }"#,
+    );
+    assert_eq!(v, json!({"h": 10, "t": [20, 30, 40]}));
+
+    let v = run(
+        br#"{"xs": []}"#,
+        r#"match $.xs with {
+            [head, ...tail] -> {h: head, t: tail},
+            []              -> {empty: true},
+            _               -> @
+        }"#,
+    );
+    assert_eq!(v, json!({"empty": true}));
+
+    let v = run(
+        br#"{"xs": [42]}"#,
+        r#"match $.xs with {
+            [head, ...tail] -> {h: head, t: tail},
+            []              -> {empty: true},
+            _               -> @
+        }"#,
+    );
+    assert_eq!(v, json!({"h": 42, "t": []}));
+}
+
+#[test]
 fn runtime_match_chained_with_postfix() {
     // Result of a match flows into a subsequent method call.
     let src = br#"{"xs": [1, 2, 3]}"#;

--- a/jetro-core/src/tests/pattern_match.rs
+++ b/jetro-core/src/tests/pattern_match.rs
@@ -1024,6 +1024,62 @@ fn runtime_partial_shared_prefix_with_mixed_suffix() {
 }
 
 #[test]
+fn runtime_deep_match_collects_truthy_arm_bodies() {
+    // `..match { arms }` walks every descendant in DFS order and
+    // collects the truthy arm-body results. The catch-all arm here
+    // returns `false`, so descendants that hit it are dropped from
+    // the output.
+    let src = br#"{
+        "page": "/home",
+        "events": [
+            {"tag": "click", "id": "btn-a"},
+            {"tag": "view", "url": "/about"},
+            {"nested": {"tag": "click", "id": "btn-b"}}
+        ],
+        "meta": {"title": "site"}
+    }"#;
+    let v = run(
+        src,
+        r#"$..match {
+            {tag: "click", id: i} -> i,
+            _                     -> false
+        }"#,
+    );
+    // Two click events match — IDs in DFS order.
+    assert_eq!(v, json!(["btn-a", "btn-b"]));
+}
+
+#[test]
+fn runtime_deep_match_with_range_pattern() {
+    // Range pattern over numeric descendants: collect every number in
+    // 100..=999 anywhere in the tree.
+    let src = br#"{
+        "stats": {"a": 50, "b": 250, "c": 1500},
+        "more":  [42, 200, 800, 9999]
+    }"#;
+    let v = run(
+        src,
+        r#"$..match {
+            n: number when n >= 100 and n < 1000 -> n,
+            _                                     -> false
+        }"#,
+    );
+    assert_eq!(v, json!([250, 200, 800]));
+}
+
+#[test]
+fn runtime_deep_match_no_matches_returns_empty() {
+    let v = run(
+        br#"{"a": 1, "b": 2}"#,
+        r#"$..match {
+            {role: "admin"} -> "found",
+            _               -> false
+        }"#,
+    );
+    assert_eq!(v, json!([]));
+}
+
+#[test]
 fn runtime_match_chained_with_postfix() {
     // Result of a match flows into a subsequent method call.
     let src = br#"{"xs": [1, 2, 3]}"#;

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -1258,6 +1258,11 @@ impl VM {
                 Opcode::DeleteMarkErr => {
                     return err!("DELETE: only valid inside a patch-field value");
                 }
+                Opcode::Match(cm) => {
+                    let scrutinee = self.exec(&cm.scrutinee, env)?;
+                    let result = self.exec_match(cm, &scrutinee, env)?;
+                    stack.push(result);
+                }
             }
         }
 
@@ -2815,6 +2820,218 @@ impl VM {
             }
             other => Ok(vec![other]),
         }
+    }
+
+    /// Evaluate a compiled `match` expression: walk arms in order, attempt
+    /// to match the scrutinee against each pattern, run the optional guard,
+    /// and evaluate the body of the first arm that fires. Returns an
+    /// evaluation error when no arm matches.
+    fn exec_match(
+        &mut self,
+        cm: &CompiledMatch,
+        scrutinee: &Val,
+        env: &Env,
+    ) -> Result<Val, EvalError> {
+        for arm in cm.arms.iter() {
+            let mut bindings: Vec<(Arc<str>, Val)> = Vec::new();
+            if !match_pat(&arm.pat, scrutinee, &mut bindings) {
+                continue;
+            }
+            let arm_env = bindings
+                .iter()
+                .fold(env.clone(), |e, (n, v)| e.with_var(n.as_ref(), v.clone()));
+            if let Some(guard) = arm.guard.as_ref() {
+                let g = self.exec(guard, &arm_env)?;
+                if !crate::util::is_truthy(&g) {
+                    continue;
+                }
+            }
+            return self.exec(&arm.body, &arm_env);
+        }
+        Err(EvalError(format!(
+            "match: no arm matched value of kind {}",
+            kind_label(scrutinee)
+        )))
+    }
+}
+
+/// Short type-tag string used in `match` non-exhaustive errors.
+fn kind_label(v: &Val) -> &'static str {
+    match v {
+        Val::Null => "null",
+        Val::Bool(_) => "bool",
+        Val::Int(_) => "int",
+        Val::Float(_) => "float",
+        Val::Str(_) | Val::StrSlice(_) | Val::StrVec(_) | Val::StrSliceVec(_) => "string",
+        Val::Arr(_) | Val::IntVec(_) | Val::FloatVec(_) | Val::ObjVec(_) => "array",
+        Val::Obj(_) | Val::ObjSmall(_) => "object",
+    }
+}
+
+/// Try to match `pat` against `val`, recording any captured names in `out`.
+/// Returns `true` on success and `false` on failure. On failure, callers
+/// must discard `out` (it may contain partial bindings from a sub-pattern
+/// that succeeded before the overall match failed).
+fn match_pat(pat: &Pat, val: &Val, out: &mut Vec<(Arc<str>, Val)>) -> bool {
+    match pat {
+        Pat::Wild => true,
+        Pat::Bind(name) => {
+            out.push((Arc::from(name.as_str()), val.clone()));
+            true
+        }
+        Pat::Lit(lit) => match_pat_lit(lit, val),
+        Pat::Or(alts) => {
+            let saved_len = out.len();
+            for alt in alts {
+                if match_pat(alt, val, out) {
+                    return true;
+                }
+                out.truncate(saved_len);
+            }
+            false
+        }
+        Pat::Kind { name, kind } => {
+            if !val_matches_kind(val, *kind) {
+                return false;
+            }
+            if let Some(n) = name.as_deref() {
+                out.push((Arc::from(n), val.clone()));
+            }
+            true
+        }
+        Pat::Obj { fields, open: _ } => {
+            if !matches!(val, Val::Obj(_) | Val::ObjSmall(_)) {
+                return false;
+            }
+            let saved_len = out.len();
+            for (key, sub_pat) in fields {
+                let Some(sub_val) = obj_like_get(val, key.as_str()) else {
+                    out.truncate(saved_len);
+                    return false;
+                };
+                if !match_pat(sub_pat, &sub_val, out) {
+                    out.truncate(saved_len);
+                    return false;
+                }
+            }
+            true
+        }
+        Pat::Arr { elems, rest } => {
+            let Some(arr_len) = arr_like_len(val) else {
+                return false;
+            };
+            let saved_len = out.len();
+            let prefix = elems.len();
+            match rest {
+                Some(_) => {
+                    if arr_len < prefix {
+                        return false;
+                    }
+                }
+                None => {
+                    if arr_len != prefix {
+                        return false;
+                    }
+                }
+            }
+            for (i, sub_pat) in elems.iter().enumerate() {
+                let item = arr_like_get(val, i);
+                if !match_pat(sub_pat, &item, out) {
+                    out.truncate(saved_len);
+                    return false;
+                }
+            }
+            if let Some(rest_name) = rest.as_ref().and_then(|n| n.as_deref()) {
+                let tail: Vec<Val> = (prefix..arr_len).map(|i| arr_like_get(val, i)).collect();
+                out.push((Arc::from(rest_name), Val::arr(tail)));
+            }
+            true
+        }
+    }
+}
+
+/// Return the element count of any array-like `Val` (the materialised
+/// `Arr` form, the columnar primitive vectors, and the row-vector
+/// `ObjVec`), or `None` for non-array values.
+fn arr_like_len(val: &Val) -> Option<usize> {
+    match val {
+        Val::Arr(a) => Some(a.len()),
+        Val::IntVec(v) => Some(v.len()),
+        Val::FloatVec(v) => Some(v.len()),
+        Val::StrVec(v) => Some(v.len()),
+        Val::StrSliceVec(v) => Some(v.len()),
+        Val::ObjVec(d) => Some(d.nrows()),
+        _ => None,
+    }
+}
+
+/// Project the `i`-th element of an array-like `Val` into a freshly
+/// constructed `Val`. Caller must guarantee `i < arr_like_len(val)`.
+fn arr_like_get(val: &Val, i: usize) -> Val {
+    match val {
+        Val::Arr(a) => a[i].clone(),
+        Val::IntVec(v) => Val::Int(v[i]),
+        Val::FloatVec(v) => Val::Float(v[i]),
+        Val::StrVec(v) => Val::Str(v[i].clone()),
+        Val::StrSliceVec(v) => Val::StrSlice(v[i].clone()),
+        Val::ObjVec(d) => d.row_val(i),
+        _ => Val::Null,
+    }
+}
+
+/// Look up an object field by string key in `Obj` / `ObjSmall` values.
+/// Returns `None` when the value is not a scalar object or the key is
+/// absent. `ObjVec` is treated as an array of objects, not a single object,
+/// and is excluded here.
+fn obj_like_get(val: &Val, key: &str) -> Option<Val> {
+    match val {
+        Val::Obj(m) => m.get(key).cloned(),
+        Val::ObjSmall(entries) => entries
+            .iter()
+            .find(|(k, _)| k.as_ref() == key)
+            .map(|(_, v)| v.clone()),
+        _ => None,
+    }
+}
+
+/// Compare a `PatLit` against a runtime `Val` for structural equality.
+fn match_pat_lit(lit: &PatLit, val: &Val) -> bool {
+    match (lit, val) {
+        (PatLit::Null, Val::Null) => true,
+        (PatLit::Bool(b), Val::Bool(v)) => b == v,
+        (PatLit::Int(n), Val::Int(v)) => n == v,
+        (PatLit::Int(n), Val::Float(v)) => (*n as f64) == *v,
+        (PatLit::Float(f), Val::Float(v)) => f == v,
+        (PatLit::Float(f), Val::Int(v)) => *f == (*v as f64),
+        (PatLit::Str(s), Val::Str(v)) => s.as_str() == v.as_ref(),
+        (PatLit::Str(s), Val::StrSlice(v)) => s.as_str() == v.as_ref(),
+        _ => false,
+    }
+}
+
+/// Return `true` when `val`'s runtime type matches the `KindType` requested
+/// by a kind-bind or kind-only pattern.
+fn val_matches_kind(val: &Val, kind: KindType) -> bool {
+    match (val, kind) {
+        (Val::Null, KindType::Null) => true,
+        (Val::Bool(_), KindType::Bool) => true,
+        (Val::Int(_) | Val::Float(_), KindType::Number) => true,
+        (Val::Str(_) | Val::StrSlice(_) | Val::StrVec(_) | Val::StrSliceVec(_), KindType::Str) => {
+            // StrVec/StrSliceVec are vector-of-string fast representations;
+            // they do not satisfy a scalar string kind check.
+            matches!(val, Val::Str(_) | Val::StrSlice(_))
+        }
+        (
+            Val::Arr(_)
+            | Val::IntVec(_)
+            | Val::FloatVec(_)
+            | Val::StrVec(_)
+            | Val::StrSliceVec(_)
+            | Val::ObjVec(_),
+            KindType::Array,
+        ) => true,
+        (Val::Obj(_) | Val::ObjSmall(_), KindType::Object) => true,
+        _ => false,
     }
 }
 

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -3001,6 +3001,15 @@ impl VM {
                     slots[*dst as usize] = Val::arr(tail);
                     pc += 1;
                 }
+                MatchOp::LoadObjRest {
+                    src,
+                    listed_keys,
+                    dst,
+                } => {
+                    let listed: Vec<&str> = listed_keys.iter().map(|k| k.as_ref()).collect();
+                    slots[*dst as usize] = build_obj_rest(&slots[*src as usize], &listed);
+                    pc += 1;
+                }
                 MatchOp::TestSubPat { slot, subpat, else_pc } => {
                     let saved = bindings.len();
                     let mut tmp: Vec<(Arc<str>, Val)> = Vec::new();
@@ -3135,7 +3144,7 @@ fn match_pat(pat: &Pat, val: &Val, out: &mut Vec<(Arc<str>, Val)>) -> bool {
             }
             true
         }
-        Pat::Obj { fields, open: _ } => {
+        Pat::Obj { fields, rest } => {
             if !matches!(val, Val::Obj(_) | Val::ObjSmall(_)) {
                 return false;
             }
@@ -3149,6 +3158,13 @@ fn match_pat(pat: &Pat, val: &Val, out: &mut Vec<(Arc<str>, Val)>) -> bool {
                     out.truncate(saved_len);
                     return false;
                 }
+            }
+            // Named `...rest` rest binding captures every key not
+            // already covered by the explicit field list.
+            if let Some(Some(rest_name)) = rest {
+                let listed: Vec<&str> = fields.iter().map(|(k, _)| k.as_str()).collect();
+                let rest_obj = build_obj_rest(val, &listed);
+                out.push((Arc::from(rest_name.as_str()), rest_obj));
             }
             true
         }
@@ -3213,6 +3229,33 @@ fn arr_like_get(val: &Val, i: usize) -> Val {
         Val::ObjVec(d) => d.row_val(i),
         _ => Val::Null,
     }
+}
+
+/// Build a fresh `Val::Obj` containing every key/value pair on `val`
+/// whose key is not present in `listed` (used by the `...name` rest
+/// binding in object patterns). Returns `Val::Null` for non-object
+/// scrutinees; callers always guard with `Val::Obj` / `Val::ObjSmall`
+/// before invoking this.
+fn build_obj_rest(val: &Val, listed: &[&str]) -> Val {
+    let mut out: IndexMap<Arc<str>, Val> = IndexMap::new();
+    match val {
+        Val::Obj(m) => {
+            for (k, v) in m.iter() {
+                if !listed.iter().any(|l| *l == k.as_ref()) {
+                    out.insert(Arc::clone(k), v.clone());
+                }
+            }
+        }
+        Val::ObjSmall(pairs) => {
+            for (k, v) in pairs.iter() {
+                if !listed.iter().any(|l| *l == k.as_ref()) {
+                    out.insert(Arc::clone(k), v.clone());
+                }
+            }
+        }
+        _ => return Val::Null,
+    }
+    Val::Obj(Arc::new(out))
 }
 
 /// Look up an object field by string key in `Obj` / `ObjSmall` values.
@@ -3938,6 +3981,18 @@ where
                     tail.push(slot_view_index(&slots[*src as usize], i as i64).materialize());
                 }
                 slots[*dst as usize] = SlotView::Owned(Val::arr(tail));
+                pc += 1;
+            }
+            MatchOp::LoadObjRest {
+                src,
+                listed_keys,
+                dst,
+            } => {
+                // Materialise the source view to a `Val::Obj` so we can
+                // walk its keys; the rest object is always owned.
+                let owned = slots[*src as usize].materialize();
+                let listed: Vec<&str> = listed_keys.iter().map(|k| k.as_ref()).collect();
+                slots[*dst as usize] = SlotView::Owned(build_obj_rest(&owned, &listed));
                 pc += 1;
             }
             MatchOp::TestSubPat {

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -1676,16 +1676,18 @@ impl VM {
         env: &Env,
     ) -> Result<Val, EvalError> {
         let sub = call.sub_progs.first();
-        
-        
+        let sub_kernel = call.sub_kernels.first();
+        let no_op_kernel = crate::exec::pipeline::BodyKernel::Generic;
+        let kernel0 = sub_kernel.unwrap_or(&no_op_kernel);
+
         let lam_param: Option<&str> = match call.orig_args.first() {
             Some(Arg::Pos(Expr::Lambda { params, .. })) if !params.is_empty() => {
                 Some(params[0].as_str())
             }
             _ => None,
         };
-        
-        
+
+
         let mut scratch = env.clone();
 
         match call.method {
@@ -1696,7 +1698,7 @@ impl VM {
                     .ok_or_else(|| EvalError("filter: expected array".into()))?;
                 let out =
                     crate::builtins::filter_apply_bounded(items, call.demand_max_keep, |item| {
-                        self.exec_lam_body_scratch(pred, item, lam_param, &mut scratch)
+                        self.exec_lam_body_kernel(pred, kernel0, item, lam_param, &mut scratch)
                     })?;
                 Ok(Val::arr(out))
             }
@@ -1707,7 +1709,7 @@ impl VM {
                     .ok_or_else(|| EvalError("map: expected array".into()))?;
                 let out =
                     crate::builtins::map_apply_bounded(items, call.demand_max_keep, |item| {
-                        self.exec_lam_body_scratch(mapper, item, lam_param, &mut scratch)
+                        self.exec_lam_body_kernel(mapper, kernel0, item, lam_param, &mut scratch)
                     })?;
                 Ok(Val::arr(out))
             }
@@ -1717,7 +1719,7 @@ impl VM {
                     .into_vec()
                     .ok_or_else(|| EvalError("flatMap: expected array".into()))?;
                 let out = crate::builtins::flat_map_apply(items, |item| {
-                    self.exec_lam_body_scratch(mapper, item, lam_param, &mut scratch)
+                    self.exec_lam_body_kernel(mapper, kernel0, item, lam_param, &mut scratch)
                 })?;
                 Ok(Val::arr(out))
             }
@@ -1765,7 +1767,7 @@ impl VM {
                     let pred = sub.ok_or_else(|| EvalError("any: requires predicate".into()))?;
                     for item in a.iter() {
                         if crate::builtins::any_one(item, |v| {
-                            self.exec_lam_body_scratch(pred, v, lam_param, &mut scratch)
+                            self.exec_lam_body_kernel(pred, kernel0, v, lam_param, &mut scratch)
                         })? {
                             return Ok(Val::Bool(true));
                         }
@@ -1783,7 +1785,7 @@ impl VM {
                     let pred = sub.ok_or_else(|| EvalError("all: requires predicate".into()))?;
                     for item in a.iter() {
                         if !crate::builtins::all_one(item, |v| {
-                            self.exec_lam_body_scratch(pred, v, lam_param, &mut scratch)
+                            self.exec_lam_body_kernel(pred, kernel0, v, lam_param, &mut scratch)
                         })? {
                             return Ok(Val::Bool(false));
                         }
@@ -1799,7 +1801,7 @@ impl VM {
                     let mut n: i64 = 0;
                     for item in a.iter() {
                         if crate::builtins::filter_one(item, |v| {
-                            self.exec_lam_body_scratch(pred, v, lam_param, &mut scratch)
+                            self.exec_lam_body_kernel(pred, kernel0, v, lam_param, &mut scratch)
                         })? {
                             n += 1;
                         }
@@ -2676,6 +2678,44 @@ impl VM {
         lam_param: Option<&str>,
         scratch: &mut Env,
     ) -> Result<Val, EvalError> {
+        let frame = scratch.push_lam(lam_param, item.clone());
+        let r = self.exec(prog, scratch);
+        scratch.pop_lam(frame);
+        r
+    }
+
+    /// Like `exec_lam_body_scratch` but consults a pre-classified
+    /// `BodyKernel`. When the kernel is non-`Generic` and the lambda
+    /// has no named parameter, the body is evaluated through native
+    /// Rust kernels (no VM stack init, no opcode dispatch). Used by
+    /// the per-element loops of `.any` / `.all` / `.find` / `.count`
+    /// / etc. so simple-predicate lambdas (the common case) avoid
+    /// VM re-entry per iteration.
+    fn exec_lam_body_kernel(
+        &mut self,
+        prog: &Program,
+        kernel: &crate::exec::pipeline::BodyKernel,
+        item: &Val,
+        lam_param: Option<&str>,
+        scratch: &mut Env,
+    ) -> Result<Val, EvalError> {
+        use crate::exec::pipeline::{eval_kernel, BodyKernel};
+        // The kernel path treats `item` as `@` and resolves bare names
+        // as fields on it. That is only safe when no `let`-bound
+        // variables shadow those names; otherwise the kernel would
+        // bypass the binding lookup that the VM does for `LoadIdent`.
+        // Skip the fast path when env has any let-bindings.
+        if lam_param.is_none()
+            && scratch.has_no_vars()
+            && !matches!(kernel, BodyKernel::Generic)
+        {
+            return eval_kernel(kernel, item, |fallback_item| {
+                let frame = scratch.push_lam(None, fallback_item.clone());
+                let result = self.exec(prog, scratch);
+                scratch.pop_lam(frame);
+                result
+            });
+        }
         let frame = scratch.push_lam(lam_param, item.clone());
         let r = self.exec(prog, scratch);
         scratch.pop_lam(frame);

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -1264,6 +1264,13 @@ impl VM {
                     collect_all_inclusive(&recv, &mut all_descendants);
                     let mut out: Vec<Val> = Vec::new();
                     for desc in &all_descendants {
+                        // Pre-filter via the compile-time shape summary:
+                        // descendants whose runtime kind cannot satisfy
+                        // any arm are skipped without paying for the
+                        // full pattern walk.
+                        if !shape_summary_admits(&cm.shape_summary, desc) {
+                            continue;
+                        }
                         match self.exec_match(cm, desc, env) {
                             Ok(v) if crate::util::is_truthy(&v) => out.push(v),
                             Ok(_) => {}
@@ -1271,6 +1278,24 @@ impl VM {
                         }
                     }
                     stack.push(Val::arr(out));
+                }
+                Opcode::DeepMatchFirst(cm) => {
+                    let recv = pop!(stack);
+                    let mut all_descendants: Vec<Val> = Vec::new();
+                    collect_all_inclusive(&recv, &mut all_descendants);
+                    let mut found: Option<Val> = None;
+                    for desc in &all_descendants {
+                        if !shape_summary_admits(&cm.shape_summary, desc) {
+                            continue;
+                        }
+                        if let Ok(v) = self.exec_match(cm, desc, env) {
+                            if crate::util::is_truthy(&v) {
+                                found = Some(v);
+                                break;
+                            }
+                        }
+                    }
+                    stack.push(found.unwrap_or(Val::Null));
                 }
                 Opcode::Match(cm) => {
                     // Resolve the scrutinee under whichever strategy the
@@ -3374,6 +3399,31 @@ fn find_desc_first(v: &Val, name: &str) -> Option<Val> {
             None
         }
         _ => None,
+    }
+}
+
+/// Test whether `val` could match any arm summarised by `summary`. The
+/// check is conservative — when `summary` is `None` (no usable
+/// structural information) every value is admitted and the per-arm
+/// runtime decides. When `summary` is present, values whose runtime
+/// kind is provably outside the summarised set are rejected upfront.
+fn shape_summary_admits(summary: &Option<MatchShapeSummary>, val: &Val) -> bool {
+    let Some(s) = summary.as_ref() else {
+        return true;
+    };
+    match s {
+        MatchShapeSummary::ObjAnyOfKeys(keys) => match val {
+            Val::Obj(m) => keys.iter().any(|k| m.contains_key(k.as_ref())),
+            Val::ObjSmall(pairs) => keys
+                .iter()
+                .any(|k| pairs.iter().any(|(pk, _)| pk.as_ref() == k.as_ref())),
+            _ => false,
+        },
+        MatchShapeSummary::KindOnly(kind) => val_matches_kind(val, *kind),
+        MatchShapeSummary::NumericRange { lo, hi, inclusive } => match val_to_f64(val) {
+            Some(n) => range_contains(*lo, *hi, *inclusive, n),
+            None => false,
+        },
     }
 }
 

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -2822,37 +2822,175 @@ impl VM {
         }
     }
 
-    /// Evaluate a compiled `match` expression: walk arms in order, attempt
-    /// to match the scrutinee against each pattern, run the optional guard,
-    /// and evaluate the body of the first arm that fires. Returns an
-    /// evaluation error when no arm matches.
+    /// Evaluate a compiled `match` expression by walking the flat
+    /// `MatchOp` instruction stream produced by the compiler. Slot 0 holds
+    /// the scrutinee; pattern tests project sub-values into successive
+    /// slots, and bindings are accumulated into a per-arm stack until a
+    /// `Body` op terminates the loop. A failed test jumps to the start of
+    /// the next arm; the trailing `Fail` op raises a non-exhaustive error.
     fn exec_match(
         &mut self,
         cm: &CompiledMatch,
         scrutinee: &Val,
         env: &Env,
     ) -> Result<Val, EvalError> {
-        for arm in cm.arms.iter() {
-            let mut bindings: Vec<(Arc<str>, Val)> = Vec::new();
-            if !match_pat(&arm.pat, scrutinee, &mut bindings) {
-                continue;
-            }
-            let arm_env = bindings
-                .iter()
-                .fold(env.clone(), |e, (n, v)| e.with_var(n.as_ref(), v.clone()));
-            if let Some(guard) = arm.guard.as_ref() {
-                let g = self.exec(guard, &arm_env)?;
-                if !crate::util::is_truthy(&g) {
-                    continue;
+        let total = (cm.max_slots as usize).max(1);
+        let mut slots: SmallVec<[Val; 8]> = SmallVec::with_capacity(total);
+        slots.resize(total, Val::Null);
+        slots[0] = scrutinee.clone();
+        let mut bindings: SmallVec<[(Arc<str>, Val); 8]> = SmallVec::new();
+        let mut pc: u32 = 0;
+        let ops = &cm.ops;
+        loop {
+            let op = &ops[pc as usize];
+            match op {
+                MatchOp::ResetArm {
+                    slots: _,
+                    keep_above,
+                } => {
+                    bindings.clear();
+                    // Preserve slots [0..keep_above); zero everything from
+                    // `keep_above` onwards so residue from a missed arm
+                    // does not leak into this one. `keep_above >= 1`
+                    // always — slot 0 (scrutinee) is invariant. The slot
+                    // vector itself was pre-sized at the top of
+                    // `exec_match` from `cm.max_slots`, so no growth is
+                    // needed here.
+                    let keep = (*keep_above as usize).max(1);
+                    for s in slots.iter_mut().skip(keep) {
+                        *s = Val::Null;
+                    }
+                    pc += 1;
+                }
+                MatchOp::KindCheck { slot, kind, else_pc } => {
+                    if val_matches_kind(&slots[*slot as usize], *kind) {
+                        pc += 1;
+                    } else {
+                        pc = *else_pc;
+                    }
+                }
+                MatchOp::LitEq { slot, lit, else_pc } => {
+                    if match_pat_lit(&cm.lits[*lit as usize], &slots[*slot as usize]) {
+                        pc += 1;
+                    } else {
+                        pc = *else_pc;
+                    }
+                }
+                MatchOp::ObjCheck { slot, else_pc } => {
+                    if matches!(
+                        &slots[*slot as usize],
+                        Val::Obj(_) | Val::ObjSmall(_)
+                    ) {
+                        pc += 1;
+                    } else {
+                        pc = *else_pc;
+                    }
+                }
+                MatchOp::LoadField {
+                    src,
+                    key,
+                    dst,
+                    else_pc,
+                } => {
+                    match obj_like_get(&slots[*src as usize], key.as_ref()) {
+                        Some(v) => {
+                            slots[*dst as usize] = v;
+                            pc += 1;
+                        }
+                        None => pc = *else_pc,
+                    }
+                }
+                MatchOp::LenCheck {
+                    slot,
+                    len,
+                    exact,
+                    else_pc,
+                } => {
+                    let arr_len = match arr_like_len(&slots[*slot as usize]) {
+                        Some(n) => n,
+                        None => {
+                            pc = *else_pc;
+                            continue;
+                        }
+                    };
+                    let want = *len as usize;
+                    let ok = if *exact { arr_len == want } else { arr_len >= want };
+                    if ok {
+                        pc += 1;
+                    } else {
+                        pc = *else_pc;
+                    }
+                }
+                MatchOp::LoadIndex { src, idx, dst } => {
+                    slots[*dst as usize] = arr_like_get(&slots[*src as usize], *idx as usize);
+                    pc += 1;
+                }
+                MatchOp::LoadTail { src, from, dst } => {
+                    let len = arr_like_len(&slots[*src as usize]).unwrap_or(0);
+                    let from_idx = *from as usize;
+                    let mut tail: Vec<Val> = Vec::with_capacity(len.saturating_sub(from_idx));
+                    for i in from_idx..len {
+                        tail.push(arr_like_get(&slots[*src as usize], i));
+                    }
+                    slots[*dst as usize] = Val::arr(tail);
+                    pc += 1;
+                }
+                MatchOp::TestSubPat { slot, subpat, else_pc } => {
+                    let saved = bindings.len();
+                    let mut tmp: Vec<(Arc<str>, Val)> = Vec::new();
+                    let ok = match_pat(
+                        &cm.subpats[*subpat as usize],
+                        &slots[*slot as usize],
+                        &mut tmp,
+                    );
+                    if ok {
+                        for b in tmp {
+                            bindings.push(b);
+                        }
+                        pc += 1;
+                    } else {
+                        bindings.truncate(saved);
+                        pc = *else_pc;
+                    }
+                }
+                MatchOp::Bind { name, slot } => {
+                    bindings.push((Arc::clone(name), slots[*slot as usize].clone()));
+                    pc += 1;
+                }
+                MatchOp::Guard { prog, else_pc } => {
+                    let arm_env = build_arm_env(env, &bindings);
+                    let g = self.exec(&cm.guards[*prog as usize], &arm_env)?;
+                    if crate::util::is_truthy(&g) {
+                        pc += 1;
+                    } else {
+                        pc = *else_pc;
+                    }
+                }
+                MatchOp::Body { prog } => {
+                    let arm_env = build_arm_env(env, &bindings);
+                    return self.exec(&cm.bodies[*prog as usize], &arm_env);
+                }
+                MatchOp::Fail => {
+                    return Err(EvalError(format!(
+                        "match: no arm matched value of kind {}",
+                        kind_label(scrutinee)
+                    )));
+                }
+                MatchOp::Jump { target_pc } => {
+                    pc = *target_pc;
                 }
             }
-            return self.exec(&arm.body, &arm_env);
         }
-        Err(EvalError(format!(
-            "match: no arm matched value of kind {}",
-            kind_label(scrutinee)
-        )))
     }
+}
+
+/// Build the body / guard environment for a match arm by extending `env`
+/// with every binding the arm has accumulated so far. Bindings later in
+/// the list shadow earlier ones, matching let-style scoping.
+fn build_arm_env(env: &Env, bindings: &[(Arc<str>, Val)]) -> Env {
+    bindings
+        .iter()
+        .fold(env.clone(), |e, (n, v)| e.with_var(n.as_ref(), v.clone()))
 }
 
 /// Short type-tag string used in `match` non-exhaustive errors.

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -1259,8 +1259,20 @@ impl VM {
                     return err!("DELETE: only valid inside a patch-field value");
                 }
                 Opcode::Match(cm) => {
-                    let scrutinee = self.exec(&cm.scrutinee, env)?;
-                    let result = self.exec_match(cm, &scrutinee, env)?;
+                    // Resolve the scrutinee under whichever strategy the
+                    // compiler chose. `Current` and `Root` skip VM re-entry
+                    // by reading the env directly; `Program` falls back to
+                    // a recursive `exec` call.
+                    let scrutinee_holder;
+                    let scrutinee_ref: &Val = match &cm.scrutinee {
+                        crate::vm::MatchScrutinee::Current => &env.current,
+                        crate::vm::MatchScrutinee::Root => &env.root,
+                        crate::vm::MatchScrutinee::Program(prog) => {
+                            scrutinee_holder = self.exec(prog, env)?;
+                            &scrutinee_holder
+                        }
+                    };
+                    let result = self.exec_match(cm, scrutinee_ref, env)?;
                     stack.push(result);
                 }
             }
@@ -2828,7 +2840,7 @@ impl VM {
     /// slots, and bindings are accumulated into a per-arm stack until a
     /// `Body` op terminates the loop. A failed test jumps to the start of
     /// the next arm; the trailing `Fail` op raises a non-exhaustive error.
-    fn exec_match(
+    pub(crate) fn exec_match(
         &mut self,
         cm: &CompiledMatch,
         scrutinee: &Val,
@@ -2871,6 +2883,21 @@ impl VM {
                 }
                 MatchOp::LitEq { slot, lit, else_pc } => {
                     if match_pat_lit(&cm.lits[*lit as usize], &slots[*slot as usize]) {
+                        pc += 1;
+                    } else {
+                        pc = *else_pc;
+                    }
+                }
+                MatchOp::RangeCheck {
+                    slot,
+                    lo,
+                    hi,
+                    inclusive,
+                    else_pc,
+                } => {
+                    let ok = val_to_f64(&slots[*slot as usize])
+                        .is_some_and(|n| range_contains(*lo, *hi, *inclusive, n));
+                    if ok {
                         pc += 1;
                     } else {
                         pc = *else_pc;
@@ -3056,6 +3083,10 @@ fn match_pat(pat: &Pat, val: &Val, out: &mut Vec<(Arc<str>, Val)>) -> bool {
             }
             false
         }
+        Pat::Range { lo, hi, inclusive } => match val_to_f64(val) {
+            Some(n) if range_contains(*lo, *hi, *inclusive, n) => true,
+            _ => false,
+        },
         Pat::Kind { name, kind } => {
             if !val_matches_kind(val, *kind) {
                 return false;
@@ -3157,6 +3188,26 @@ fn obj_like_get(val: &Val, key: &str) -> Option<Val> {
             .find(|(k, _)| k.as_ref() == key)
             .map(|(_, v)| v.clone()),
         _ => None,
+    }
+}
+
+/// Coerce `Val` to `f64` for range-pattern membership tests. Integer
+/// values widen losslessly; non-numeric values yield `None`.
+fn val_to_f64(val: &Val) -> Option<f64> {
+    match val {
+        Val::Int(n) => Some(*n as f64),
+        Val::Float(f) => Some(*f),
+        _ => None,
+    }
+}
+
+/// Test whether `n` falls within the half-open or closed range
+/// `[lo, hi)` / `[lo, hi]` defined by `inclusive`.
+fn range_contains(lo: f64, hi: f64, inclusive: bool, n: f64) -> bool {
+    if inclusive {
+        n >= lo && n <= hi
+    } else {
+        n >= lo && n < hi
     }
 }
 
@@ -3628,5 +3679,318 @@ fn hash_structure_into(v: &Val, h: &mut DefaultHasher, depth: usize) {
                 hash_structure_into(v, h, depth + 1);
             }
         }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// View-domain match runtime.
+//
+// `exec_match_view` mirrors `VM::exec_match` but operates against a
+// borrowed `ValueView` scrutinee. Slots hold either a borrowed view or
+// an owned `Val` produced by operations that synthesise data
+// (`LoadTail`, `TestSubPat` materialisations). Pattern tests against
+// borrowed scalars avoid the per-row `Val` allocation that the in-memory
+// path performs to project sub-fields.
+//
+// **Semantics of missing keys.** `ValueView::field` returns a null view
+// for both an absent key and an explicitly-null value. The view-domain
+// runtime therefore treats these cases identically: a `Pat::Obj { k: p }`
+// whose sub-pattern accepts null will match an object that lacks `k`.
+// Callers that need strict missing-key rejection should fall back to
+// the `Val`-domain path. Mixing-and-matching the two domains in the
+// same query is supported because the chain IR labels stages with the
+// kind they need (`ChainOp::Match` is domain-agnostic; the executor
+// chooses the runtime).
+// ─────────────────────────────────────────────────────────────────────
+
+use crate::data::view::ValueView;
+use crate::util::JsonView;
+
+/// Evaluate a compiled `match` expression against a borrowed
+/// `ValueView` scrutinee, materialising values only when necessary
+/// (bindings and arm bodies require a real `Val`).
+pub(crate) fn exec_match_view<'a, V>(
+    vm: &mut VM,
+    cm: &CompiledMatch,
+    scrutinee: V,
+    env: &Env,
+) -> Result<Val, EvalError>
+where
+    V: ValueView<'a>,
+{
+    let total = (cm.max_slots as usize).max(1);
+    let mut slots: Vec<SlotView<V>> = (0..total).map(|_| SlotView::Owned(Val::Null)).collect();
+    slots[0] = SlotView::View(scrutinee);
+    let mut bindings: SmallVec<[(Arc<str>, Val); 8]> = SmallVec::new();
+    let mut pc: u32 = 0;
+    let ops = &cm.ops;
+    loop {
+        let op = &ops[pc as usize];
+        match op {
+            MatchOp::ResetArm {
+                slots: _,
+                keep_above,
+            } => {
+                bindings.clear();
+                let keep = (*keep_above as usize).max(1);
+                for s in slots.iter_mut().skip(keep) {
+                    *s = SlotView::Owned(Val::Null);
+                }
+                pc += 1;
+            }
+            MatchOp::KindCheck { slot, kind, else_pc } => {
+                if slot_view_matches_kind(&slots[*slot as usize], *kind) {
+                    pc += 1;
+                } else {
+                    pc = *else_pc;
+                }
+            }
+            MatchOp::LitEq { slot, lit, else_pc } => {
+                if slot_view_match_lit(&cm.lits[*lit as usize], &slots[*slot as usize]) {
+                    pc += 1;
+                } else {
+                    pc = *else_pc;
+                }
+            }
+            MatchOp::RangeCheck {
+                slot,
+                lo,
+                hi,
+                inclusive,
+                else_pc,
+            } => {
+                let ok = slot_view_to_f64(&slots[*slot as usize])
+                    .is_some_and(|n| range_contains(*lo, *hi, *inclusive, n));
+                if ok {
+                    pc += 1;
+                } else {
+                    pc = *else_pc;
+                }
+            }
+            MatchOp::ObjCheck { slot, else_pc } => {
+                if slot_view_is_obj(&slots[*slot as usize]) {
+                    pc += 1;
+                } else {
+                    pc = *else_pc;
+                }
+            }
+            MatchOp::LoadField {
+                src,
+                key,
+                dst,
+                else_pc,
+            } => match slot_view_field(&slots[*src as usize], key.as_ref()) {
+                Some(child) => {
+                    slots[*dst as usize] = child;
+                    pc += 1;
+                }
+                None => pc = *else_pc,
+            },
+            MatchOp::LenCheck {
+                slot,
+                len,
+                exact,
+                else_pc,
+            } => {
+                let arr_len = match slot_view_arr_len(&slots[*slot as usize]) {
+                    Some(n) => n,
+                    None => {
+                        pc = *else_pc;
+                        continue;
+                    }
+                };
+                let want = *len as usize;
+                let ok = if *exact { arr_len == want } else { arr_len >= want };
+                if ok {
+                    pc += 1;
+                } else {
+                    pc = *else_pc;
+                }
+            }
+            MatchOp::LoadIndex { src, idx, dst } => {
+                slots[*dst as usize] = slot_view_index(&slots[*src as usize], *idx as i64);
+                pc += 1;
+            }
+            MatchOp::LoadTail { src, from, dst } => {
+                let len = slot_view_arr_len(&slots[*src as usize]).unwrap_or(0);
+                let from_idx = *from as usize;
+                let mut tail: Vec<Val> = Vec::with_capacity(len.saturating_sub(from_idx));
+                for i in from_idx..len {
+                    tail.push(slot_view_index(&slots[*src as usize], i as i64).materialize());
+                }
+                slots[*dst as usize] = SlotView::Owned(Val::arr(tail));
+                pc += 1;
+            }
+            MatchOp::TestSubPat {
+                slot,
+                subpat,
+                else_pc,
+            } => {
+                let saved = bindings.len();
+                let val = slots[*slot as usize].materialize();
+                let mut tmp: Vec<(Arc<str>, Val)> = Vec::new();
+                if match_pat(&cm.subpats[*subpat as usize], &val, &mut tmp) {
+                    for b in tmp {
+                        bindings.push(b);
+                    }
+                    pc += 1;
+                } else {
+                    bindings.truncate(saved);
+                    pc = *else_pc;
+                }
+            }
+            MatchOp::Bind { name, slot } => {
+                bindings.push((Arc::clone(name), slots[*slot as usize].materialize()));
+                pc += 1;
+            }
+            MatchOp::Guard { prog, else_pc } => {
+                let arm_env = build_arm_env(env, &bindings);
+                let g = vm.exec(&cm.guards[*prog as usize], &arm_env)?;
+                if crate::util::is_truthy(&g) {
+                    pc += 1;
+                } else {
+                    pc = *else_pc;
+                }
+            }
+            MatchOp::Body { prog } => {
+                let arm_env = build_arm_env(env, &bindings);
+                return vm.exec(&cm.bodies[*prog as usize], &arm_env);
+            }
+            MatchOp::Fail => {
+                let s = slots[0].materialize();
+                return Err(EvalError(format!(
+                    "match: no arm matched {} value {}",
+                    kind_label(&s),
+                    snippet_for_error(&s),
+                )));
+            }
+            MatchOp::Jump { target_pc } => pc = *target_pc,
+        }
+    }
+}
+
+/// Slot contents in the view-domain match interpreter. `View` retains a
+/// borrow into the source document; `Owned` holds a freshly synthesised
+/// value (used by `LoadTail` and after `TestSubPat` materialisations).
+enum SlotView<V> {
+    /// Borrowed view from the source document.
+    View(V),
+    /// Owned value synthesised during pattern execution.
+    Owned(Val),
+}
+
+impl<'a, V> SlotView<V>
+where
+    V: ValueView<'a>,
+{
+    /// Materialise the slot into an owned `Val`. For `View`, this calls
+    /// the trait's `materialize()`; for `Owned`, a clone bumps the
+    /// underlying `Arc` for compound values.
+    fn materialize(&self) -> Val {
+        match self {
+            SlotView::View(v) => v.materialize(),
+            SlotView::Owned(v) => v.clone(),
+        }
+    }
+}
+
+/// Extract a borrowed scalar view of `slot`'s contents for kind / literal
+/// tests. Falls through to `JsonView::from_val` for the `Owned` arm.
+fn slot_view_scalar<'s, 'a, V>(slot: &'s SlotView<V>) -> JsonView<'s>
+where
+    V: ValueView<'a>,
+{
+    match slot {
+        SlotView::View(v) => v.scalar(),
+        SlotView::Owned(val) => JsonView::from_val(val),
+    }
+}
+
+fn slot_view_matches_kind<'a, V>(slot: &SlotView<V>, kind: KindType) -> bool
+where
+    V: ValueView<'a>,
+{
+    match (slot_view_scalar(slot), kind) {
+        (JsonView::Null, KindType::Null) => true,
+        (JsonView::Bool(_), KindType::Bool) => true,
+        (JsonView::Int(_) | JsonView::UInt(_) | JsonView::Float(_), KindType::Number) => true,
+        (JsonView::Str(_), KindType::Str) => true,
+        (JsonView::ArrayLen(_), KindType::Array) => true,
+        (JsonView::ObjectLen(_), KindType::Object) => true,
+        _ => false,
+    }
+}
+
+fn slot_view_is_obj<'a, V>(slot: &SlotView<V>) -> bool
+where
+    V: ValueView<'a>,
+{
+    matches!(slot_view_scalar(slot), JsonView::ObjectLen(_))
+}
+
+fn slot_view_arr_len<'a, V>(slot: &SlotView<V>) -> Option<usize>
+where
+    V: ValueView<'a>,
+{
+    match slot_view_scalar(slot) {
+        JsonView::ArrayLen(n) => Some(n),
+        _ => None,
+    }
+}
+
+fn slot_view_to_f64<'a, V>(slot: &SlotView<V>) -> Option<f64>
+where
+    V: ValueView<'a>,
+{
+    match slot_view_scalar(slot) {
+        JsonView::Int(n) => Some(n as f64),
+        JsonView::UInt(n) => Some(n as f64),
+        JsonView::Float(f) => Some(f),
+        _ => None,
+    }
+}
+
+fn slot_view_match_lit<'a, V>(lit: &PatLit, slot: &SlotView<V>) -> bool
+where
+    V: ValueView<'a>,
+{
+    match (lit, slot_view_scalar(slot)) {
+        (PatLit::Null, JsonView::Null) => true,
+        (PatLit::Bool(b), JsonView::Bool(v)) => *b == v,
+        (PatLit::Int(n), JsonView::Int(v)) => *n == v,
+        (PatLit::Int(n), JsonView::UInt(v)) => *n >= 0 && (*n as u64) == v,
+        (PatLit::Int(n), JsonView::Float(v)) => (*n as f64) == v,
+        (PatLit::Float(f), JsonView::Float(v)) => *f == v,
+        (PatLit::Float(f), JsonView::Int(v)) => *f == v as f64,
+        (PatLit::Float(f), JsonView::UInt(v)) => *f == v as f64,
+        (PatLit::Str(s), JsonView::Str(v)) => s.as_str() == v,
+        _ => false,
+    }
+}
+
+fn slot_view_field<'a, V>(slot: &SlotView<V>, key: &str) -> Option<SlotView<V>>
+where
+    V: ValueView<'a>,
+{
+    match slot {
+        SlotView::View(v) => {
+            // The view path treats absent keys and explicit `null` values
+            // identically (see module-level docs); both proceed with a
+            // null view. Callers that need strict presence semantics
+            // route through the `Val`-domain path.
+            let child = v.field(key);
+            Some(SlotView::View(child))
+        }
+        SlotView::Owned(val) => obj_like_get(val, key).map(SlotView::Owned),
+    }
+}
+
+fn slot_view_index<'a, V>(slot: &SlotView<V>, idx: i64) -> SlotView<V>
+where
+    V: ValueView<'a>,
+{
+    match slot {
+        SlotView::View(v) => SlotView::View(v.index(idx)),
+        SlotView::Owned(val) => SlotView::Owned(arr_like_get(val, idx as usize)),
     }
 }

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -2972,8 +2972,9 @@ impl VM {
                 }
                 MatchOp::Fail => {
                     return Err(EvalError(format!(
-                        "match: no arm matched value of kind {}",
-                        kind_label(scrutinee)
+                        "match: no arm matched {} value {}",
+                        kind_label(scrutinee),
+                        snippet_for_error(scrutinee),
                     )));
                 }
                 MatchOp::Jump { target_pc } => {
@@ -2991,6 +2992,33 @@ fn build_arm_env(env: &Env, bindings: &[(Arc<str>, Val)]) -> Env {
     bindings
         .iter()
         .fold(env.clone(), |e, (n, v)| e.with_var(n.as_ref(), v.clone()))
+}
+
+/// Render a short, single-line snippet of `val` suitable for inclusion in
+/// a non-exhaustive-match error message. Long compound values are
+/// truncated so the error stays scannable.
+fn snippet_for_error(val: &Val) -> String {
+    const MAX_LEN: usize = 80;
+    let mut s = match val {
+        Val::Null => "null".to_string(),
+        Val::Bool(b) => b.to_string(),
+        Val::Int(n) => n.to_string(),
+        Val::Float(f) => f.to_string(),
+        Val::Str(s) => format!("{:?}", s.as_ref()),
+        Val::StrSlice(r) => format!("{:?}", r.as_ref()),
+        Val::Arr(_)
+        | Val::IntVec(_)
+        | Val::FloatVec(_)
+        | Val::StrVec(_)
+        | Val::StrSliceVec(_)
+        | Val::ObjVec(_) => "[…]".to_string(),
+        Val::Obj(_) | Val::ObjSmall(_) => "{…}".to_string(),
+    };
+    if s.len() > MAX_LEN {
+        s.truncate(MAX_LEN);
+        s.push('…');
+    }
+    s
 }
 
 /// Short type-tag string used in `match` non-exhaustive errors.

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -1258,6 +1258,20 @@ impl VM {
                 Opcode::DeleteMarkErr => {
                     return err!("DELETE: only valid inside a patch-field value");
                 }
+                Opcode::DeepMatchAll(cm) => {
+                    let recv = pop!(stack);
+                    let mut all_descendants: Vec<Val> = Vec::new();
+                    collect_all_inclusive(&recv, &mut all_descendants);
+                    let mut out: Vec<Val> = Vec::new();
+                    for desc in &all_descendants {
+                        match self.exec_match(cm, desc, env) {
+                            Ok(v) if crate::util::is_truthy(&v) => out.push(v),
+                            Ok(_) => {}
+                            Err(_) => {}
+                        }
+                    }
+                    stack.push(Val::arr(out));
+                }
                 Opcode::Match(cm) => {
                     // Resolve the scrutinee under whichever strategy the
                     // compiler chose. `Current` and `Root` skip VM re-entry
@@ -3360,6 +3374,61 @@ fn find_desc_first(v: &Val, name: &str) -> Option<Val> {
             None
         }
         _ => None,
+    }
+}
+
+/// Collect every node in the subtree of `v` (DFS pre-order) into `out`,
+/// including `v` itself and every leaf and compound representation
+/// (`IntVec`, `FloatVec`, `StrVec`, `StrSliceVec`, `ObjVec`, `ObjSmall`).
+/// Used by `DeepMatchAll` to feed the match runtime with every
+/// descendant regardless of how the document was promoted at parse
+/// time. The pre-existing `collect_all` walks only `Obj` / `Arr`
+/// because its callers (`$..**`) operate before columnar promotion.
+fn collect_all_inclusive(v: &Val, out: &mut Vec<Val>) {
+    out.push(v.clone());
+    match v {
+        Val::Obj(m) => {
+            for child in m.values() {
+                collect_all_inclusive(child, out);
+            }
+        }
+        Val::ObjSmall(pairs) => {
+            for (_, child) in pairs.iter() {
+                collect_all_inclusive(child, out);
+            }
+        }
+        Val::ObjVec(data) => {
+            for row in 0..data.nrows() {
+                let row_val = data.row_val(row);
+                collect_all_inclusive(&row_val, out);
+            }
+        }
+        Val::Arr(a) => {
+            for item in a.as_ref() {
+                collect_all_inclusive(item, out);
+            }
+        }
+        Val::IntVec(a) => {
+            for &n in a.iter() {
+                out.push(Val::Int(n));
+            }
+        }
+        Val::FloatVec(a) => {
+            for &f in a.iter() {
+                out.push(Val::Float(f));
+            }
+        }
+        Val::StrVec(a) => {
+            for s in a.iter() {
+                out.push(Val::Str(Arc::clone(s)));
+            }
+        }
+        Val::StrSliceVec(a) => {
+            for s in a.iter() {
+                out.push(Val::StrSlice(s.clone()));
+            }
+        }
+        _ => {}
     }
 }
 

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -2701,12 +2701,23 @@ impl VM {
     ) -> Result<Val, EvalError> {
         use crate::exec::pipeline::{eval_kernel, BodyKernel};
         // The kernel path treats `item` as `@` and resolves bare names
-        // as fields on it. That is only safe when no `let`-bound
-        // variables shadow those names; otherwise the kernel would
-        // bypass the binding lookup that the VM does for `LoadIdent`.
-        // Skip the fast path when env has any let-bindings.
+        // as fields on it. That is only safe when:
+        //   - the lambda has no named parameter (the kernel always
+        //     reads `@`, not a per-call binding),
+        //   - the env has no let-bindings (otherwise a let-shadowed
+        //     name would be silently rerouted to a field read), and
+        //   - the program does not begin with `LoadIdent` — that
+        //     opcode dispatches to a no-arg builtin when the current
+        //     value is array/string and the ident matches a builtin
+        //     name (e.g. `.map(len)` invokes `len` as a builtin), a
+        //     dispatch the kernel form drops on the floor.
+        let starts_with_load_ident = matches!(
+            prog.ops.first(),
+            Some(crate::vm::Opcode::LoadIdent(_))
+        );
         if lam_param.is_none()
             && scratch.has_no_vars()
+            && !starts_with_load_ident
             && !matches!(kernel, BodyKernel::Generic)
         {
             return eval_kernel(kernel, item, |fallback_item| {

--- a/jetro-core/src/vm/opcode.rs
+++ b/jetro-core/src/vm/opcode.rs
@@ -332,6 +332,35 @@ pub enum Opcode {
 
     /// Guard that fires when a `DELETE` sentinel reaches execution outside a patch context.
     DeleteMarkErr,
+
+    /// Execute a compiled pattern-match expression: evaluate the scrutinee,
+    /// try each arm's pattern (and optional guard) in order, and run the body
+    /// of the first matching arm with its bindings in scope.
+    Match(Arc<CompiledMatch>),
+}
+
+/// Compiled representation of a `match scrutinee with { arms }` expression.
+/// Patterns are stored unflattened; the runtime walks them directly. Arm
+/// bodies and guards are pre-compiled to `Program`s so they can be re-used
+/// across invocations.
+#[derive(Debug, Clone)]
+pub struct CompiledMatch {
+    /// Program that evaluates the value being matched.
+    pub scrutinee: Arc<Program>,
+    /// Ordered arm list; first matching arm wins.
+    pub arms: Arc<[CompiledMatchArm]>,
+}
+
+/// One compiled arm of a `match` expression, including the pattern, the
+/// optional guard expression, and the body to evaluate on a successful match.
+#[derive(Debug, Clone)]
+pub struct CompiledMatchArm {
+    /// Pattern that the scrutinee must satisfy.
+    pub pat: crate::parse::ast::Pat,
+    /// Optional guard expression; the arm fires only if it evaluates truthy.
+    pub guard: Option<Arc<Program>>,
+    /// Body program evaluated when the pattern matches and the guard passes.
+    pub body: Arc<Program>,
 }
 
 

--- a/jetro-core/src/vm/opcode.rs
+++ b/jetro-core/src/vm/opcode.rs
@@ -32,6 +32,12 @@ pub struct CompiledCall {
     pub name: Arc<str>,
     /// Pre-compiled sub-programs for each lambda/expression argument; shared via `Arc`.
     pub sub_progs: Arc<[Arc<Program>]>,
+    /// `BodyKernel`-classified form of each sub-program, computed once at
+    /// compile time. Higher-order builtins (`.filter`, `.map`, `.any`,
+    /// `.all`, `.find`, ...) consult this to dispatch the per-element
+    /// hot path through `eval_kernel` for native-speed Rust evaluation,
+    /// falling back to the `Program` arm for `BodyKernel::Generic`.
+    pub sub_kernels: Arc<[crate::exec::pipeline::BodyKernel]>,
     /// Original un-compiled arguments kept for lambda-param introspection at runtime.
     pub orig_args: Arc<[Arg]>,
     /// When set, `filter`/`map` may stop early after collecting this many results.

--- a/jetro-core/src/vm/opcode.rs
+++ b/jetro-core/src/vm/opcode.rs
@@ -339,6 +339,21 @@ pub enum Opcode {
     Match(Arc<CompiledMatch>),
 }
 
+/// Strategy for producing the scrutinee value of a compiled `match`
+/// expression. Most query authors write `match @ with { ... }` (matching
+/// the current row) or `match $.path with { ... }` (matching the
+/// document root or a navigation chain). The first two cases avoid VM
+/// re-entry by reading directly from the runtime environment.
+#[derive(Debug, Clone)]
+pub enum MatchScrutinee {
+    /// Read the current row from `Env::current` (the `@` token).
+    Current,
+    /// Read the document root from `Env::root` (the `$` token).
+    Root,
+    /// Evaluate an arbitrary scrutinee program against the current env.
+    Program(Arc<Program>),
+}
+
 /// Compiled representation of a `match scrutinee with { arms }` expression.
 /// Arms are lowered to a flat `MatchOp` instruction stream with explicit
 /// jumps between arms; each arm starts with `ResetArm`, which initialises
@@ -346,8 +361,8 @@ pub enum Opcode {
 /// separate `Program` pools indexed from the op stream.
 #[derive(Debug, Clone)]
 pub struct CompiledMatch {
-    /// Program that evaluates the value being matched.
-    pub scrutinee: Arc<Program>,
+    /// Strategy for evaluating the value being matched.
+    pub scrutinee: MatchScrutinee,
     /// Flat instruction stream describing arm tests, captures, guards, and bodies.
     pub ops: Arc<[MatchOp]>,
     /// Pool of pattern literals indexed by `MatchOp::LitEq.lit`.
@@ -365,6 +380,12 @@ pub struct CompiledMatch {
     /// run before the first `ResetArm`) can write into projection slots
     /// without underflow.
     pub max_slots: u16,
+    /// `true` when at least one arm has an unconditional catch-all
+    /// pattern (`_` or a bare `Bind`) with no guard. Tooling and
+    /// future analysers consume this flag; the runtime always produces
+    /// the same non-exhaustive error if every arm misses, regardless of
+    /// the flag value.
+    pub is_exhaustive: bool,
 }
 
 /// Slot identifier used by the match instruction stream. Slot 0 always
@@ -413,6 +434,22 @@ pub enum MatchOp {
         /// Index into `CompiledMatch::lits`.
         lit: u16,
         /// PC to jump to on inequality.
+        else_pc: u32,
+    },
+
+    /// Test that the value at `slot` is a number in the range `[lo, hi)`
+    /// when `inclusive == false`, or `[lo, hi]` when `inclusive == true`.
+    /// Non-numeric values fail and jump to `else_pc`.
+    RangeCheck {
+        /// Slot whose value is being range-tested.
+        slot: MatchSlot,
+        /// Lower bound (inclusive).
+        lo: f64,
+        /// Upper bound (semantics determined by `inclusive`).
+        hi: f64,
+        /// `true` when `hi` is inclusive (`..=` syntax).
+        inclusive: bool,
+        /// PC to jump to when the value is non-numeric or out of range.
         else_pc: u32,
     },
 

--- a/jetro-core/src/vm/opcode.rs
+++ b/jetro-core/src/vm/opcode.rs
@@ -552,6 +552,20 @@ pub enum MatchOp {
         dst: MatchSlot,
     },
 
+    /// Capture the object "rest" — every key/value pair on `src` whose
+    /// key is *not* present in `listed_keys` — into `dst` as a freshly
+    /// built `Val::Obj`. Emitted by the compiler when an object pattern
+    /// binds a named rest marker (`{a: x, ...rest}`).
+    LoadObjRest {
+        /// Source slot holding the object value.
+        src: MatchSlot,
+        /// Keys already covered by explicit pattern fields; excluded
+        /// from the captured rest object.
+        listed_keys: Arc<[Arc<str>]>,
+        /// Destination slot for the rest object.
+        dst: MatchSlot,
+    },
+
     /// Walk a tree-form sub-pattern at `subpat` against the value at `slot`,
     /// pushing any captured bindings into the arm's binding stack. Used for
     /// sub-patterns (currently `Or`) whose flat representation would expand

--- a/jetro-core/src/vm/opcode.rs
+++ b/jetro-core/src/vm/opcode.rs
@@ -337,6 +337,12 @@ pub enum Opcode {
     /// try each arm's pattern (and optional guard) in order, and run the body
     /// of the first matching arm with its bindings in scope.
     Match(Arc<CompiledMatch>),
+
+    /// Walk every descendant of the receiver in DFS pre-order, run the
+    /// compiled match against each, and collect every arm-body result
+    /// that is truthy. Falsy bodies and unmatched values (the trailing
+    /// `Fail`) are silently dropped. Pushes the resulting `Val::Arr`.
+    DeepMatchAll(Arc<CompiledMatch>),
 }
 
 /// Strategy for producing the scrutinee value of a compiled `match`

--- a/jetro-core/src/vm/opcode.rs
+++ b/jetro-core/src/vm/opcode.rs
@@ -340,27 +340,184 @@ pub enum Opcode {
 }
 
 /// Compiled representation of a `match scrutinee with { arms }` expression.
-/// Patterns are stored unflattened; the runtime walks them directly. Arm
-/// bodies and guards are pre-compiled to `Program`s so they can be re-used
-/// across invocations.
+/// Arms are lowered to a flat `MatchOp` instruction stream with explicit
+/// jumps between arms; each arm starts with `ResetArm`, which initialises
+/// its local slot space and binding cursor. Bodies and guards are stored as
+/// separate `Program` pools indexed from the op stream.
 #[derive(Debug, Clone)]
 pub struct CompiledMatch {
     /// Program that evaluates the value being matched.
     pub scrutinee: Arc<Program>,
-    /// Ordered arm list; first matching arm wins.
-    pub arms: Arc<[CompiledMatchArm]>,
+    /// Flat instruction stream describing arm tests, captures, guards, and bodies.
+    pub ops: Arc<[MatchOp]>,
+    /// Pool of pattern literals indexed by `MatchOp::LitEq.lit`.
+    pub lits: Arc<[crate::parse::ast::PatLit]>,
+    /// Pool of compiled guard sub-programs indexed by `MatchOp::Guard.prog`.
+    pub guards: Arc<[Arc<Program>]>,
+    /// Pool of compiled body sub-programs indexed by `MatchOp::Body.prog`.
+    pub bodies: Arc<[Arc<Program>]>,
+    /// Pool of free-standing `Pat` nodes referenced from `MatchOp::TestSubPat`,
+    /// used for sub-patterns whose runtime test is more economical to walk
+    /// recursively than to flatten (currently `Pat::Or`).
+    pub subpats: Arc<[crate::parse::ast::Pat]>,
+    /// Maximum number of slots any prelude or arm needs at once. The VM
+    /// pre-sizes its slot vector to this value so that prelude ops (which
+    /// run before the first `ResetArm`) can write into projection slots
+    /// without underflow.
+    pub max_slots: u16,
 }
 
-/// One compiled arm of a `match` expression, including the pattern, the
-/// optional guard expression, and the body to evaluate on a successful match.
+/// Slot identifier used by the match instruction stream. Slot 0 always
+/// holds the scrutinee; subsequent slots hold sub-projections produced by
+/// `LoadField` / `LoadIndex` / `LoadTail`. Slot space is reset at the
+/// start of each arm via `ResetArm`.
+pub type MatchSlot = u16;
+
+/// Single instruction of the flat match decision machine.
+///
+/// Execution model: a program counter walks `ops` left to right; each
+/// failing test or load jumps to the start of the next arm (or to the
+/// trailing `Fail` if no arm remains). Successful tests fall through to the
+/// next instruction. `Body` terminates the loop with the body's evaluated
+/// result; `Fail` raises a non-exhaustive-match error.
 #[derive(Debug, Clone)]
-pub struct CompiledMatchArm {
-    /// Pattern that the scrutinee must satisfy.
-    pub pat: crate::parse::ast::Pat,
-    /// Optional guard expression; the arm fires only if it evaluates truthy.
-    pub guard: Option<Arc<Program>>,
-    /// Body program evaluated when the pattern matches and the guard passes.
-    pub body: Arc<Program>,
+pub enum MatchOp {
+    /// Mark the start of a new arm. Clears the binding stack and grows
+    /// the slot vector to `slots`. Slots in the range `0..keep_above` are
+    /// preserved across arm boundaries; slots at or above `keep_above`
+    /// are zeroed. `keep_above >= 1` always — slot 0 (scrutinee) is
+    /// always preserved. Values greater than 1 are used by cross-arm
+    /// prefix sharing to retain sub-projections (e.g. an object key's
+    /// loaded value) across all arms participating in the shared prefix.
+    ResetArm {
+        /// Number of slots this arm requires (including slot 0).
+        slots: u16,
+        /// Number of leading slots whose contents must be preserved.
+        keep_above: u16,
+    },
+
+    /// Verify the value at `slot` has runtime kind `kind`; jump on miss.
+    KindCheck {
+        /// Slot whose value is being kind-checked.
+        slot: MatchSlot,
+        /// Target kind.
+        kind: crate::parse::ast::KindType,
+        /// PC to jump to when the value is not of `kind`.
+        else_pc: u32,
+    },
+
+    /// Compare the value at `slot` against literal pool entry `lit`; jump on miss.
+    LitEq {
+        /// Slot whose value is being compared.
+        slot: MatchSlot,
+        /// Index into `CompiledMatch::lits`.
+        lit: u16,
+        /// PC to jump to on inequality.
+        else_pc: u32,
+    },
+
+    /// Verify the value at `slot` is an object (any object representation); jump on miss.
+    ObjCheck {
+        /// Slot expected to hold an object value.
+        slot: MatchSlot,
+        /// PC to jump to when the value is not an object.
+        else_pc: u32,
+    },
+
+    /// Look up `key` in the object value at `src` and store the result into
+    /// `dst`. On a missing key (any object representation) jump to `else_pc`.
+    LoadField {
+        /// Source slot holding the parent object.
+        src: MatchSlot,
+        /// Object key being projected.
+        key: Arc<str>,
+        /// Destination slot for the projected value.
+        dst: MatchSlot,
+        /// PC to jump to when `key` is absent.
+        else_pc: u32,
+    },
+
+    /// Verify array length at `slot`. When `exact`, must equal `len`;
+    /// otherwise must be `>= len`. Accepts any array-like representation.
+    LenCheck {
+        /// Slot expected to hold an array-like value.
+        slot: MatchSlot,
+        /// Required length / minimum length.
+        len: u32,
+        /// `true` for exact length, `false` for `>=` (used with rest patterns).
+        exact: bool,
+        /// PC to jump to when the length test fails.
+        else_pc: u32,
+    },
+
+    /// Read element at `idx` from the array-like value at `src` and store
+    /// it into `dst`. Caller is responsible for emitting a preceding `LenCheck`.
+    LoadIndex {
+        /// Source slot holding the array-like value.
+        src: MatchSlot,
+        /// Zero-based array index to project.
+        idx: u32,
+        /// Destination slot for the projected element.
+        dst: MatchSlot,
+    },
+
+    /// Capture the array tail starting at `from` from the value at `src`
+    /// into `dst` as a freshly-built `Val::Arr`.
+    LoadTail {
+        /// Source slot holding the array-like value.
+        src: MatchSlot,
+        /// First index included in the captured tail.
+        from: u32,
+        /// Destination slot for the tail array.
+        dst: MatchSlot,
+    },
+
+    /// Walk a tree-form sub-pattern at `subpat` against the value at `slot`,
+    /// pushing any captured bindings into the arm's binding stack. Used for
+    /// sub-patterns (currently `Or`) whose flat representation would expand
+    /// the op stream more than a recursive walk.
+    TestSubPat {
+        /// Slot whose value is being tested.
+        slot: MatchSlot,
+        /// Index into `CompiledMatch::subpats`.
+        subpat: u16,
+        /// PC to jump to on test failure.
+        else_pc: u32,
+    },
+
+    /// Push a binding onto the arm's binding stack: `name` = value at `slot`.
+    Bind {
+        /// Variable name introduced into the arm body's scope.
+        name: Arc<str>,
+        /// Slot whose value is captured.
+        slot: MatchSlot,
+    },
+
+    /// Run guard sub-program at `prog`; jump on falsy / errored result.
+    Guard {
+        /// Index into `CompiledMatch::guards`.
+        prog: u16,
+        /// PC to jump to when the guard fails.
+        else_pc: u32,
+    },
+
+    /// Run body sub-program at `prog` with the arm's bindings in scope and
+    /// terminate match evaluation with its result.
+    Body {
+        /// Index into `CompiledMatch::bodies`.
+        prog: u16,
+    },
+
+    /// Raise a non-exhaustive-match error. Emitted as the trailing op so a
+    /// failed scan over every arm lands here.
+    Fail,
+
+    /// Unconditional jump to `target_pc`. Used by literal or-pattern
+    /// cascades to skip remaining alternatives once one has matched.
+    Jump {
+        /// Absolute PC to jump to.
+        target_pc: u32,
+    },
 }
 
 

--- a/jetro-core/src/vm/opcode.rs
+++ b/jetro-core/src/vm/opcode.rs
@@ -343,6 +343,12 @@ pub enum Opcode {
     /// that is truthy. Falsy bodies and unmatched values (the trailing
     /// `Fail`) are silently dropped. Pushes the resulting `Val::Arr`.
     DeepMatchAll(Arc<CompiledMatch>),
+
+    /// Like `DeepMatchAll` but stops at the first descendant whose
+    /// match produces a truthy arm-body result. Pushes the body
+    /// directly (not wrapped in an array); pushes `Val::Null` when no
+    /// descendant matches.
+    DeepMatchFirst(Arc<CompiledMatch>),
 }
 
 /// Strategy for producing the scrutinee value of a compiled `match`
@@ -392,6 +398,37 @@ pub struct CompiledMatch {
     /// the same non-exhaustive error if every arm misses, regardless of
     /// the flag value.
     pub is_exhaustive: bool,
+    /// Shape summary describing what the structural backend can serve
+    /// from a bitmap index without touching the document body. `None`
+    /// means the match has no exploitable structure (mixed shapes,
+    /// guard-only arms, etc.) and the runtime walks every descendant
+    /// directly.
+    pub shape_summary: Option<MatchShapeSummary>,
+}
+
+/// Compile-time summary of a `match`'s arm shapes, used by deep-search
+/// (`..match`) dispatch to pre-filter candidates via a structural
+/// bitmap before running the per-arm pattern test.
+#[derive(Debug, Clone)]
+pub enum MatchShapeSummary {
+    /// Every arm is a `Pat::Obj` and the union of leading keys across
+    /// arms is the listed set. A document node qualifies as a candidate
+    /// when it is an object containing *any* of these keys; the per-arm
+    /// runtime then narrows further.
+    ObjAnyOfKeys(Arc<[Arc<str>]>),
+    /// Every arm tests the same scalar kind. Non-matching kinds can
+    /// be skipped entirely.
+    KindOnly(crate::parse::ast::KindType),
+    /// Every arm tests a numeric range. The union range is the smallest
+    /// interval covering all per-arm bounds.
+    NumericRange {
+        /// Lower bound across all arms (inclusive).
+        lo: f64,
+        /// Upper bound across all arms.
+        hi: f64,
+        /// `true` when the upper bound is inclusive (any arm uses `..=`).
+        inclusive: bool,
+    },
 }
 
 /// Slot identifier used by the match instruction stream. Slot 0 always

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
 ## Summary

  Adds pattern matching to Jetro and extends the demand-propagation infrastructure.

  This introduces `match scrutinee with { pat -> body, ... }` expressions, deep `$..match`
  traversal, VM/runtime support for compiled match decision programs, and documentation/tests/
  benchmarks for the new pattern language. It also moves demand propagation into a shared planner
  module and wires additional builtin demand behavior through builtin metadata.

  ## Changes

  - Add `match ... with { ... }` expression syntax with ordered first-match semantics.
  - Add pattern forms for wildcard, literals, bindings, kind checks, object/array patterns, rest
  captures, or-patterns, and numeric ranges.
  - Add guarded arms via `when`.
  - Add `$..match { ... }` and `$..match! { ... }` for deep structural search and early-stop
  matching.
  - Add parser validation for pattern binding linearity, with optional strict exhaustiveness lint
  via `JETRO_STRICT_MATCH=1`.
  - Compile match expressions into a flat VM decision program with shared-prefix optimizations.
  - Add view-domain match execution and structural-index-backed deep-match dispatch.
  - Document pattern matching in README, SYNTAX, CHANGELOG, and benchmark notes.
  - Add pattern-match regression coverage and Criterion benchmark harness.
  - Move shared demand primitives into `plan/demand.rs`.
  - Extend demand metadata for match-shaped chains plus filter-like builtins such as `compact`,
  literal `remove`, and `find_first`.

  ## Notes

  - New reserved keywords: `match`, `with`.
  - `$..match` can use structural bitmap candidates when arm patterns share object-key prefixes.
  - Demand propagation remains metadata-driven; no handwritten `map_last`/`filter_first` style
  fusion was added.