### PR TITLE
[bugfix/improvements] lambda lowering and demand-aware view execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 0.5.3
+
+### Lambda
+
+- AST-level single-param lambda lowering: `r => r.id` and `lambda r: r.id`
+  emit byte-identical opcodes to the equivalent `@`-form. Kernel
+  classification (`FieldRead`, `FieldChain`, `FString`, `Object`,
+  `FieldCmpLit`, …) fires uniformly across all forms.
+- Multi-param fast path: rightmost param substituted to `Current` so
+  comparator and binary-HOF bodies skip one `LoadIdent` per row.
+- `Opcode::BindLamCurrent` for nested-lambda outer-param refs: emitted
+  only when an inner lambda body reads the outer param. One env clone +
+  `push_lam` / `pop_lam` per outer row, never per inner element.
+- Kernel fast path no longer gates on `lam_param.is_none()` —
+  single-param named lambdas hit the same Rust kernels as `@`-form.
+- `push_lam` skips the unused-name binding when the AST substitution
+  has removed every reference, dropping one env-var insert/remove per
+  row across HOFs.
+- First-class lambdas via let-bound macro expansion:
+  `let f = (x => x*2) in $.xs.map(f)` desugars at parse time. Aliased
+  chains (`let g = f`) supported. Method-arg position only.
+
+### Engine
+
+- Filter-pushdown over arithmetic projections fixed: `FilterBeforeMap`
+  optimizer rewrites the pushed-down predicate via
+  `substitute_current_with_expr(predicate, projection)` so the swapped
+  filter sees source rows but tests the same mapped value the original
+  placement would have observed.
+- `normalize_symbolic` unwraps single-param `Expr::Lambda` wrappers
+  before threading them through symbolic substitution, so vm and
+  engine paths agree on lambda-bearing pipelines.
+- `compile_stage_expr` no longer re-unwraps lambdas; the symbolic pass
+  owns that responsibility (prevents corruption of
+  `r => (x => x)`-style outer-Lambda-wrapping-inner-Lambda bodies).
+- `.sort((a, b) => …)` engine path: pipeline lowering bails out on
+  multi-param lambda args so the router falls back to VM
+  `sort_comparator_apply`.
+- VM `Opcode::DynIndex` accepts `Val::StrSlice` keys (simd-json tape
+  paths) — previously fell through to `Val::Null` for borrowed strings.
+
+### Builtins
+
+- `.find(pred)` returns the first match (conventional first-match
+  semantics) and `Val::Null` when nothing matches. `.find_all(pred)`
+  keeps the previous filter-alias semantics. Spec migrated to
+  `BuiltinPipelineLowering::TerminalExprArg { terminal: First }`; VM
+  dispatch routes `Find | FindFirst` through `find_first_apply`.
+
 ## 0.5.2 — unreleased
 
 ### Pattern Matching

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "jetro"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "jetro-core",
  "serde_json",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "jetro-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["jetro-core/fuzz"]
 
 [package]
 name = "jetro"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["Milad (Mike) Taghavi <mitghi.at.me.com>"]
 license = "MIT"
@@ -18,7 +18,7 @@ keywords = ["json-search", "json-query", "json-path", "jmespath", "serde"]
 categories = ["algorithms", "encoding"]
 
 [dependencies]
-jetro-core   = { path = "jetro-core", version = "0.5.1" }
+jetro-core   = { path = "jetro-core", version = "0.5.3" }
 serde_json   = "1.0.102"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ assert_eq!(report, json!({
 
 ```toml
 [dependencies]
-jetro = "0.4"
+jetro = "0.5.3"
 ```
 
 ## API

--- a/jetro-core/Cargo.toml
+++ b/jetro-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jetro-core"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["Milad (Mike) Taghavi <mitghi.at.me.com>"]
 license = "MIT"

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -26,22 +26,13 @@ fn numeric_reducer_spec(reducer: BuiltinNumericReducer) -> BuiltinSpec {
         .lowering(BuiltinPipelineLowering::TerminalSink)
 }
 
-/// Predicate-driven barrier reducer skeleton (IndicesWhere / MaxBy / MinBy).
+/// Arg-extreme reducer (`max_by` / `min_by`) skeleton.
 #[inline]
-fn predicate_reducer_spec() -> BuiltinSpec {
+fn arg_extreme_reducer_spec() -> BuiltinSpec {
     BuiltinSpec::new(BuiltinCategory::Reducer, BuiltinCardinality::Reducing)
         .view_native()
         .cost(10.0)
-        .materialization(BuiltinPipelineMaterialization::LegacyMaterialized)
-        .pipeline_shape(BuiltinPipelineShape::new(
-            BuiltinCardinality::OneToOne,
-            true,
-            1.0,
-            1.0,
-        ))
-        .lowering(BuiltinPipelineLowering::TerminalExprArg {
-            terminal: BuiltinMethod::First,
-        })
+        .lowering(BuiltinPipelineLowering::TerminalSink)
 }
 
 /// Predicate terminal sink skeleton for short-circuiting reducers.
@@ -788,7 +779,7 @@ impl Builtin for MaxBy {
     const NAME: &'static str = "max_by";
 
     fn spec() -> BuiltinSpec {
-        predicate_reducer_spec()
+        arg_extreme_reducer_spec()
     }
 
     #[inline]
@@ -808,7 +799,7 @@ impl Builtin for MinBy {
     const NAME: &'static str = "min_by";
 
     fn spec() -> BuiltinSpec {
-        predicate_reducer_spec()
+        arg_extreme_reducer_spec()
     }
 
     #[inline]

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -107,14 +107,22 @@ impl Builtin for Filter {
     }
 }
 
-/// Surface alias of `Filter` (same semantics; user-facing v2 name).
+/// `find(pred)` — returns the first element for which `pred` is truthy,
+/// or `null` when nothing matches. Matches the conventional first-match
+/// semantics found in JavaScript / Rust / Python iterators. Use
+/// `find_all` (filter alias) when every match is desired.
 pub(crate) struct Find;
 impl Builtin for Find {
     const METHOD: BuiltinMethod = BuiltinMethod::Find;
     const NAME: &'static str = "find";
 
     fn spec() -> BuiltinSpec {
-        filter_spec()
+        BuiltinSpec::new(BuiltinCategory::StreamingFilter, BuiltinCardinality::Filtering)
+            .cost(10.0)
+            .demand_law(BuiltinDemandLaw::FilterLike)
+            .lowering(BuiltinPipelineLowering::TerminalExprArg {
+                terminal: BuiltinMethod::First,
+            })
     }
 }
 

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -2827,7 +2827,6 @@ macro_rules! str_arg_scalar_native {
 
 str_arg_scalar_native! {
     Has, "has", has_apply;
-    HasKey, "has_key", has_apply;
     StripPrefix, "strip_prefix", strip_prefix_apply;
     StripSuffix, "strip_suffix", strip_suffix_apply;
     Scan, "scan", scan_apply;
@@ -2835,6 +2834,26 @@ str_arg_scalar_native! {
     ReMatchFirst, "match_first", re_match_first_apply;
     ReMatchAll, "match_all", re_match_all_apply;
     ReCaptures, "captures", re_captures_apply;
+}
+
+/// `has_key(key)` — object key existence test with a view/tape-native backend.
+pub(crate) struct HasKey;
+impl Builtin for HasKey {
+    const METHOD: BuiltinMethod = BuiltinMethod::HasKey;
+    const NAME: &'static str = "has_key";
+    fn spec() -> BuiltinSpec {
+        scalar_native_element_spec().view_scalar()
+    }
+    #[inline]
+    fn apply_args(
+        recv: &crate::data::value::Val,
+        args: &super::BuiltinArgs,
+    ) -> Option<crate::data::value::Val> {
+        match args {
+            super::BuiltinArgs::Str(p) => Some(super::has_apply(recv, p).unwrap_or_else(|| recv.clone())),
+            _ => None,
+        }
+    }
 }
 
 // ── More multi-arg scalar element methods ──

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -2827,6 +2827,7 @@ macro_rules! str_arg_scalar_native {
 
 str_arg_scalar_native! {
     Has, "has", has_apply;
+    HasKey, "has_key", has_apply;
     StripPrefix, "strip_prefix", strip_prefix_apply;
     StripSuffix, "strip_suffix", strip_suffix_apply;
     Scan, "scan", scan_apply;

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -711,7 +711,7 @@ impl Builtin for IndicesWhere {
     const NAME: &'static str = "indices_where";
 
     fn spec() -> BuiltinSpec {
-        predicate_reducer_spec()
+        predicate_terminal_sink_spec()
     }
 
     #[inline]

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -2583,7 +2583,10 @@ impl Builtin for Includes {
     const METHOD: BuiltinMethod = BuiltinMethod::Includes;
     const NAME: &'static str = "includes";
     const ALIASES: &'static [&'static str] = &["contains"];
-    fn spec() -> BuiltinSpec { default_scalar_spec(BuiltinMethod::Includes) }
+    fn spec() -> BuiltinSpec {
+        default_scalar_spec(BuiltinMethod::Includes)
+            .lowering(BuiltinPipelineLowering::TerminalSink)
+    }
     #[inline]
     fn apply_args(recv: &crate::data::value::Val, args: &super::BuiltinArgs) -> Option<crate::data::value::Val> {
         match args {
@@ -2598,7 +2601,9 @@ pub(crate) struct Index;
 impl Builtin for Index {
     const METHOD: BuiltinMethod = BuiltinMethod::Index;
     const NAME: &'static str = "index";
-    fn spec() -> BuiltinSpec { default_scalar_spec(BuiltinMethod::Index) }
+    fn spec() -> BuiltinSpec {
+        default_scalar_spec(BuiltinMethod::Index).lowering(BuiltinPipelineLowering::TerminalSink)
+    }
     #[inline]
     fn apply_args(recv: &crate::data::value::Val, args: &super::BuiltinArgs) -> Option<crate::data::value::Val> {
         match args {
@@ -2613,7 +2618,10 @@ pub(crate) struct IndicesOf;
 impl Builtin for IndicesOf {
     const METHOD: BuiltinMethod = BuiltinMethod::IndicesOf;
     const NAME: &'static str = "indices_of";
-    fn spec() -> BuiltinSpec { default_scalar_spec(BuiltinMethod::IndicesOf) }
+    fn spec() -> BuiltinSpec {
+        default_scalar_spec(BuiltinMethod::IndicesOf)
+            .lowering(BuiltinPipelineLowering::TerminalSink)
+    }
     #[inline]
     fn apply_args(recv: &crate::data::value::Val, args: &super::BuiltinArgs) -> Option<crate::data::value::Val> {
         match args {

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -490,6 +490,7 @@ impl Builtin for DropWhile {
         BuiltinSpec::new(BuiltinCategory::StreamingFilter, BuiltinCardinality::Filtering)
             .view_stage(BuiltinViewStage::DropWhile)
             .cost(10.0)
+            .demand_law(BuiltinDemandLaw::DropWhile)
             .materialization(BuiltinPipelineMaterialization::LegacyMaterialized)
             .pipeline_shape(BuiltinPipelineShape::new(
                 BuiltinCardinality::Filtering,
@@ -1477,7 +1478,7 @@ impl Builtin for Reverse {
         BuiltinSpec::new(BuiltinCategory::Barrier, BuiltinCardinality::Barrier)
             .cost(10.0)
             .cancellation(BuiltinCancellation::SelfInverse(BuiltinCancelGroup::Reverse))
-            .demand_law(BuiltinDemandLaw::OrderBarrier)
+            .demand_law(BuiltinDemandLaw::Reverse)
             .materialization(BuiltinPipelineMaterialization::ComposedBarrier)
             .lowering(BuiltinPipelineLowering::Nullary)
     }

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -995,7 +995,7 @@ impl Builtin for FindFirst {
     }
 }
 
-/// `find_one(pred)` — terminal expr-arg without demand annotation.
+/// `find_one(pred)` — terminal predicate sink requiring exactly one match.
 pub(crate) struct FindOne;
 impl Builtin for FindOne {
     const METHOD: BuiltinMethod = BuiltinMethod::FindOne;
@@ -1003,9 +1003,7 @@ impl Builtin for FindOne {
     fn spec() -> BuiltinSpec {
         BuiltinSpec::new(BuiltinCategory::StreamingFilter, BuiltinCardinality::Filtering)
             .cost(10.0)
-            .lowering(BuiltinPipelineLowering::TerminalExprArg {
-                terminal: BuiltinMethod::First,
-            })
+            .lowering(BuiltinPipelineLowering::TerminalSink)
     }
 }
 

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -2470,6 +2470,7 @@ impl Builtin for Slice {
                 1.0,
             ))
             .order_effect(BuiltinPipelineOrderEffect::Preserves)
+            .demand_law(BuiltinDemandLaw::Slice)
             .lowering(BuiltinPipelineLowering::IntRangeArg)
     }
     #[inline]

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -1633,7 +1633,12 @@ impl Builtin for ZipShape {
 
 #[inline]
 fn object_element_spec() -> BuiltinSpec {
-    BuiltinSpec::new(BuiltinCategory::Object, BuiltinCardinality::OneToOne).element()
+    BuiltinSpec::new(BuiltinCategory::Object, BuiltinCardinality::OneToOne)
+        .view_scalar()
+        .demand_law(BuiltinDemandLaw::MapLike)
+        .order_effect(BuiltinPipelineOrderEffect::Preserves)
+        .lowering(BuiltinPipelineLowering::Nullary)
+        .element()
 }
 
 /// `keys` — extract keys of an object (element-wise).
@@ -1718,7 +1723,13 @@ pub(crate) struct Pick;
 impl Builtin for Pick {
     const METHOD: BuiltinMethod = BuiltinMethod::Pick;
     const NAME: &'static str = "pick";
-    fn spec() -> BuiltinSpec { object_simple_spec() }
+    fn spec() -> BuiltinSpec {
+        object_simple_spec()
+            .view_scalar()
+            .demand_law(BuiltinDemandLaw::MapLike)
+            .order_effect(BuiltinPipelineOrderEffect::Preserves)
+            .element()
+    }
     #[inline]
     fn apply_args(recv: &crate::data::value::Val, args: &super::BuiltinArgs) -> Option<crate::data::value::Val> {
         match args {
@@ -1733,7 +1744,13 @@ pub(crate) struct Omit;
 impl Builtin for Omit {
     const METHOD: BuiltinMethod = BuiltinMethod::Omit;
     const NAME: &'static str = "omit";
-    fn spec() -> BuiltinSpec { object_simple_spec() }
+    fn spec() -> BuiltinSpec {
+        object_simple_spec()
+            .view_scalar()
+            .demand_law(BuiltinDemandLaw::MapLike)
+            .order_effect(BuiltinPipelineOrderEffect::Preserves)
+            .element()
+    }
     #[inline]
     fn apply_args(recv: &crate::data::value::Val, args: &super::BuiltinArgs) -> Option<crate::data::value::Val> {
         match args {

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -1129,6 +1129,7 @@ impl Builtin for Window {
                 2.0,
                 1.0,
             ))
+            .demand_law(BuiltinDemandLaw::Window)
             .lowering(BuiltinPipelineLowering::UsizeArg { min: 1 })
     }
 
@@ -1159,6 +1160,7 @@ impl Builtin for Chunk {
                 2.0,
                 1.0,
             ))
+            .demand_law(BuiltinDemandLaw::Chunk)
             .lowering(BuiltinPipelineLowering::UsizeArg { min: 1 })
     }
 

--- a/jetro-core/src/builtins/defs.rs
+++ b/jetro-core/src/builtins/defs.rs
@@ -26,7 +26,7 @@ fn numeric_reducer_spec(reducer: BuiltinNumericReducer) -> BuiltinSpec {
         .lowering(BuiltinPipelineLowering::TerminalSink)
 }
 
-/// Predicate-driven reducer-with-take-first skeleton (FindIndex / IndicesWhere / MaxBy / MinBy).
+/// Predicate-driven barrier reducer skeleton (IndicesWhere / MaxBy / MinBy).
 #[inline]
 fn predicate_reducer_spec() -> BuiltinSpec {
     BuiltinSpec::new(BuiltinCategory::Reducer, BuiltinCardinality::Reducing)
@@ -42,6 +42,15 @@ fn predicate_reducer_spec() -> BuiltinSpec {
         .lowering(BuiltinPipelineLowering::TerminalExprArg {
             terminal: BuiltinMethod::First,
         })
+}
+
+/// Predicate terminal sink skeleton for short-circuiting reducers.
+#[inline]
+fn predicate_terminal_sink_spec() -> BuiltinSpec {
+    BuiltinSpec::new(BuiltinCategory::Reducer, BuiltinCardinality::Reducing)
+        .view_native()
+        .cost(10.0)
+        .lowering(BuiltinPipelineLowering::TerminalSink)
 }
 
 // ── Streaming filters ────────────────────────────────────────────────────────
@@ -640,6 +649,7 @@ impl Builtin for Any {
         BuiltinSpec::new(BuiltinCategory::Reducer, BuiltinCardinality::Reducing)
             .view_native()
             .cost(10.0)
+            .lowering(BuiltinPipelineLowering::TerminalSink)
     }
 }
 
@@ -653,6 +663,7 @@ impl Builtin for All {
         BuiltinSpec::new(BuiltinCategory::Reducer, BuiltinCardinality::Reducing)
             .view_native()
             .cost(10.0)
+            .lowering(BuiltinPipelineLowering::TerminalSink)
     }
 }
 
@@ -663,7 +674,7 @@ impl Builtin for FindIndex {
     const NAME: &'static str = "find_index";
 
     fn spec() -> BuiltinSpec {
-        predicate_reducer_spec()
+        predicate_terminal_sink_spec()
     }
 
     #[inline]

--- a/jetro-core/src/builtins/mod.rs
+++ b/jetro-core/src/builtins/mod.rs
@@ -221,6 +221,8 @@ pub enum BuiltinMethod {
     Or,
     /// Returns true if the object contains the given key.
     Has,
+    /// Returns true if the object contains the given key.
+    HasKey,
     /// Returns true if a field path is absent or null in the receiver.
     Missing,
     /// Returns true if the array/string/object contains the given item.
@@ -414,8 +416,8 @@ macro_rules! for_each_builtin {
             DropWhile, EndsWith, Entries, Enumerate, EquiJoin, Explode, Fanout, Filter,
             FilterKeys, FilterValues, Find, FindAll, FindFirst, FindIndex, FindOne, First,
             FlatMap, Flatten, FlattenKeys, Floor, FromBase64, FromJson, FromPairs, GetPath,
-            GroupBy, GroupShape, Has, HasPath, HtmlEscape, HtmlUnescape, Implode, Includes,
-            Indent, Index, IndexBy, IndexOf, IndicesOf, IndicesWhere, Intersect, Invert,
+            GroupBy, GroupShape, Has, HasKey, HasPath, HtmlEscape, HtmlUnescape, Implode,
+            Includes, Indent, Index, IndexBy, IndexOf, IndicesOf, IndicesWhere, Intersect, Invert,
             IsAlpha, IsAscii, IsBlank, IsNumeric, Join, KebabCase, Keys, Lag, Last,
             LastIndexOf, Lead, Len, Lines, Lower, Map, Matches, Max, MaxBy, Merge, Min,
             MinBy, Missing, Nth, Omit, Or, PadLeft, PadRight, Pairwise, ParseBool,
@@ -1591,7 +1593,9 @@ impl BuiltinCall {
             (BuiltinMethod::Implode, BuiltinArgs::Str(field)) => {
                 apply_or_recv!(implode_apply(recv, field))
             }
-            (BuiltinMethod::Has, BuiltinArgs::Str(k)) => apply_or_recv!(has_apply(recv, k)),
+            (BuiltinMethod::Has | BuiltinMethod::HasKey, BuiltinArgs::Str(k)) => {
+                apply_or_recv!(has_apply(recv, k))
+            }
             (BuiltinMethod::GetPath, BuiltinArgs::Str(p)) => {
                 apply_or_recv!(get_path_apply(recv, p))
             }
@@ -1833,6 +1837,7 @@ impl BuiltinCall {
             BuiltinMethod::GetPath
             | BuiltinMethod::HasPath
             | BuiltinMethod::Has
+            | BuiltinMethod::HasKey
             | BuiltinMethod::Join
             | BuiltinMethod::Explode
             | BuiltinMethod::Implode
@@ -2643,6 +2648,7 @@ where
         BuiltinMethod::GetPath
         | BuiltinMethod::HasPath
         | BuiltinMethod::Has
+        | BuiltinMethod::HasKey
         | BuiltinMethod::Missing
         | BuiltinMethod::Explode
         | BuiltinMethod::Implode

--- a/jetro-core/src/builtins/mod.rs
+++ b/jetro-core/src/builtins/mod.rs
@@ -649,6 +649,8 @@ pub enum BuiltinDemandLaw {
     FilterLike,
     /// Like `take_while`: stops at the first predicate failure, so `UntilOutput(n)` becomes `FirstInput(n)`.
     TakeWhile,
+    /// Like `drop_while`: prefix predicate barrier; safe upstream demand is a full ordered scan.
+    DropWhile,
     /// Like `unique`/`unique_by`: scan until enough distinct outputs are observed.
     UniqueLike,
     /// Like map: the output count equals the input count; passes demand through but requires whole values.
@@ -673,6 +675,8 @@ pub enum BuiltinDemandLaw {
     KeyedReducer,
     /// A full-input ordering barrier; downstream limits can choose strategy, but source scan remains all input.
     OrderBarrier,
+    /// Reverses one-to-one output order, swapping first/last positional demand.
+    Reverse,
 }
 
 /// Marker that a builtin has a structural (index-based) execution backend.

--- a/jetro-core/src/builtins/mod.rs
+++ b/jetro-core/src/builtins/mod.rs
@@ -2361,7 +2361,10 @@ where
             }
             return Ok(Val::Int(n));
         }
-        BuiltinMethod::Find | BuiltinMethod::FindAll => {
+        BuiltinMethod::Find | BuiltinMethod::FindFirst => {
+            return find_first_apply(recv, args.len(), |item, idx| eval_item(item, &args[idx]));
+        }
+        BuiltinMethod::FindAll => {
             return find_apply(recv, args.len(), |item, idx| eval_item(item, &args[idx]));
         }
         BuiltinMethod::FindIndex => {

--- a/jetro-core/src/builtins/mod.rs
+++ b/jetro-core/src/builtins/mod.rs
@@ -1887,6 +1887,13 @@ impl BuiltinCall {
             BuiltinMethod::ContainsAny | BuiltinMethod::ContainsAll => {
                 Self::new(method, BuiltinArgs::StrVec(args.str_vec(0)?))
             }
+            BuiltinMethod::Omit => {
+                let mut keys = Vec::with_capacity(arg_len);
+                for idx in 0..arg_len {
+                    keys.push(args.str(idx)?);
+                }
+                Self::new(method, BuiltinArgs::StrVec(keys))
+            }
             BuiltinMethod::Repeat => Self::new(method, BuiltinArgs::Usize(args.usize(0)?)),
             BuiltinMethod::Indent => {
                 let n = if arg_len > 0 { args.usize(0)? } else { 2 };

--- a/jetro-core/src/builtins/mod.rs
+++ b/jetro-core/src/builtins/mod.rs
@@ -153,7 +153,7 @@ pub enum BuiltinMethod {
     DropWhile,
     /// Returns the first element satisfying the predicate, or null.
     FindFirst,
-    /// Alias of `find_first`.
+    /// Returns the only element satisfying the predicate, erroring on zero or multiple matches.
     FindOne,
     /// Counts approximate distinct values using a HyperLogLog-style sketch.
     ApproxCountDistinct,

--- a/jetro-core/src/builtins/mod.rs
+++ b/jetro-core/src/builtins/mod.rs
@@ -663,6 +663,10 @@ pub enum BuiltinDemandLaw {
     Take,
     /// Shift the upstream pull window by the provided count argument.
     Skip,
+    /// Fixed-size chunking; bounded output demand maps to a bounded input prefix.
+    Chunk,
+    /// Sliding window; bounded output demand maps to a bounded input prefix.
+    Window,
     /// Only the first element is needed; translates any downstream demand to `FirstInput(1)`.
     First,
     /// The last element is needed; requires all ordered input.

--- a/jetro-core/src/builtins/mod.rs
+++ b/jetro-core/src/builtins/mod.rs
@@ -655,6 +655,8 @@ pub enum BuiltinDemandLaw {
     UniqueLike,
     /// Like map: the output count equals the input count; passes demand through but requires whole values.
     MapLike,
+    /// Like scalar `slice`: one-to-one and order-preserving, but consumes the whole input value.
+    Slice,
     /// Like `flat_map`: output count is unbounded relative to input, so always requests all input.
     FlatMapLike,
     /// Cap the upstream pull to the provided count argument.

--- a/jetro-core/src/builtins/ops/array.rs
+++ b/jetro-core/src/builtins/ops/array.rs
@@ -1040,34 +1040,43 @@ where
 /// Returns an array of every key in the object, or an empty array for non-objects.
 #[inline]
 pub fn keys_apply(recv: &Val) -> Val {
-    Val::arr(
-        recv.as_object()
-            .map(|m| m.keys().map(|k| Val::Str(k.clone())).collect())
-            .unwrap_or_default(),
-    )
+    match recv {
+        Val::Obj(m) => Val::arr(m.keys().map(|k| Val::Str(k.clone())).collect()),
+        Val::ObjSmall(pairs) => Val::arr(
+            pairs
+                .iter()
+                .map(|(key, _)| Val::Str(key.clone()))
+                .collect(),
+        ),
+        _ => Val::arr(Vec::new()),
+    }
 }
 
 /// Returns an array of every value in the object, or an empty array for non-objects.
 #[inline]
 pub fn values_apply(recv: &Val) -> Val {
-    Val::arr(
-        recv.as_object()
-            .map(|m| m.values().cloned().collect())
-            .unwrap_or_default(),
-    )
+    match recv {
+        Val::Obj(m) => Val::arr(m.values().cloned().collect()),
+        Val::ObjSmall(pairs) => Val::arr(pairs.iter().map(|(_, value)| value.clone()).collect()),
+        _ => Val::arr(Vec::new()),
+    }
 }
 
 /// Returns `[[key, value], ...]` pairs for each entry in the object.
 #[inline]
 pub fn entries_apply(recv: &Val) -> Val {
-    Val::arr(
-        recv.as_object()
-            .map(|m| {
-                m.iter()
-                    .map(|(k, v)| Val::arr(vec![Val::Str(k.clone()), v.clone()]))
-                    .collect()
-            })
-            .unwrap_or_default(),
-    )
+    match recv {
+        Val::Obj(m) => Val::arr(
+            m.iter()
+                .map(|(k, v)| Val::arr(vec![Val::Str(k.clone()), v.clone()]))
+                .collect(),
+        ),
+        Val::ObjSmall(pairs) => Val::arr(
+            pairs
+                .iter()
+                .map(|(k, v)| Val::arr(vec![Val::Str(k.clone()), v.clone()]))
+                .collect(),
+        ),
+        _ => Val::arr(Vec::new()),
+    }
 }
-

--- a/jetro-core/src/builtins/ops/array.rs
+++ b/jetro-core/src/builtins/ops/array.rs
@@ -268,6 +268,32 @@ where
     Ok(Val::arr(out))
 }
 
+/// Returns the first element for which every predicate is truthy. Distinct
+/// from `find_apply` (which keeps every match): this corresponds to the
+/// conventional `.find(pred)` semantics in JavaScript / Rust / Python
+/// iterators. Returns `Val::Null` when nothing matches.
+#[inline]
+pub fn find_first_apply<F>(recv: Val, pred_count: usize, mut eval: F) -> Result<Val, EvalError>
+where
+    F: FnMut(&Val, usize) -> Result<Val, EvalError>,
+{
+    if pred_count == 0 {
+        return Err(EvalError("find: requires at least one predicate".into()));
+    }
+    let items = recv
+        .into_vec()
+        .ok_or_else(|| EvalError("find: expected array".into()))?;
+    'outer: for item in items {
+        for idx in 0..pred_count {
+            if !is_truthy(&eval(&item, idx)?) {
+                continue 'outer;
+            }
+        }
+        return Ok(item);
+    }
+    Ok(Val::Null)
+}
+
 /// Deduplicates an array by a key expression, keeping the first occurrence of each distinct key.
 #[inline]
 pub fn unique_by_apply<F>(recv: Val, mut eval: F) -> Result<Val, EvalError>

--- a/jetro-core/src/builtins/ops/path.rs
+++ b/jetro-core/src/builtins/ops/path.rs
@@ -216,8 +216,12 @@ pub fn has_path_apply(recv: &Val, path: &str) -> Option<Val> {
 /// Returns `Val::Bool(true)` when the object has a top-level key named `key`.
 #[inline]
 pub fn has_apply(recv: &Val, key: &str) -> Option<Val> {
-    let m = recv.as_object()?;
-    Some(Val::Bool(m.contains_key(key)))
+    let found = match recv {
+        Val::Obj(m) => m.contains_key(key),
+        Val::ObjSmall(pairs) => pairs.iter().any(|(k, _)| k.as_ref() == key),
+        _ => return None,
+    };
+    Some(Val::Bool(found))
 }
 
 /// Keeps only the listed `keys` from an object (or each object in an array), dropping all others.
@@ -354,4 +358,3 @@ pub fn unflatten_keys_apply(recv: &Val, sep: &str) -> Option<Val> {
         None
     }
 }
-

--- a/jetro-core/src/builtins/ops/path.rs
+++ b/jetro-core/src/builtins/ops/path.rs
@@ -239,12 +239,24 @@ pub fn pick_apply(recv: &Val, keys: &[Arc<str>]) -> Option<Val> {
         Val::obj(out)
     }
 
+    fn pick_small(pairs: &[(Arc<str>, Val)], keys: &[Arc<str>]) -> Val {
+        let mut out = IndexMap::with_capacity(keys.len());
+        for key in keys {
+            if let Some((_, v)) = pairs.iter().find(|(k, _)| k.as_ref() == key.as_ref()) {
+                out.insert(key.clone(), v.clone());
+            }
+        }
+        Val::obj(out)
+    }
+
     match recv {
         Val::Obj(m) => Some(pick_obj(m, keys)),
+        Val::ObjSmall(pairs) => Some(pick_small(pairs, keys)),
         Val::Arr(a) => Some(Val::arr(
             a.iter()
                 .filter_map(|v| match v {
                     Val::Obj(m) => Some(pick_obj(m, keys)),
+                    Val::ObjSmall(pairs) => Some(pick_small(pairs, keys)),
                     _ => None,
                 })
                 .collect(),
@@ -302,12 +314,26 @@ pub fn omit_apply(recv: &Val, keys: &[Arc<str>]) -> Option<Val> {
         Val::obj(out)
     }
 
+    fn omit_small(pairs: &[(Arc<str>, Val)], keys: &[Arc<str>]) -> Val {
+        let omitted: std::collections::HashSet<&str> =
+            keys.iter().map(|key| key.as_ref()).collect();
+        Val::obj(
+            pairs
+                .iter()
+                .filter(|(key, _)| !omitted.contains(key.as_ref()))
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+        )
+    }
+
     match recv {
         Val::Obj(m) => Some(omit_obj(m, keys)),
+        Val::ObjSmall(pairs) => Some(omit_small(pairs, keys)),
         Val::Arr(a) => Some(Val::arr(
             a.iter()
                 .filter_map(|v| match v {
                     Val::Obj(m) => Some(omit_obj(m, keys)),
+                    Val::ObjSmall(pairs) => Some(omit_small(pairs, keys)),
                     _ => None,
                 })
                 .collect(),

--- a/jetro-core/src/builtins/registry.rs
+++ b/jetro-core/src/builtins/registry.rs
@@ -124,6 +124,44 @@ pub(crate) fn propagate_demand(id: BuiltinId, arg: BuiltinDemandArg, downstream:
             },
             BuiltinDemandArg::None => downstream,
         },
+        BuiltinDemandLaw::Chunk => match arg {
+            BuiltinDemandArg::Usize(n) => {
+                let width = n.max(1);
+                Demand {
+                    pull: match downstream.pull {
+                        PullDemand::FirstInput(k) | PullDemand::UntilOutput(k) => {
+                            PullDemand::FirstInput(width.saturating_mul(k))
+                        }
+                        PullDemand::NthInput(i) => {
+                            PullDemand::FirstInput(width.saturating_mul(i.saturating_add(1)))
+                        }
+                        PullDemand::All | PullDemand::LastInput(_) => PullDemand::All,
+                    },
+                    value: downstream.value.merge(ValueNeed::Whole),
+                    order: true,
+                }
+            }
+            BuiltinDemandArg::None => Demand::all(ValueNeed::Whole),
+        },
+        BuiltinDemandLaw::Window => match arg {
+            BuiltinDemandArg::Usize(n) => {
+                let width = n.max(1);
+                Demand {
+                    pull: match downstream.pull {
+                        PullDemand::FirstInput(k) | PullDemand::UntilOutput(k) => {
+                            PullDemand::FirstInput(width.saturating_add(k.saturating_sub(1)))
+                        }
+                        PullDemand::NthInput(i) => {
+                            PullDemand::FirstInput(width.saturating_add(i))
+                        }
+                        PullDemand::All | PullDemand::LastInput(_) => PullDemand::All,
+                    },
+                    value: downstream.value.merge(ValueNeed::Whole),
+                    order: true,
+                }
+            }
+            BuiltinDemandArg::None => Demand::all(ValueNeed::Whole),
+        },
         BuiltinDemandLaw::First => Demand::first(ValueNeed::Whole),
         BuiltinDemandLaw::Last => Demand {
             pull: PullDemand::LastInput(1),
@@ -410,6 +448,8 @@ mod tests {
         let reverse = BuiltinId::from_method(BuiltinMethod::Reverse);
         let drop_while = BuiltinId::from_method(BuiltinMethod::DropWhile);
         let slice = BuiltinId::from_method(BuiltinMethod::Slice);
+        let chunk = BuiltinId::from_method(BuiltinMethod::Chunk);
+        let window = BuiltinId::from_method(BuiltinMethod::Window);
 
         let demand = propagate_demand(take, BuiltinDemandArg::Usize(3), Demand::RESULT);
         assert_eq!(demand.pull, PullDemand::FirstInput(3));
@@ -487,6 +527,24 @@ mod tests {
         assert_eq!(demand.pull, PullDemand::LastInput(1));
         assert_eq!(demand.value, ValueNeed::Whole);
         assert!(demand.order);
+
+        let downstream = Demand {
+            pull: PullDemand::FirstInput(3),
+            value: ValueNeed::Whole,
+            order: true,
+        };
+        let demand = propagate_demand(chunk, BuiltinDemandArg::Usize(4), downstream);
+        assert_eq!(demand.pull, PullDemand::FirstInput(12));
+        assert_eq!(demand.value, ValueNeed::Whole);
+
+        let downstream = Demand {
+            pull: PullDemand::UntilOutput(3),
+            value: ValueNeed::Whole,
+            order: true,
+        };
+        let demand = propagate_demand(window, BuiltinDemandArg::Usize(4), downstream);
+        assert_eq!(demand.pull, PullDemand::FirstInput(6));
+        assert_eq!(demand.value, ValueNeed::Whole);
     }
 
     #[test]

--- a/jetro-core/src/builtins/registry.rs
+++ b/jetro-core/src/builtins/registry.rs
@@ -604,9 +604,7 @@ mod tests {
         );
         assert_eq!(
             pipeline_lowering(BuiltinId::from_method(BuiltinMethod::FindOne)),
-            Some(BuiltinPipelineLowering::TerminalExprArg {
-                terminal: BuiltinMethod::First,
-            })
+            Some(BuiltinPipelineLowering::TerminalSink)
         );
         assert_eq!(
             pipeline_lowering(BuiltinId::from_method(BuiltinMethod::Take)),

--- a/jetro-core/src/builtins/registry.rs
+++ b/jetro-core/src/builtins/registry.rs
@@ -79,6 +79,11 @@ pub(crate) fn propagate_demand(id: BuiltinId, arg: BuiltinDemandArg, downstream:
             value: downstream.value.merge(ValueNeed::Predicate),
             order: downstream.order,
         },
+        BuiltinDemandLaw::DropWhile => Demand {
+            pull: PullDemand::All,
+            value: downstream.value.merge(ValueNeed::Predicate),
+            order: true,
+        },
         BuiltinDemandLaw::UniqueLike => Demand {
             pull: match downstream.pull {
                 PullDemand::All => PullDemand::All,
@@ -148,6 +153,16 @@ pub(crate) fn propagate_demand(id: BuiltinId, arg: BuiltinDemandArg, downstream:
             pull: PullDemand::All,
             value: downstream.value.merge(ValueNeed::Whole),
             order: true,
+        },
+        BuiltinDemandLaw::Reverse => Demand {
+            pull: match downstream.pull {
+                PullDemand::FirstInput(n) | PullDemand::UntilOutput(n) => PullDemand::LastInput(n),
+                PullDemand::LastInput(n) => PullDemand::FirstInput(n),
+                PullDemand::NthInput(_) => PullDemand::All,
+                PullDemand::All => PullDemand::All,
+            },
+            value: downstream.value,
+            order: downstream.order,
         },
     }
 }
@@ -388,6 +403,8 @@ mod tests {
         let unique = BuiltinId::from_method(BuiltinMethod::Unique);
         let count_by = BuiltinId::from_method(BuiltinMethod::CountBy);
         let sort = BuiltinId::from_method(BuiltinMethod::Sort);
+        let reverse = BuiltinId::from_method(BuiltinMethod::Reverse);
+        let drop_while = BuiltinId::from_method(BuiltinMethod::DropWhile);
 
         let demand = propagate_demand(take, BuiltinDemandArg::Usize(3), Demand::RESULT);
         assert_eq!(demand.pull, PullDemand::FirstInput(3));
@@ -422,6 +439,36 @@ mod tests {
             order: false,
         };
         let demand = propagate_demand(sort, BuiltinDemandArg::None, downstream);
+        assert_eq!(demand.pull, PullDemand::All);
+        assert_eq!(demand.value, ValueNeed::Whole);
+        assert!(demand.order);
+
+        let downstream = Demand {
+            pull: PullDemand::FirstInput(2),
+            value: ValueNeed::Whole,
+            order: true,
+        };
+        let demand = propagate_demand(reverse, BuiltinDemandArg::None, downstream);
+        assert_eq!(demand.pull, PullDemand::LastInput(2));
+        assert_eq!(demand.value, ValueNeed::Whole);
+        assert!(demand.order);
+
+        let downstream = Demand {
+            pull: PullDemand::LastInput(1),
+            value: ValueNeed::Whole,
+            order: true,
+        };
+        let demand = propagate_demand(reverse, BuiltinDemandArg::None, downstream);
+        assert_eq!(demand.pull, PullDemand::FirstInput(1));
+        assert_eq!(demand.value, ValueNeed::Whole);
+        assert!(demand.order);
+
+        let downstream = Demand {
+            pull: PullDemand::FirstInput(1),
+            value: ValueNeed::Whole,
+            order: false,
+        };
+        let demand = propagate_demand(drop_while, BuiltinDemandArg::None, downstream);
         assert_eq!(demand.pull, PullDemand::All);
         assert_eq!(demand.value, ValueNeed::Whole);
         assert!(demand.order);

--- a/jetro-core/src/builtins/registry.rs
+++ b/jetro-core/src/builtins/registry.rs
@@ -300,6 +300,11 @@ fn terminal_sink_arity(method: BuiltinMethod) -> Option<BuiltinPipelineArity> {
             }
         }
         BuiltinSinkAccumulator::Numeric => BuiltinPipelineArity::Range { min: 0, max: 1 },
+        BuiltinSinkAccumulator::SelectOne(_)
+            if matches!(method, BuiltinMethod::First | BuiltinMethod::Last) =>
+        {
+            BuiltinPipelineArity::Range { min: 0, max: 1 }
+        }
         BuiltinSinkAccumulator::SelectOne(_) | BuiltinSinkAccumulator::ApproxDistinct => {
             BuiltinPipelineArity::Exact(0)
         }
@@ -699,8 +704,13 @@ mod tests {
             1,
             true
         ));
-        assert!(!pipeline_accepts_arity(
+        assert!(pipeline_accepts_arity(
             BuiltinId::from_method(BuiltinMethod::First),
+            1,
+            true
+        ));
+        assert!(pipeline_accepts_arity(
+            BuiltinId::from_method(BuiltinMethod::Last),
             1,
             true
         ));

--- a/jetro-core/src/builtins/registry.rs
+++ b/jetro-core/src/builtins/registry.rs
@@ -99,6 +99,10 @@ pub(crate) fn propagate_demand(id: BuiltinId, arg: BuiltinDemandArg, downstream:
             value: downstream.value.merge(ValueNeed::Whole),
             ..downstream
         },
+        BuiltinDemandLaw::Slice => Demand {
+            value: downstream.value.merge(ValueNeed::Whole),
+            ..downstream
+        },
         BuiltinDemandLaw::FlatMapLike => Demand::all(ValueNeed::Whole),
         BuiltinDemandLaw::Take => match arg {
             BuiltinDemandArg::Usize(n) => Demand {
@@ -405,6 +409,7 @@ mod tests {
         let sort = BuiltinId::from_method(BuiltinMethod::Sort);
         let reverse = BuiltinId::from_method(BuiltinMethod::Reverse);
         let drop_while = BuiltinId::from_method(BuiltinMethod::DropWhile);
+        let slice = BuiltinId::from_method(BuiltinMethod::Slice);
 
         let demand = propagate_demand(take, BuiltinDemandArg::Usize(3), Demand::RESULT);
         assert_eq!(demand.pull, PullDemand::FirstInput(3));
@@ -470,6 +475,16 @@ mod tests {
         };
         let demand = propagate_demand(drop_while, BuiltinDemandArg::None, downstream);
         assert_eq!(demand.pull, PullDemand::All);
+        assert_eq!(demand.value, ValueNeed::Whole);
+        assert!(demand.order);
+
+        let downstream = Demand {
+            pull: PullDemand::LastInput(1),
+            value: ValueNeed::Predicate,
+            order: true,
+        };
+        let demand = propagate_demand(slice, BuiltinDemandArg::None, downstream);
+        assert_eq!(demand.pull, PullDemand::LastInput(1));
         assert_eq!(demand.value, ValueNeed::Whole);
         assert!(demand.order);
     }

--- a/jetro-core/src/builtins/registry.rs
+++ b/jetro-core/src/builtins/registry.rs
@@ -735,6 +735,7 @@ mod tests {
             BuiltinMethod::Abs,
             BuiltinMethod::ParseInt,
             BuiltinMethod::Has,
+            BuiltinMethod::HasKey,
             BuiltinMethod::Lines,
             BuiltinMethod::GetPath,
         ] {

--- a/jetro-core/src/builtins/registry.rs
+++ b/jetro-core/src/builtins/registry.rs
@@ -283,7 +283,12 @@ pub(crate) fn pipeline_arity(id: BuiltinId, is_last: bool) -> Option<BuiltinPipe
 
 #[inline]
 fn terminal_sink_arity(method: BuiltinMethod) -> Option<BuiltinPipelineArity> {
-    let Some(sink) = method.spec().sink else {
+    let spec = method.spec();
+    if spec.sink.is_none() && matches!(spec.lowering, Some(BuiltinPipelineLowering::TerminalSink))
+    {
+        return Some(BuiltinPipelineArity::Exact(1));
+    }
+    let Some(sink) = spec.sink else {
         return None;
     };
     Some(match sink.accumulator {

--- a/jetro-core/src/builtins/registry.rs
+++ b/jetro-core/src/builtins/registry.rs
@@ -706,6 +706,16 @@ mod tests {
             1,
             true
         ));
+        assert!(pipeline_accepts_arity(
+            BuiltinId::from_method(BuiltinMethod::Includes),
+            1,
+            true
+        ));
+        assert!(!pipeline_accepts_arity(
+            BuiltinId::from_method(BuiltinMethod::Includes),
+            1,
+            false
+        ));
     }
 
     #[test]

--- a/jetro-core/src/compile/compiler.rs
+++ b/jetro-core/src/compile/compiler.rs
@@ -691,26 +691,64 @@ impl Compiler {
     }
 
     /// Compile a method argument that may be a lambda or a plain expression.
-    /// For single-param lambdas, the parameter identifier is rewritten to `PushCurrent`
-    /// so the body can be executed without an extra variable lookup.
+    ///
+    /// For single-param lambdas, the parameter identifier is substituted with
+    /// `Expr::Current` at the AST level — recursively, with shadowing-aware
+    /// stop-conditions for nested lambdas, `let`, comprehensions, match-arm
+    /// pattern bindings, and pipeline binds — before the body is emitted.
+    /// The resulting program is identical to what the equivalent `@`-form
+    /// would produce, which means kernel classification (`BodyKernel`) and
+    /// every peephole pass apply uniformly. Multi-param lambdas keep their
+    /// runtime-binding path: each param resolves through `env.get_var` after
+    /// a `push_lam` at call time.
     fn compile_lambda_or_expr(expr: &Expr, ctx: &VarCtx) -> Program {
         match expr {
+            Expr::Lambda { params, body } if params.len() == 1 => {
+                let name = &params[0];
+                let lowered = crate::compile::lambda_lower::substitute_current(
+                    (**body).clone(),
+                    name.as_str(),
+                );
+                let inner_ctx = ctx.with_vars(params);
+                let prog = Self::compile_sub(&lowered, &inner_ctx);
+                // If the substituted body still references the parameter
+                // name (only possible from inside a nested lambda whose
+                // own `@` is reassigned), wrap the program in a runtime
+                // binding opcode so `LoadIdent(name)` resolves to the
+                // outer iteration item even when the host pipeline stage
+                // advances per row via `swap_current`.
+                if crate::plan::analysis::expr_uses_ident(&lowered, name.as_str()) {
+                    let body = Arc::new(prog);
+                    let ops = vec![Opcode::BindLamCurrent {
+                        name: Some(Arc::from(name.as_str())),
+                        body,
+                    }];
+                    Program::new(ops, "<lam-body-bind>")
+                } else {
+                    prog
+                }
+            }
+            Expr::Lambda { params, body } if params.len() >= 2 => {
+                // Multi-param fast path: `apply_compiled_pair` pushes
+                // params left-to-right via `push_lam`, so `env.current`
+                // ends up bound to the rightmost argument. Substitute
+                // that param's identifier with `Expr::Current` at the
+                // AST level — the inner params 0..N-1 still resolve
+                // through `LoadIdent` / `env.get_var`, but the rightmost
+                // (the one read most heavily in comparators and pair
+                // reducers per row's right operand) skips the var
+                // lookup entirely.
+                let last = params.last().expect("multi-param lambda");
+                let lowered = crate::compile::lambda_lower::substitute_current(
+                    (**body).clone(),
+                    last.as_str(),
+                );
+                let inner_ctx = ctx.with_vars(params);
+                Self::compile_sub(&lowered, &inner_ctx)
+            }
             Expr::Lambda { params, body } => {
                 let inner = ctx.with_vars(params);
-                let mut p = Self::compile_sub(body, &inner);
-                if params.len() == 1 {
-                    let name = params[0].as_str();
-                    let new_ops: Vec<Opcode> = p
-                        .ops
-                        .iter()
-                        .map(|op| match op {
-                            Opcode::LoadIdent(k) if k.as_ref() == name => Opcode::PushCurrent,
-                            other => other.clone(),
-                        })
-                        .collect();
-                    p = Program::new(Self::optimize(new_ops), "<lam-body>");
-                }
-                p
+                Self::compile_sub(body, &inner)
             }
             other => Self::compile_sub(other, ctx),
         }

--- a/jetro-core/src/compile/lambda_lower.rs
+++ b/jetro-core/src/compile/lambda_lower.rs
@@ -1,0 +1,742 @@
+//! AST-level lambda body lowering.
+//!
+//! `substitute_current(body, name)` walks `body` and rewrites every free
+//! `Expr::Ident(name)` to `Expr::Current`, respecting all binding-form
+//! shadows (nested lambdas, `let`, comprehensions, match-arm pattern
+//! bindings, pipeline `as`-binds). The compiler invokes this once per
+//! single-param lambda argument so the emitted bytecode is identical to
+//! what the equivalent `@`-form expression would produce — no opcode
+//! rewriting at the bytecode level, no per-row runtime variable lookup,
+//! and uniform participation in kernel classification and peephole passes.
+
+use crate::parse::ast::{
+    Arg, ArrayElem, BindTarget, Expr, FStringPart, MatchArm, ObjField, Pat, PatchOp, PathStep,
+    PipeStep, Step,
+};
+
+/// If `expr` is `Expr::Lambda { params: [name], body }`, return its
+/// substituted body (param identifier → `Expr::Current`). Otherwise clone
+/// `expr` and return it. Used by every site that calls `Compiler::compile`
+/// on an arbitrary `Expr` so a top-level single-param lambda compiles to
+/// the same program shape the equivalent `@`-form would.
+pub(crate) fn unwrap_single_lambda(expr: &Expr) -> Expr {
+    match expr {
+        Expr::Lambda { params, body } if params.len() == 1 => {
+            substitute_current((**body).clone(), params[0].as_str())
+        }
+        other => other.clone(),
+    }
+}
+
+/// Inline let-bound lambda values into method-arg references. Implements
+/// first-class lambdas as a static macro expansion: `let f = (x => x*2) in
+/// $.xs.map(f)` desugars to `$.xs.map(x => x*2)` before any compile pass
+/// runs. Pure AST rewrite — no closure runtime, no `Val::Lambda` variant —
+/// so the resulting form benefits from the same single-param substitution
+/// and `BindLamCurrent` machinery as inline lambdas.
+///
+/// Resolution rule: an `Expr::Ident(n)` appearing as a positional or named
+/// argument to a method or global call is replaced with the most recent
+/// active `let n = LAMBDA in ...` binding. `let` shadowing is respected;
+/// a non-lambda init for the same name removes the binding.
+pub(crate) fn inline_let_bound_lambdas(expr: Expr) -> Expr {
+    inline_walk(expr, &mut Vec::new())
+}
+
+fn inline_walk(expr: Expr, env: &mut Vec<(String, Expr)>) -> Expr {
+    match expr {
+        Expr::Null
+        | Expr::Bool(_)
+        | Expr::Int(_)
+        | Expr::Float(_)
+        | Expr::Str(_)
+        | Expr::Root
+        | Expr::Current
+        | Expr::Ident(_)
+        | Expr::DeleteMark => expr,
+        Expr::FString(parts) => Expr::FString(
+            parts
+                .into_iter()
+                .map(|p| match p {
+                    FStringPart::Lit(s) => FStringPart::Lit(s),
+                    FStringPart::Interp { expr, fmt } => FStringPart::Interp {
+                        expr: inline_walk(expr, env),
+                        fmt,
+                    },
+                })
+                .collect(),
+        ),
+        Expr::Chain(base, steps) => Expr::Chain(
+            Box::new(inline_walk(*base, env)),
+            steps
+                .into_iter()
+                .map(|s| inline_walk_step(s, env))
+                .collect(),
+        ),
+        Expr::BinOp(l, op, r) => Expr::BinOp(
+            Box::new(inline_walk(*l, env)),
+            op,
+            Box::new(inline_walk(*r, env)),
+        ),
+        Expr::UnaryNeg(e) => Expr::UnaryNeg(Box::new(inline_walk(*e, env))),
+        Expr::Not(e) => Expr::Not(Box::new(inline_walk(*e, env))),
+        Expr::Kind { expr, ty, negate } => Expr::Kind {
+            expr: Box::new(inline_walk(*expr, env)),
+            ty,
+            negate,
+        },
+        Expr::Coalesce(l, r) => Expr::Coalesce(
+            Box::new(inline_walk(*l, env)),
+            Box::new(inline_walk(*r, env)),
+        ),
+        Expr::Object(fields) => Expr::Object(
+            fields
+                .into_iter()
+                .map(|f| inline_walk_obj_field(f, env))
+                .collect(),
+        ),
+        Expr::Array(elems) => Expr::Array(
+            elems
+                .into_iter()
+                .map(|e| match e {
+                    ArrayElem::Expr(e) => ArrayElem::Expr(inline_walk(e, env)),
+                    ArrayElem::Spread(e) => ArrayElem::Spread(inline_walk(e, env)),
+                })
+                .collect(),
+        ),
+        Expr::Pipeline { base, steps } => Expr::Pipeline {
+            base: Box::new(inline_walk(*base, env)),
+            steps: steps
+                .into_iter()
+                .map(|s| match s {
+                    PipeStep::Forward(e) => PipeStep::Forward(inline_walk(e, env)),
+                    PipeStep::Bind(b) => PipeStep::Bind(b),
+                })
+                .collect(),
+        },
+        Expr::ListComp {
+            expr,
+            vars,
+            iter,
+            cond,
+        } => Expr::ListComp {
+            expr: Box::new(inline_walk(*expr, env)),
+            vars,
+            iter: Box::new(inline_walk(*iter, env)),
+            cond: cond.map(|c| Box::new(inline_walk(*c, env))),
+        },
+        Expr::DictComp {
+            key,
+            val,
+            vars,
+            iter,
+            cond,
+        } => Expr::DictComp {
+            key: Box::new(inline_walk(*key, env)),
+            val: Box::new(inline_walk(*val, env)),
+            vars,
+            iter: Box::new(inline_walk(*iter, env)),
+            cond: cond.map(|c| Box::new(inline_walk(*c, env))),
+        },
+        Expr::SetComp {
+            expr,
+            vars,
+            iter,
+            cond,
+        } => Expr::SetComp {
+            expr: Box::new(inline_walk(*expr, env)),
+            vars,
+            iter: Box::new(inline_walk(*iter, env)),
+            cond: cond.map(|c| Box::new(inline_walk(*c, env))),
+        },
+        Expr::GenComp {
+            expr,
+            vars,
+            iter,
+            cond,
+        } => Expr::GenComp {
+            expr: Box::new(inline_walk(*expr, env)),
+            vars,
+            iter: Box::new(inline_walk(*iter, env)),
+            cond: cond.map(|c| Box::new(inline_walk(*c, env))),
+        },
+        Expr::Lambda { params, body } => Expr::Lambda {
+            params,
+            body: Box::new(inline_walk(*body, env)),
+        },
+        Expr::Let { name, init, body } => {
+            let new_init = inline_walk(*init, env);
+            // Bind `name` to a lambda value when:
+            //   - `init` is itself an `Expr::Lambda { .. }` (literal), or
+            //   - `init` is an `Expr::Ident(prev)` whose binding in scope
+            //     resolves to a lambda (let-alias chain).
+            let resolved_lambda: Option<Expr> = match &new_init {
+                Expr::Lambda { .. } => Some(new_init.clone()),
+                Expr::Ident(prev) => env
+                    .iter()
+                    .rev()
+                    .find(|(bound, _)| bound == prev)
+                    .map(|(_, lam)| lam.clone())
+                    .filter(|e| matches!(e, Expr::Lambda { .. })),
+                _ => None,
+            };
+            match resolved_lambda {
+                Some(lam) => env.push((name.clone(), lam)),
+                None => {
+                    // Even when init is not a Lambda, an outer same-named
+                    // binding (if any) is shadowed inside `body`. Push a
+                    // sentinel so resolution finds the new binding (a
+                    // non-lambda) and stops there rather than reaching past
+                    // it.
+                    env.push((name.clone(), Expr::Null));
+                }
+            }
+            let new_body = inline_walk(*body, env);
+            env.pop();
+            Expr::Let {
+                name,
+                init: Box::new(new_init),
+                body: Box::new(new_body),
+            }
+        }
+        Expr::IfElse { cond, then_, else_ } => Expr::IfElse {
+            cond: Box::new(inline_walk(*cond, env)),
+            then_: Box::new(inline_walk(*then_, env)),
+            else_: Box::new(inline_walk(*else_, env)),
+        },
+        Expr::Try { body, default } => Expr::Try {
+            body: Box::new(inline_walk(*body, env)),
+            default: Box::new(inline_walk(*default, env)),
+        },
+        Expr::GlobalCall { name, args } => Expr::GlobalCall {
+            name,
+            args: args
+                .into_iter()
+                .map(|a| inline_walk_arg(a, env))
+                .collect(),
+        },
+        Expr::Cast { expr, ty } => Expr::Cast {
+            expr: Box::new(inline_walk(*expr, env)),
+            ty,
+        },
+        Expr::Patch { root, ops } => Expr::Patch {
+            root: Box::new(inline_walk(*root, env)),
+            ops: ops
+                .into_iter()
+                .map(|op| PatchOp {
+                    path: op
+                        .path
+                        .into_iter()
+                        .map(|s| match s {
+                            PathStep::DynIndex(e) => PathStep::DynIndex(inline_walk(e, env)),
+                            PathStep::WildcardFilter(e) => {
+                                PathStep::WildcardFilter(Box::new(inline_walk(*e, env)))
+                            }
+                            other => other,
+                        })
+                        .collect(),
+                    val: inline_walk(op.val, env),
+                    cond: op.cond.map(|c| inline_walk(c, env)),
+                })
+                .collect(),
+        },
+        Expr::Match { scrutinee, arms } => Expr::Match {
+            scrutinee: Box::new(inline_walk(*scrutinee, env)),
+            arms: arms
+                .into_iter()
+                .map(|a| MatchArm {
+                    pat: a.pat,
+                    guard: a.guard.map(|g| inline_walk(g, env)),
+                    body: inline_walk(a.body, env),
+                })
+                .collect(),
+        },
+    }
+}
+
+fn inline_walk_step(step: Step, env: &mut Vec<(String, Expr)>) -> Step {
+    match step {
+        Step::DynIndex(e) => Step::DynIndex(Box::new(inline_walk(*e, env))),
+        Step::InlineFilter(e) => Step::InlineFilter(Box::new(inline_walk(*e, env))),
+        Step::Method(n, args) => Step::Method(
+            n,
+            args.into_iter().map(|a| inline_walk_arg(a, env)).collect(),
+        ),
+        Step::OptMethod(n, args) => Step::OptMethod(
+            n,
+            args.into_iter().map(|a| inline_walk_arg(a, env)).collect(),
+        ),
+        Step::DeepMatch { arms, early_stop } => Step::DeepMatch {
+            arms: arms
+                .into_iter()
+                .map(|a| MatchArm {
+                    pat: a.pat,
+                    guard: a.guard.map(|g| inline_walk(g, env)),
+                    body: inline_walk(a.body, env),
+                })
+                .collect(),
+            early_stop,
+        },
+        other => other,
+    }
+}
+
+fn inline_walk_arg(arg: Arg, env: &mut Vec<(String, Expr)>) -> Arg {
+    let (name, inner) = match arg {
+        Arg::Pos(e) => (None::<String>, e),
+        Arg::Named(k, e) => (Some(k), e),
+    };
+    let resolved = match &inner {
+        // Method-arg position is the only place a let-bound lambda is
+        // legally invocable as a higher-order function. Resolve only here.
+        Expr::Ident(n) => env
+            .iter()
+            .rev()
+            .find(|(bound, _)| bound == n)
+            .map(|(_, lambda)| lambda.clone())
+            .filter(|e| matches!(e, Expr::Lambda { .. })),
+        _ => None,
+    };
+    let final_expr = match resolved {
+        Some(lam) => lam,
+        None => inline_walk(inner, env),
+    };
+    match name {
+        None => Arg::Pos(final_expr),
+        Some(k) => Arg::Named(k, final_expr),
+    }
+}
+
+fn inline_walk_obj_field(field: ObjField, env: &mut Vec<(String, Expr)>) -> ObjField {
+    match field {
+        ObjField::Kv {
+            key,
+            val,
+            optional,
+            cond,
+        } => ObjField::Kv {
+            key,
+            val: inline_walk(val, env),
+            optional,
+            cond: cond.map(|c| inline_walk(c, env)),
+        },
+        ObjField::Short(s) => ObjField::Short(s),
+        ObjField::Dynamic { key, val } => ObjField::Dynamic {
+            key: inline_walk(key, env),
+            val: inline_walk(val, env),
+        },
+        ObjField::Spread(e) => ObjField::Spread(inline_walk(e, env)),
+        ObjField::SpreadDeep(e) => ObjField::SpreadDeep(inline_walk(e, env)),
+    }
+}
+
+/// Compile `expr` to a `Program`, transparently lowering single-param
+/// `Expr::Lambda` to its substituted body. When the substituted body still
+/// references the lambda parameter (only possible from inside a nested
+/// lambda whose own `@` is reassigned), wrap the program in a
+/// `BindLamCurrent` opcode so `LoadIdent(name)` resolves to the outer row
+/// at runtime — even when the host pipeline stage advances per row via
+/// `swap_current` rather than `push_lam`. Used by every pipeline-side
+/// compile site that previously routed `Compiler::compile` on an
+/// `Expr::Lambda` (which would have lowered to a single `PushNull`).
+pub(crate) fn compile_lambda_arg(
+    expr: &Expr,
+    source: &str,
+) -> std::sync::Arc<crate::vm::Program> {
+    use crate::vm::Opcode;
+    use std::sync::Arc;
+    if let Expr::Lambda { params, body } = expr {
+        if params.len() == 1 {
+            let name = params[0].as_str();
+            let lowered = substitute_current((**body).clone(), name);
+            let body_prog = crate::compile::compiler::Compiler::compile(&lowered, source);
+            if crate::plan::analysis::expr_uses_ident(&lowered, name) {
+                let body = Arc::new(body_prog);
+                let ops = vec![Opcode::BindLamCurrent {
+                    name: Some(Arc::from(name)),
+                    body,
+                }];
+                return Arc::new(crate::vm::Program::new(ops, "<lam-body-bind>"));
+            }
+            return Arc::new(body_prog);
+        }
+    }
+    Arc::new(crate::compile::compiler::Compiler::compile(expr, source))
+}
+
+/// Returns `true` when matching `pat` introduces a binding whose name equals
+/// `name`. Used to stop substitution descent into match-arm bodies whose
+/// patterns shadow the substituted lambda parameter.
+fn pat_binds_name(pat: &Pat, name: &str) -> bool {
+    match pat {
+        Pat::Wild | Pat::Lit(_) | Pat::Range { .. } => false,
+        Pat::Bind(n) => n == name,
+        Pat::Or(alts) => alts.iter().any(|p| pat_binds_name(p, name)),
+        Pat::Obj { fields, rest } => {
+            fields.iter().any(|(_, p)| pat_binds_name(p, name))
+                || matches!(rest, Some(Some(r)) if r == name)
+        }
+        Pat::Arr { elems, rest } => {
+            elems.iter().any(|p| pat_binds_name(p, name))
+                || matches!(rest, Some(Some(r)) if r == name)
+        }
+        Pat::Kind { name: bind, .. } => matches!(bind, Some(n) if n == name),
+    }
+}
+
+fn bind_target_shadows(bt: &BindTarget, name: &str) -> bool {
+    match bt {
+        BindTarget::Name(n) => n == name,
+        BindTarget::Obj { fields, rest } => {
+            fields.iter().any(|f| f == name) || matches!(rest, Some(r) if r == name)
+        }
+        BindTarget::Arr(ns) => ns.iter().any(|n| n == name),
+    }
+}
+
+/// Substitute every free `Expr::Ident(name)` with `Expr::Current` inside
+/// `expr`, respecting shadowing introduced by nested lambdas, `let`,
+/// comprehensions, match-arm pattern binds, and pipeline binds.
+pub(crate) fn substitute_current(expr: Expr, name: &str) -> Expr {
+    match expr {
+        Expr::Ident(ref n) if n == name => Expr::Current,
+        Expr::Null
+        | Expr::Bool(_)
+        | Expr::Int(_)
+        | Expr::Float(_)
+        | Expr::Str(_)
+        | Expr::Root
+        | Expr::Current
+        | Expr::Ident(_)
+        | Expr::DeleteMark => expr,
+        Expr::FString(parts) => Expr::FString(
+            parts
+                .into_iter()
+                .map(|p| match p {
+                    FStringPart::Lit(s) => FStringPart::Lit(s),
+                    FStringPart::Interp { expr, fmt } => FStringPart::Interp {
+                        expr: substitute_current(expr, name),
+                        fmt,
+                    },
+                })
+                .collect(),
+        ),
+        Expr::Chain(base, steps) => Expr::Chain(
+            Box::new(substitute_current(*base, name)),
+            steps
+                .into_iter()
+                .map(|s| substitute_step(s, name))
+                .collect(),
+        ),
+        Expr::BinOp(l, op, r) => Expr::BinOp(
+            Box::new(substitute_current(*l, name)),
+            op,
+            Box::new(substitute_current(*r, name)),
+        ),
+        Expr::UnaryNeg(e) => Expr::UnaryNeg(Box::new(substitute_current(*e, name))),
+        Expr::Not(e) => Expr::Not(Box::new(substitute_current(*e, name))),
+        Expr::Kind { expr, ty, negate } => Expr::Kind {
+            expr: Box::new(substitute_current(*expr, name)),
+            ty,
+            negate,
+        },
+        Expr::Coalesce(l, r) => Expr::Coalesce(
+            Box::new(substitute_current(*l, name)),
+            Box::new(substitute_current(*r, name)),
+        ),
+        Expr::Object(fields) => Expr::Object(
+            fields
+                .into_iter()
+                .map(|f| substitute_obj_field(f, name))
+                .collect(),
+        ),
+        Expr::Array(elems) => Expr::Array(
+            elems
+                .into_iter()
+                .map(|e| match e {
+                    ArrayElem::Expr(e) => ArrayElem::Expr(substitute_current(e, name)),
+                    ArrayElem::Spread(e) => ArrayElem::Spread(substitute_current(e, name)),
+                })
+                .collect(),
+        ),
+        Expr::Pipeline { base, steps } => {
+            let mut shadowed = false;
+            let new_base = substitute_current(*base, name);
+            let new_steps = steps
+                .into_iter()
+                .map(|s| match s {
+                    PipeStep::Forward(e) => PipeStep::Forward(if shadowed {
+                        e
+                    } else {
+                        substitute_current(e, name)
+                    }),
+                    PipeStep::Bind(bt) => {
+                        if bind_target_shadows(&bt, name) {
+                            shadowed = true;
+                        }
+                        PipeStep::Bind(bt)
+                    }
+                })
+                .collect();
+            Expr::Pipeline {
+                base: Box::new(new_base),
+                steps: new_steps,
+            }
+        }
+        Expr::ListComp {
+            expr,
+            vars,
+            iter,
+            cond,
+        } => {
+            let new_iter = substitute_current(*iter, name);
+            if vars.iter().any(|v| v == name) {
+                Expr::ListComp {
+                    expr,
+                    vars,
+                    iter: Box::new(new_iter),
+                    cond,
+                }
+            } else {
+                Expr::ListComp {
+                    expr: Box::new(substitute_current(*expr, name)),
+                    vars,
+                    iter: Box::new(new_iter),
+                    cond: cond.map(|c| Box::new(substitute_current(*c, name))),
+                }
+            }
+        }
+        Expr::DictComp {
+            key,
+            val,
+            vars,
+            iter,
+            cond,
+        } => {
+            let new_iter = substitute_current(*iter, name);
+            if vars.iter().any(|v| v == name) {
+                Expr::DictComp {
+                    key,
+                    val,
+                    vars,
+                    iter: Box::new(new_iter),
+                    cond,
+                }
+            } else {
+                Expr::DictComp {
+                    key: Box::new(substitute_current(*key, name)),
+                    val: Box::new(substitute_current(*val, name)),
+                    vars,
+                    iter: Box::new(new_iter),
+                    cond: cond.map(|c| Box::new(substitute_current(*c, name))),
+                }
+            }
+        }
+        Expr::SetComp {
+            expr,
+            vars,
+            iter,
+            cond,
+        } => {
+            let new_iter = substitute_current(*iter, name);
+            if vars.iter().any(|v| v == name) {
+                Expr::SetComp {
+                    expr,
+                    vars,
+                    iter: Box::new(new_iter),
+                    cond,
+                }
+            } else {
+                Expr::SetComp {
+                    expr: Box::new(substitute_current(*expr, name)),
+                    vars,
+                    iter: Box::new(new_iter),
+                    cond: cond.map(|c| Box::new(substitute_current(*c, name))),
+                }
+            }
+        }
+        Expr::GenComp {
+            expr,
+            vars,
+            iter,
+            cond,
+        } => {
+            let new_iter = substitute_current(*iter, name);
+            if vars.iter().any(|v| v == name) {
+                Expr::GenComp {
+                    expr,
+                    vars,
+                    iter: Box::new(new_iter),
+                    cond,
+                }
+            } else {
+                Expr::GenComp {
+                    expr: Box::new(substitute_current(*expr, name)),
+                    vars,
+                    iter: Box::new(new_iter),
+                    cond: cond.map(|c| Box::new(substitute_current(*c, name))),
+                }
+            }
+        }
+        Expr::Lambda { params, body } => {
+            // Never descend into a nested `Expr::Lambda` body: that lambda
+            // rebinds `@`, so substituting `name` → `Expr::Current` inside
+            // would silently change which value `Current` refers to. The
+            // inner reference to the outer param remains as `Expr::Ident`
+            // and resolves at runtime through the outer call's
+            // `env.push_lam(Some(name), item)` binding.
+            Expr::Lambda { params, body }
+        }
+        Expr::Let {
+            name: ln,
+            init,
+            body,
+        } => {
+            let new_init = substitute_current(*init, name);
+            let new_body = if ln == name {
+                *body
+            } else {
+                substitute_current(*body, name)
+            };
+            Expr::Let {
+                name: ln,
+                init: Box::new(new_init),
+                body: Box::new(new_body),
+            }
+        }
+        Expr::IfElse { cond, then_, else_ } => Expr::IfElse {
+            cond: Box::new(substitute_current(*cond, name)),
+            then_: Box::new(substitute_current(*then_, name)),
+            else_: Box::new(substitute_current(*else_, name)),
+        },
+        Expr::Try { body, default } => Expr::Try {
+            body: Box::new(substitute_current(*body, name)),
+            default: Box::new(substitute_current(*default, name)),
+        },
+        Expr::GlobalCall { name: n, args } => Expr::GlobalCall {
+            name: n,
+            args: args
+                .into_iter()
+                .map(|a| substitute_arg(a, name))
+                .collect(),
+        },
+        Expr::Cast { expr, ty } => Expr::Cast {
+            expr: Box::new(substitute_current(*expr, name)),
+            ty,
+        },
+        Expr::Patch { root, ops } => Expr::Patch {
+            root: Box::new(substitute_current(*root, name)),
+            ops: ops
+                .into_iter()
+                .map(|op| substitute_patch_op(op, name))
+                .collect(),
+        },
+        Expr::Match { scrutinee, arms } => Expr::Match {
+            scrutinee: Box::new(substitute_current(*scrutinee, name)),
+            arms: arms
+                .into_iter()
+                .map(|a| {
+                    if pat_binds_name(&a.pat, name) {
+                        a
+                    } else {
+                        MatchArm {
+                            pat: a.pat,
+                            guard: a.guard.map(|g| substitute_current(g, name)),
+                            body: substitute_current(a.body, name),
+                        }
+                    }
+                })
+                .collect(),
+        },
+    }
+}
+
+fn substitute_step(step: Step, name: &str) -> Step {
+    match step {
+        Step::DynIndex(e) => Step::DynIndex(Box::new(substitute_current(*e, name))),
+        Step::Method(n, args) => Step::Method(
+            n,
+            args.into_iter().map(|a| substitute_arg(a, name)).collect(),
+        ),
+        Step::OptMethod(n, args) => Step::OptMethod(
+            n,
+            args.into_iter().map(|a| substitute_arg(a, name)).collect(),
+        ),
+        Step::InlineFilter(e) => Step::InlineFilter(Box::new(substitute_current(*e, name))),
+        Step::DeepMatch { arms, early_stop } => Step::DeepMatch {
+            arms: arms
+                .into_iter()
+                .map(|a| {
+                    if pat_binds_name(&a.pat, name) {
+                        a
+                    } else {
+                        MatchArm {
+                            pat: a.pat,
+                            guard: a.guard.map(|g| substitute_current(g, name)),
+                            body: substitute_current(a.body, name),
+                        }
+                    }
+                })
+                .collect(),
+            early_stop,
+        },
+        // Field/OptField/Descendant/DescendAll/Index/Slice/Quantifier carry no exprs.
+        other => other,
+    }
+}
+
+fn substitute_arg(arg: Arg, name: &str) -> Arg {
+    match arg {
+        Arg::Pos(e) => Arg::Pos(substitute_current(e, name)),
+        Arg::Named(k, e) => Arg::Named(k, substitute_current(e, name)),
+    }
+}
+
+fn substitute_obj_field(field: ObjField, name: &str) -> ObjField {
+    match field {
+        ObjField::Kv {
+            key,
+            val,
+            optional,
+            cond,
+        } => ObjField::Kv {
+            key,
+            val: substitute_current(val, name),
+            optional,
+            cond: cond.map(|c| substitute_current(c, name)),
+        },
+        ObjField::Short(s) => {
+            // `{name}` shorthand desugars to `{name: $.name}` — never touches
+            // the lambda parameter, regardless of whether `s == name`.
+            ObjField::Short(s)
+        }
+        ObjField::Dynamic { key, val } => ObjField::Dynamic {
+            key: substitute_current(key, name),
+            val: substitute_current(val, name),
+        },
+        ObjField::Spread(e) => ObjField::Spread(substitute_current(e, name)),
+        ObjField::SpreadDeep(e) => ObjField::SpreadDeep(substitute_current(e, name)),
+    }
+}
+
+fn substitute_patch_op(op: PatchOp, name: &str) -> PatchOp {
+    PatchOp {
+        path: op
+            .path
+            .into_iter()
+            .map(|s| substitute_path_step(s, name))
+            .collect(),
+        val: substitute_current(op.val, name),
+        cond: op.cond.map(|c| substitute_current(c, name)),
+    }
+}
+
+fn substitute_path_step(step: PathStep, name: &str) -> PathStep {
+    match step {
+        PathStep::DynIndex(e) => PathStep::DynIndex(substitute_current(e, name)),
+        PathStep::WildcardFilter(e) => {
+            PathStep::WildcardFilter(Box::new(substitute_current(*e, name)))
+        }
+        other => other,
+    }
+}

--- a/jetro-core/src/compile/mod.rs
+++ b/jetro-core/src/compile/mod.rs
@@ -4,4 +4,5 @@
 //! rewrites applied to programs before they reach the VM.
 
 pub(crate) mod compiler;
+pub(crate) mod lambda_lower;
 pub(crate) mod passes;

--- a/jetro-core/src/data/runtime.rs
+++ b/jetro-core/src/data/runtime.rs
@@ -239,25 +239,24 @@ fn apply_compiled_item(
         .ok_or_else(|| EvalError(format!("{}: missing compiled argument", call.name)))?;
     let kernel = call.sub_kernels.get(idx);
 
-    // Fast path: when the kernel is a non-`Generic` shape and the lambda
-    // does not introduce a named parameter, evaluate directly against
-    // `item` without entering the VM. The kernel reads `@` semantically
-    // by treating `item` as the current value.
+    // Fast path: when the kernel is a non-`Generic` shape, evaluate `prog`
+    // directly against `item` through native Rust kernels — no VM stack
+    // init, no opcode-dispatch loop. The compile-time AST lambda lowering
+    // rewrites `r => r.id` to the same opcodes as `@.id`, so single-param
+    // named lambdas are kernel-eligible exactly when the equivalent
+    // `@`-form is. Multi-param lambdas and bodies wrapped in
+    // `BindLamCurrent` (nested-ref case) classify as `Generic`, so the
+    // gate alone is sufficient.
     if let Some(k) = kernel {
         if !matches!(k, BodyKernel::Generic) && env.has_no_vars() {
-            let lambda_name = match arg {
-                Arg::Pos(Expr::Lambda { params, .. })
-                | Arg::Named(_, Expr::Lambda { params, .. }) => params.first().map(|s| s.as_str()),
-                _ => None,
-            };
-            // `LoadIdent` at the head of a body program dispatches to
-            // a no-arg builtin when current is array/string and the
-            // ident is a builtin name (e.g. `.map(len)` invokes `len`
-            // as a builtin) — a path the kernel form drops. Skip the
-            // fast path for those programs.
+            // `LoadIdent` at the head of a body program dispatches to a
+            // no-arg builtin when current is array/string and the ident
+            // is a builtin name (e.g. `.map(len)` invokes `len` as a
+            // builtin) — a path the kernel form drops. Skip the fast
+            // path for those programs.
             let starts_with_load_ident =
                 matches!(prog.ops.first(), Some(crate::vm::Opcode::LoadIdent(_)));
-            if lambda_name.is_none() && !starts_with_load_ident {
+            if !starts_with_load_ident {
                 return eval_kernel(k, &item, |fallback_item| {
                     let frame = env.push_lam(None, fallback_item.clone());
                     let result = vm.exec_in_env(prog, env);
@@ -270,7 +269,16 @@ fn apply_compiled_item(
 
     match arg {
         Arg::Pos(Expr::Lambda { params, .. }) | Arg::Named(_, Expr::Lambda { params, .. }) => {
-            let name = params.first().map(|s| s.as_str());
+            // Single-param lambda body has been AST-substituted to the
+            // `@`-form opcode shape — name is unreferenced in `prog`,
+            // so push_lam can skip the var insert/remove and only swap
+            // `current`. Multi-param lambdas (handled in
+            // `apply_compiled_pair`) keep their named bindings.
+            let name = if params.len() == 1 {
+                None
+            } else {
+                params.first().map(|s| s.as_str())
+            };
             let frame = env.push_lam(name, item);
             let result = vm.exec_in_env(prog, env);
             env.pop_lam(frame);
@@ -311,15 +319,20 @@ fn apply_compiled_pair(
                     env.pop_lam(frame);
                     result
                 }
-                [param] => {
-                    let frame = env.push_lam(Some(param), second);
+                [_param] => {
+                    // Single-param lambda body is AST-substituted; param
+                    // name is no longer referenced in `prog`.
+                    let frame = env.push_lam(None, second);
                     let result = vm.exec_in_env(prog, env);
                     env.pop_lam(frame);
                     result
                 }
-                [left, right, ..] => {
+                [left, _right, ..] => {
+                    // Multi-param fast path: rightmost param substituted
+                    // to `Current`, only earlier params keep their named
+                    // bindings.
                     let left_frame = env.push_lam(Some(left), first);
-                    let right_frame = env.push_lam(Some(right), second);
+                    let right_frame = env.push_lam(None, second);
                     let result = vm.exec_in_env(prog, env);
                     env.pop_lam(right_frame);
                     env.pop_lam(left_frame);

--- a/jetro-core/src/data/view.rs
+++ b/jetro-core/src/data/view.rs
@@ -19,6 +19,8 @@ pub(crate) trait ValueView<'a>: Clone {
     fn scalar(&self) -> JsonView<'_>;
     /// Navigate into the named field of an object node, returning `Null` if absent.
     fn field(&self, key: &str) -> Self;
+    /// Return whether the current object has `key`, or `None` if the current node is not an object.
+    fn has_key(&self, key: &str) -> Option<bool>;
     /// Navigate to the element at `idx` (negative indices count from the end),
     /// returning `Null` if out of bounds.
     fn index(&self, idx: i64) -> Self;
@@ -96,6 +98,15 @@ impl<'a> ValueView<'a> for ValView<'a> {
                 .unwrap_or_else(|| Self::Owned(Val::Null)),
             Self::Borrowed(_) => Self::Owned(Val::Null),
             Self::Owned(value) => Self::Owned(value.get_field(key)),
+        }
+    }
+
+    #[inline]
+    fn has_key(&self, key: &str) -> Option<bool> {
+        match self.value() {
+            Val::Obj(map) => Some(map.contains_key(key)),
+            Val::ObjSmall(pairs) => Some(pairs.iter().any(|(k, _)| k.as_ref() == key)),
+            _ => None,
         }
     }
 
@@ -317,6 +328,29 @@ impl<'a> ValueView<'a> for TapeView<'a> {
     }
 
     #[inline]
+    fn has_key(&self, key: &str) -> Option<bool> {
+        use crate::data::tape::TapeNode;
+
+        let Self::Node { tape, idx } = self else {
+            return None;
+        };
+        let TapeNode::Object { len, .. } = tape.nodes[*idx] else {
+            return None;
+        };
+
+        let mut cur = *idx + 1;
+        for _ in 0..len {
+            let current_key = tape.str_at(cur);
+            cur += 1;
+            if current_key == key {
+                return Some(true);
+            }
+            cur += tape.span(cur);
+        }
+        Some(false)
+    }
+
+    #[inline]
     fn index(&self, idx: i64) -> Self {
         use crate::data::tape::TapeNode;
 
@@ -440,6 +474,18 @@ mod tests {
     }
 
     #[test]
+    fn val_view_checks_object_keys_without_reading_values() {
+        let value = Val::from(&json!({
+            "book": {"title": "Dune", "score": 901}
+        }));
+        let book = ValView::new(&value).field("book");
+
+        assert_eq!(book.has_key("title"), Some(true));
+        assert_eq!(book.has_key("missing"), Some(false));
+        assert_eq!(book.field("title").has_key("x"), None);
+    }
+
+    #[test]
     fn val_view_indexes_columnar_arrays() {
         let nums = Val::IntVec(Arc::new(vec![10, 20, 30]));
         let view = ValView::new(&nums);
@@ -490,6 +536,12 @@ mod tests {
             (tape_score, val_score),
             (JsonView::Int(901), JsonView::Int(901))
         ));
+        let tape_book = TapeView::root(&tape).field("books").index(1);
+        let val_book = ValView::new(&val).field("books").index(1);
+
+        assert_eq!(tape_book.has_key("title"), Some(true));
+        assert_eq!(tape_book.has_key("missing"), Some(false));
+        assert_eq!(tape_book.has_key("title"), val_book.has_key("title"));
     }
 
     #[cfg(feature = "simd-json")]

--- a/jetro-core/src/data/view.rs
+++ b/jetro-core/src/data/view.rs
@@ -6,10 +6,11 @@
 //! (simd-json, behind the `simd-json` feature). Paths that need a concrete
 //! `Val` call `materialize()`; structural navigation stays zero-alloc.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::util::JsonView;
 use crate::data::value::Val;
+use crate::util::JsonView;
 
 /// Navigation interface shared by all document representations.
 /// Implementations exist for `ValView` (in-memory `Val` tree) and,
@@ -21,6 +22,16 @@ pub(crate) trait ValueView<'a>: Clone {
     fn field(&self, key: &str) -> Self;
     /// Return whether the current object has `key`, or `None` if the current node is not an object.
     fn has_key(&self, key: &str) -> Option<bool>;
+    /// Return the current object's keys without materialising child values.
+    fn object_keys(&self) -> Option<Val>;
+    /// Return the current object's values, materialising only the values.
+    fn object_values(&self) -> Option<Val>;
+    /// Return the current object's `[key, value]` entries.
+    fn object_entries(&self) -> Option<Val>;
+    /// Keep only `keys` from the current object, materialising selected values only.
+    fn pick_keys(&self, keys: &[Arc<str>]) -> Option<Val>;
+    /// Drop `keys` from the current object.
+    fn omit_keys(&self, keys: &[Arc<str>]) -> Option<Val>;
     /// Navigate to the element at `idx` (negative indices count from the end),
     /// returning `Null` if out of bounds.
     fn index(&self, idx: i64) -> Self;
@@ -106,6 +117,98 @@ impl<'a> ValueView<'a> for ValView<'a> {
         match self.value() {
             Val::Obj(map) => Some(map.contains_key(key)),
             Val::ObjSmall(pairs) => Some(pairs.iter().any(|(k, _)| k.as_ref() == key)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn object_keys(&self) -> Option<Val> {
+        match self.value() {
+            Val::Obj(map) => Some(Val::arr(
+                map.keys().cloned().map(Val::Str).collect::<Vec<_>>(),
+            )),
+            Val::ObjSmall(pairs) => Some(Val::arr(
+                pairs
+                    .iter()
+                    .map(|(key, _)| Val::Str(Arc::clone(key)))
+                    .collect::<Vec<_>>(),
+            )),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn object_values(&self) -> Option<Val> {
+        match self.value() {
+            Val::Obj(map) => Some(Val::arr(map.values().cloned().collect::<Vec<_>>())),
+            Val::ObjSmall(pairs) => Some(Val::arr(
+                pairs.iter().map(|(_, value)| value.clone()).collect::<Vec<_>>(),
+            )),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn object_entries(&self) -> Option<Val> {
+        match self.value() {
+            Val::Obj(map) => Some(Val::arr(
+                map.iter()
+                    .map(|(key, value)| Val::arr(vec![Val::Str(Arc::clone(key)), value.clone()]))
+                    .collect::<Vec<_>>(),
+            )),
+            Val::ObjSmall(pairs) => Some(Val::arr(
+                pairs
+                    .iter()
+                    .map(|(key, value)| Val::arr(vec![Val::Str(Arc::clone(key)), value.clone()]))
+                    .collect::<Vec<_>>(),
+            )),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn pick_keys(&self, keys: &[Arc<str>]) -> Option<Val> {
+        match self.value() {
+            Val::Obj(map) => {
+                let mut out = indexmap::IndexMap::with_capacity(keys.len());
+                for key in keys {
+                    if let Some(value) = map.get(key.as_ref()) {
+                        out.insert(Arc::clone(key), value.clone());
+                    }
+                }
+                Some(Val::obj(out))
+            }
+            Val::ObjSmall(pairs) => {
+                let mut out = indexmap::IndexMap::with_capacity(keys.len());
+                for key in keys {
+                    if let Some((_, value)) = pairs.iter().find(|(k, _)| k.as_ref() == key.as_ref())
+                    {
+                        out.insert(Arc::clone(key), value.clone());
+                    }
+                }
+                Some(Val::obj(out))
+            }
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn omit_keys(&self, keys: &[Arc<str>]) -> Option<Val> {
+        let omitted: HashSet<&str> = keys.iter().map(|key| key.as_ref()).collect();
+        match self.value() {
+            Val::Obj(map) => Some(Val::obj(
+                map.iter()
+                    .filter(|(key, _)| !omitted.contains(key.as_ref()))
+                    .map(|(key, value)| (Arc::clone(key), value.clone()))
+                    .collect(),
+            )),
+            Val::ObjSmall(pairs) => Some(Val::obj(
+                pairs
+                    .iter()
+                    .filter(|(key, _)| !omitted.contains(key.as_ref()))
+                    .map(|(key, value)| (Arc::clone(key), value.clone()))
+                    .collect(),
+            )),
             _ => None,
         }
     }
@@ -351,6 +454,136 @@ impl<'a> ValueView<'a> for TapeView<'a> {
     }
 
     #[inline]
+    fn object_keys(&self) -> Option<Val> {
+        use crate::data::tape::TapeNode;
+
+        let Self::Node { tape, idx } = self else {
+            return None;
+        };
+        let TapeNode::Object { len, .. } = tape.nodes[*idx] else {
+            return None;
+        };
+
+        let mut out = Vec::with_capacity(len);
+        let mut cur = *idx + 1;
+        for _ in 0..len {
+            out.push(Val::Str(Arc::from(tape.str_at(cur))));
+            cur += 1;
+            cur += tape.span(cur);
+        }
+        Some(Val::arr(out))
+    }
+
+    #[inline]
+    fn object_values(&self) -> Option<Val> {
+        use crate::data::tape::TapeNode;
+
+        let Self::Node { tape, idx } = self else {
+            return None;
+        };
+        let TapeNode::Object { len, .. } = tape.nodes[*idx] else {
+            return None;
+        };
+
+        let mut out = Vec::with_capacity(len);
+        let mut cur = *idx + 1;
+        for _ in 0..len {
+            cur += 1;
+            let mut value_idx = cur;
+            out.push(Self::materialize_at(tape, &mut value_idx));
+            cur += tape.span(cur);
+        }
+        Some(Val::arr(out))
+    }
+
+    #[inline]
+    fn object_entries(&self) -> Option<Val> {
+        use crate::data::tape::TapeNode;
+
+        let Self::Node { tape, idx } = self else {
+            return None;
+        };
+        let TapeNode::Object { len, .. } = tape.nodes[*idx] else {
+            return None;
+        };
+
+        let mut out = Vec::with_capacity(len);
+        let mut cur = *idx + 1;
+        for _ in 0..len {
+            let key = Arc::from(tape.str_at(cur));
+            cur += 1;
+            let mut value_idx = cur;
+            out.push(Val::arr(vec![
+                Val::Str(key),
+                Self::materialize_at(tape, &mut value_idx),
+            ]));
+            cur += tape.span(cur);
+        }
+        Some(Val::arr(out))
+    }
+
+    #[inline]
+    fn pick_keys(&self, keys: &[Arc<str>]) -> Option<Val> {
+        use crate::data::tape::TapeNode;
+
+        let Self::Node { tape, idx } = self else {
+            return None;
+        };
+        let TapeNode::Object { len, .. } = tape.nodes[*idx] else {
+            return None;
+        };
+
+        let mut out = indexmap::IndexMap::with_capacity(keys.len());
+        let mut remaining: HashSet<&str> = keys.iter().map(|key| key.as_ref()).collect();
+        let mut cur = *idx + 1;
+        for _ in 0..len {
+            let current_key = tape.str_at(cur);
+            cur += 1;
+            if remaining.remove(current_key) {
+                let mut value_idx = cur;
+                out.insert(
+                    crate::data::value::intern_key(current_key),
+                    Self::materialize_at(tape, &mut value_idx),
+                );
+                if remaining.is_empty() {
+                    break;
+                }
+            }
+            cur += tape.span(cur);
+        }
+        Some(Val::obj(out))
+    }
+
+    #[inline]
+    fn omit_keys(&self, keys: &[Arc<str>]) -> Option<Val> {
+        use crate::data::tape::TapeNode;
+
+        let Self::Node { tape, idx } = self else {
+            return None;
+        };
+        let TapeNode::Object { len, .. } = tape.nodes[*idx] else {
+            return None;
+        };
+
+        let omitted: HashSet<&str> = keys.iter().map(|key| key.as_ref()).collect();
+        let mut out = indexmap::IndexMap::with_capacity(len.saturating_sub(omitted.len()));
+        let mut cur = *idx + 1;
+        for _ in 0..len {
+            let current_key = tape.str_at(cur);
+            cur += 1;
+            if !omitted.contains(current_key) {
+                let mut value_idx = cur;
+                out.insert(
+                    crate::data::value::intern_key(current_key),
+                    Self::materialize_at(tape, &mut value_idx),
+                );
+            }
+            cur += tape.span(cur);
+        }
+        Some(Val::obj(out))
+    }
+
+    #[inline]
     fn index(&self, idx: i64) -> Self {
         use crate::data::tape::TapeNode;
 
@@ -486,6 +719,27 @@ mod tests {
     }
 
     #[test]
+    fn val_view_object_helpers_match_object_semantics() {
+        let value = Val::from(&json!({
+            "book": {"title": "Dune", "score": 901, "debug": true}
+        }));
+        let book = ValView::new(&value).field("book");
+
+        assert_eq!(
+            serde_json::Value::from(book.object_keys().unwrap()),
+            json!(["debug", "score", "title"])
+        );
+        assert_eq!(
+            serde_json::Value::from(book.pick_keys(&[Arc::from("score")]).unwrap()),
+            json!({"score": 901})
+        );
+        assert_eq!(
+            serde_json::Value::from(book.omit_keys(&[Arc::from("debug")]).unwrap()),
+            json!({"score": 901, "title": "Dune"})
+        );
+    }
+
+    #[test]
     fn val_view_indexes_columnar_arrays() {
         let nums = Val::IntVec(Arc::new(vec![10, 20, 30]));
         let view = ValView::new(&nums);
@@ -542,6 +796,35 @@ mod tests {
         assert_eq!(tape_book.has_key("title"), Some(true));
         assert_eq!(tape_book.has_key("missing"), Some(false));
         assert_eq!(tape_book.has_key("title"), val_book.has_key("title"));
+
+        assert_eq!(
+            tape_book.object_keys().map(serde_json::Value::from),
+            val_book.object_keys().map(serde_json::Value::from)
+        );
+        assert_eq!(
+            tape_book.object_values().map(serde_json::Value::from),
+            val_book.object_values().map(serde_json::Value::from)
+        );
+        assert_eq!(
+            tape_book.object_entries().map(serde_json::Value::from),
+            val_book.object_entries().map(serde_json::Value::from)
+        );
+        assert_eq!(
+            tape_book
+                .pick_keys(&[Arc::from("score")])
+                .map(serde_json::Value::from),
+            val_book
+                .pick_keys(&[Arc::from("score")])
+                .map(serde_json::Value::from)
+        );
+        assert_eq!(
+            tape_book
+                .omit_keys(&[Arc::from("title")])
+                .map(serde_json::Value::from),
+            val_book
+                .omit_keys(&[Arc::from("title")])
+                .map(serde_json::Value::from)
+        );
     }
 
     #[cfg(feature = "simd-json")]

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -1568,6 +1568,15 @@ mod tests {
     }
 
     #[test]
+    fn positional_many_terminal_sinks_use_indexed_dispatch_for_indexed_chains() {
+        let first = lower_query("$.xs.map(@ + 1).first(2)").unwrap();
+        assert_eq!(first.exec_path, PhysicalExecPath::Indexed);
+
+        let last = lower_query("$.xs.map(@ + 1).last(2)").unwrap();
+        assert_eq!(last.exec_path, PhysicalExecPath::Indexed);
+    }
+
+    #[test]
     fn positional_many_terminal_sinks_propagate_bounded_demand() {
         let first = lower_query("$.xs.first(3)").unwrap();
         assert!(matches!(

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -139,6 +139,7 @@ fn sink_name(s: &Sink) -> &'static str {
             PredicateSinkOp::All => "all",
             PredicateSinkOp::FindIndex => "find_index",
             PredicateSinkOp::IndicesWhere => "indices_where",
+            PredicateSinkOp::FindOne => "find_one",
         },
         Sink::ArgExtreme(spec) if spec.want_max => "max_by",
         Sink::ArgExtreme(_) => "min_by",
@@ -1711,6 +1712,11 @@ mod tests {
         ] {
             assert_pipeline_matches_vm(query, doc.clone());
         }
+
+        let pipeline = lower_query("$.xs.find_one(score == 9)").unwrap();
+        let root = Val::from(&doc);
+        let actual: serde_json::Value = pipeline.run(&root).unwrap().into();
+        assert_eq!(actual["isbn"], json!("b"));
     }
 
     #[test]
@@ -1750,6 +1756,36 @@ mod tests {
             indices_where.source_demand().chain.value,
             crate::plan::demand::ValueNeed::Predicate
         );
+
+        let find_one = lower_query("$.xs.find_one(@ > 2)").unwrap();
+        assert!(matches!(find_one.sink, Sink::Predicate(ref spec) if spec.op == PredicateSinkOp::FindOne));
+        assert_eq!(
+            find_one.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::All
+        );
+        assert_eq!(
+            find_one.source_demand().chain.value,
+            crate::plan::demand::ValueNeed::Whole
+        );
+    }
+
+    #[test]
+    fn find_one_terminal_sink_errors_on_zero_or_multiple_matches() {
+        use serde_json::json;
+        let doc = json!({
+            "xs": [
+                {"score": 1},
+                {"score": 9},
+                {"score": 11}
+            ]
+        });
+        let root = Val::from(&doc);
+
+        let zero = lower_query("$.xs.find_one(score > 100)").unwrap();
+        assert!(zero.run(&root).is_err());
+
+        let multiple = lower_query("$.xs.find_one(score > 5)").unwrap();
+        assert!(multiple.run(&root).is_err());
     }
 
     #[test]

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -138,6 +138,7 @@ fn sink_name(s: &Sink) -> &'static str {
             PredicateSinkOp::Any => "any",
             PredicateSinkOp::All => "all",
             PredicateSinkOp::FindIndex => "find_index",
+            PredicateSinkOp::IndicesWhere => "indices_where",
         },
         Sink::Terminal(BuiltinMethod::First) => "first",
         Sink::Terminal(BuiltinMethod::Last) => "last",
@@ -1701,6 +1702,7 @@ mod tests {
             "$.xs.exists(score > 10)",
             "$.xs.all(score > 0)",
             "$.xs.find_index(score > 10)",
+            "$.xs.indices_where(score > 5)",
             "$.xs.map(isbn).find_index(@ == \"c\")",
         ] {
             assert_pipeline_matches_vm(query, doc.clone());
@@ -1734,6 +1736,15 @@ mod tests {
         assert_eq!(
             find_index.source_demand().chain.pull,
             crate::plan::demand::PullDemand::All
+        );
+
+        let indices_where = lower_query("$.xs.indices_where(@ > 2)").unwrap();
+        assert!(
+            matches!(indices_where.sink, Sink::Predicate(ref spec) if spec.op == PredicateSinkOp::IndicesWhere)
+        );
+        assert_eq!(
+            indices_where.source_demand().chain.value,
+            crate::plan::demand::ValueNeed::Predicate
         );
     }
 

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -51,8 +51,8 @@ pub use ir::{PhysicalExecPath, Plan, Position, StageStrategy};
 pub use kernels::{eval_cmp_op, eval_kernel, BodyKernel};
 pub(crate) use kernels::{eval_view_kernel, CollectLayout, ObjectKernel, ViewKernelValue};
 pub use operator::{
-    MembershipSinkOp, MembershipSinkSpec, PredicateSinkOp, PredicateSinkSpec, ReducerOp,
-    ReducerSpec,
+    ArgExtremeSinkSpec, MembershipSinkOp, MembershipSinkSpec, PredicateSinkOp, PredicateSinkSpec,
+    ReducerOp, ReducerSpec,
 };
 #[cfg(test)]
 pub use plan::compute_strategies;
@@ -140,6 +140,8 @@ fn sink_name(s: &Sink) -> &'static str {
             PredicateSinkOp::FindIndex => "find_index",
             PredicateSinkOp::IndicesWhere => "indices_where",
         },
+        Sink::ArgExtreme(spec) if spec.want_max => "max_by",
+        Sink::ArgExtreme(_) => "min_by",
         Sink::Terminal(BuiltinMethod::First) => "first",
         Sink::Terminal(BuiltinMethod::Last) => "last",
         Sink::Nth(_) => "nth",
@@ -364,6 +366,8 @@ pub enum Sink {
     Predicate(PredicateSinkSpec),
     /// Evaluates an element-membership terminal (`includes`, `index`, `indices_of`).
     Membership(MembershipSinkSpec),
+    /// Keeps the row with the largest or smallest projected key (`max_by`, `min_by`).
+    ArgExtreme(ArgExtremeSinkSpec),
     /// Delegates to a built-in method that consumes the stream (e.g. `first`, `last`).
     Terminal(BuiltinMethod),
     /// Selects the nth emitted row from the stream.
@@ -1792,5 +1796,46 @@ mod tests {
         assert!(
             matches!(indices.sink, Sink::Membership(ref spec) if spec.op == MembershipSinkOp::IndicesOf)
         );
+    }
+
+    #[test]
+    fn arg_extreme_terminal_sinks_match_vm() {
+        use serde_json::json;
+        let doc = json!({
+            "xs": [
+                {"title": "A", "score": 1, "price": 20},
+                {"title": "B", "score": 9, "price": 10},
+                {"title": "C", "score": 9, "price": 30}
+            ],
+            "names": ["a", "abc", "ab"]
+        });
+
+        for query in [
+            "$.xs.max_by(score)",
+            "$.xs.min_by(price)",
+            "$.names.max_by(@.len())",
+            "$.names.min_by(@.len())",
+            "$.xs.map(@).max_by(score)",
+        ] {
+            assert_pipeline_matches_vm(query, doc.clone());
+        }
+    }
+
+    #[test]
+    fn arg_extreme_terminal_sinks_keep_conservative_source_demand() {
+        let max_by = lower_query("$.xs.max_by(score)").unwrap();
+        assert!(matches!(max_by.sink, Sink::ArgExtreme(ref spec) if spec.want_max));
+        assert_eq!(
+            max_by.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::All
+        );
+        assert_eq!(
+            max_by.source_demand().chain.value,
+            crate::plan::demand::ValueNeed::Whole
+        );
+        assert!(max_by.source_demand().chain.order);
+
+        let min_by = lower_query("$.xs.min_by(score)").unwrap();
+        assert!(matches!(min_by.sink, Sink::ArgExtreme(ref spec) if !spec.want_max));
     }
 }

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -1600,4 +1600,41 @@ mod tests {
         let out = p.run(&doc).unwrap();
         assert_eq!(out, Val::Int(50));
     }
+
+    #[test]
+    fn path_slice_lowers_to_bounded_positional_stages() {
+        use serde_json::json;
+        let doc: Val = (&json!({"xs": [10, 20, 30, 40, 50]})).into();
+
+        let p = lower_query("$.xs[0:3].last()").unwrap();
+        assert_eq!(
+            p.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::FirstInput(3)
+        );
+        assert_eq!(p.run(&doc).unwrap(), Val::Int(30));
+
+        let p = lower_query("$.xs[2:].take(2)").unwrap();
+        assert_eq!(
+            p.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::FirstInput(4)
+        );
+        let out: serde_json::Value = p.run(&doc).unwrap().into();
+        assert_eq!(out, json!([30, 40]));
+
+        assert!(lower_query("$.xs[-2:].first()").is_none());
+    }
+
+    #[test]
+    fn scalar_slice_preserves_pipeline_demand() {
+        use serde_json::json;
+        let doc: Val = (&json!({"rows": ["abc", "def"]})).into();
+
+        let p = lower_query("$.rows.slice(0, 2).last()").unwrap();
+        assert_eq!(
+            p.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::LastInput(1)
+        );
+        let out: serde_json::Value = p.run(&doc).unwrap().into();
+        assert_eq!(out, json!("de"));
+    }
 }

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -51,8 +51,8 @@ pub use ir::{PhysicalExecPath, Plan, Position, StageStrategy};
 pub use kernels::{eval_cmp_op, eval_kernel, BodyKernel};
 pub(crate) use kernels::{eval_view_kernel, CollectLayout, ObjectKernel, ViewKernelValue};
 pub use operator::{
-    ArgExtremeSinkSpec, MembershipSinkOp, MembershipSinkSpec, PredicateSinkOp, PredicateSinkSpec,
-    ReducerOp, ReducerSpec,
+    ArgExtremeSinkSpec, MembershipSinkOp, MembershipSinkSpec, MembershipSinkTarget,
+    PredicateSinkOp, PredicateSinkSpec, ReducerOp, ReducerSpec,
 };
 #[cfg(test)]
 pub use plan::compute_strategies;
@@ -1757,7 +1757,9 @@ mod tests {
         use serde_json::json;
         let doc = json!({
             "xs": ["a", "urgent", "x", "urgent"],
+            "needle": "urgent",
             "s": "hello",
+            "substring": "ell",
             "obj": {"urgent": true}
         });
 
@@ -1766,8 +1768,13 @@ mod tests {
             "$.xs.contains(\"urgent\")",
             "$.xs.index(\"urgent\")",
             "$.xs.indices_of(\"urgent\")",
+            "$.xs.includes($.needle)",
+            "$.xs.index($.needle)",
+            "$.xs.indices_of($.needle)",
             "$.xs.map(@).includes(\"x\")",
+            "$.xs.map(@).includes($.needle)",
             "$.s.includes(\"ell\")",
+            "$.s.includes($.substring)",
             "$.obj.includes(\"urgent\")",
         ] {
             assert_pipeline_matches_vm(query, doc.clone());
@@ -1795,6 +1802,12 @@ mod tests {
         let indices = lower_query("$.xs.indices_of(\"urgent\")").unwrap();
         assert!(
             matches!(indices.sink, Sink::Membership(ref spec) if spec.op == MembershipSinkOp::IndicesOf)
+        );
+
+        let dynamic = lower_query("$.xs.includes($.needle)").unwrap();
+        assert!(
+            matches!(dynamic.sink, Sink::Membership(ref spec)
+                if matches!(spec.target, MembershipSinkTarget::Program(_)))
         );
     }
 

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -50,7 +50,7 @@ pub use ir::Strategy;
 pub use ir::{PhysicalExecPath, Plan, Position, StageStrategy};
 pub use kernels::{eval_cmp_op, eval_kernel, BodyKernel};
 pub(crate) use kernels::{eval_view_kernel, CollectLayout, ObjectKernel, ViewKernelValue};
-pub use operator::{ReducerOp, ReducerSpec};
+pub use operator::{PredicateSinkOp, PredicateSinkSpec, ReducerOp, ReducerSpec};
 #[cfg(test)]
 pub use plan::compute_strategies;
 #[cfg(test)]
@@ -125,6 +125,11 @@ fn sink_name(s: &Sink) -> &'static str {
             ReducerOp::Numeric(NumOp::Min) => "min",
             ReducerOp::Numeric(NumOp::Max) => "max",
             ReducerOp::Numeric(NumOp::Avg) => "avg",
+        },
+        Sink::Predicate(spec) => match spec.op {
+            PredicateSinkOp::Any => "any",
+            PredicateSinkOp::All => "all",
+            PredicateSinkOp::FindIndex => "find_index",
         },
         Sink::Terminal(BuiltinMethod::First) => "first",
         Sink::Terminal(BuiltinMethod::Last) => "last",
@@ -346,6 +351,8 @@ pub enum Sink {
 
     /// Folds the stream using the given `ReducerSpec` (count, sum, min, max, avg).
     Reducer(ReducerSpec),
+    /// Evaluates a predicate terminal (`any`, `all`, `find_index`) with sink-owned state.
+    Predicate(PredicateSinkSpec),
     /// Delegates to a built-in method that consumes the stream (e.g. `first`, `last`).
     Terminal(BuiltinMethod),
     /// Selects the nth emitted row from the stream.
@@ -1660,8 +1667,63 @@ mod tests {
         assert_eq!(out, json!([[1, 2, 3], [2, 3, 4]]));
 
         let p = lower_query("$.xs.window(3).last()").unwrap();
-        assert_eq!(p.source_demand().chain.pull, crate::plan::demand::PullDemand::All);
+        assert_eq!(
+            p.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::All
+        );
         let out: serde_json::Value = p.run(&doc).unwrap().into();
         assert_eq!(out, json!([6, 7, 8]));
+    }
+
+    #[test]
+    fn predicate_terminal_sinks_match_vm() {
+        use serde_json::json;
+        let doc = json!({
+            "xs": [
+                {"score": 1, "isbn": "a"},
+                {"score": 9, "isbn": "b"},
+                {"score": 11, "isbn": "c"}
+            ]
+        });
+
+        for query in [
+            "$.xs.any(score > 10)",
+            "$.xs.exists(score > 10)",
+            "$.xs.all(score > 0)",
+            "$.xs.find_index(score > 10)",
+            "$.xs.map(isbn).find_index(@ == \"c\")",
+        ] {
+            assert_pipeline_matches_vm(query, doc.clone());
+        }
+    }
+
+    #[test]
+    fn predicate_terminal_sinks_keep_conservative_source_demand() {
+        let any = lower_query("$.xs.any(@ > 2)").unwrap();
+        assert!(matches!(any.sink, Sink::Predicate(ref spec) if spec.op == PredicateSinkOp::Any));
+        assert_eq!(
+            any.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::All
+        );
+        assert_eq!(
+            any.source_demand().chain.value,
+            crate::plan::demand::ValueNeed::Predicate
+        );
+
+        let all = lower_query("$.xs.all(@ > 2)").unwrap();
+        assert!(matches!(all.sink, Sink::Predicate(ref spec) if spec.op == PredicateSinkOp::All));
+        assert_eq!(
+            all.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::All
+        );
+
+        let find_index = lower_query("$.xs.find_index(@ > 2)").unwrap();
+        assert!(
+            matches!(find_index.sink, Sink::Predicate(ref spec) if spec.op == PredicateSinkOp::FindIndex)
+        );
+        assert_eq!(
+            find_index.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::All
+        );
     }
 }

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -145,6 +145,8 @@ fn sink_name(s: &Sink) -> &'static str {
         Sink::ArgExtreme(_) => "min_by",
         Sink::Terminal(BuiltinMethod::First) => "first",
         Sink::Terminal(BuiltinMethod::Last) => "last",
+        Sink::SelectMany { from_end: false, .. } => "first_n",
+        Sink::SelectMany { from_end: true, .. } => "last_n",
         Sink::Nth(_) => "nth",
         Sink::Terminal(_) => "terminal",
         Sink::ApproxCountDistinct => "approx_count_distinct",
@@ -371,6 +373,13 @@ pub enum Sink {
     ArgExtreme(ArgExtremeSinkSpec),
     /// Delegates to a built-in method that consumes the stream (e.g. `first`, `last`).
     Terminal(BuiltinMethod),
+    /// Selects a bounded prefix or suffix from the stream.
+    SelectMany {
+        /// Number of rows to return.
+        n: usize,
+        /// When true, returns the last `n` rows; otherwise returns the first `n`.
+        from_end: bool,
+    },
     /// Selects the nth emitted row from the stream.
     Nth(usize),
 
@@ -1520,6 +1529,71 @@ mod tests {
         let out = p.run(&doc).unwrap();
         let out_json: serde_json::Value = out.into();
         assert_eq!(out_json, json!(902));
+    }
+
+    #[test]
+    fn positional_many_terminal_sinks_match_runtime_semantics() {
+        use serde_json::json;
+        let root = Val::from(&json!({"xs": [1, 2, 3, 4]}));
+
+        let first_one: serde_json::Value =
+            lower_query("$.xs.first(1)").unwrap().run(&root).unwrap().into();
+        assert_eq!(first_one, json!(1));
+
+        let first_two: serde_json::Value =
+            lower_query("$.xs.first(2)").unwrap().run(&root).unwrap().into();
+        assert_eq!(first_two, json!([1, 2]));
+
+        let last_one: serde_json::Value =
+            lower_query("$.xs.last(1)").unwrap().run(&root).unwrap().into();
+        assert_eq!(last_one, json!(4));
+
+        let last_two: serde_json::Value =
+            lower_query("$.xs.last(2)").unwrap().run(&root).unwrap().into();
+        assert_eq!(last_two, json!([3, 4]));
+
+        let mapped_first: serde_json::Value = lower_query("$.xs.map(@ + 1).first(2)")
+            .unwrap()
+            .run(&root)
+            .unwrap()
+            .into();
+        assert_eq!(mapped_first, json!([2, 3]));
+
+        let mapped_last: serde_json::Value = lower_query("$.xs.map(@ + 1).last(2)")
+            .unwrap()
+            .run(&root)
+            .unwrap()
+            .into();
+        assert_eq!(mapped_last, json!([4, 5]));
+    }
+
+    #[test]
+    fn positional_many_terminal_sinks_propagate_bounded_demand() {
+        let first = lower_query("$.xs.first(3)").unwrap();
+        assert!(matches!(
+            first.sink,
+            Sink::SelectMany {
+                n: 3,
+                from_end: false
+            }
+        ));
+        assert_eq!(
+            first.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::FirstInput(3)
+        );
+
+        let last = lower_query("$.xs.last(3)").unwrap();
+        assert!(matches!(
+            last.sink,
+            Sink::SelectMany {
+                n: 3,
+                from_end: true
+            }
+        ));
+        assert_eq!(
+            last.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::LastInput(3)
+        );
     }
 
     #[test]

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -37,7 +37,8 @@ mod symbolic;
 mod val_stage_flow;
 pub(crate) use capability::{
     view_capabilities, view_prefix_capabilities, SourceAccessMode, SourceCapabilities,
-    ViewInputMode, ViewMaterialization, ViewOutputMode, ViewSinkCapability, ViewStageCapability,
+    ViewInputMode, ViewMaterialization, ViewMembershipTarget, ViewOutputMode, ViewSinkCapability,
+    ViewStageCapability,
 };
 pub(crate) use collector::{TerminalCollector, TerminalMapCollector};
 pub(crate) use common::{

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -1637,4 +1637,31 @@ mod tests {
         let out: serde_json::Value = p.run(&doc).unwrap().into();
         assert_eq!(out, json!("de"));
     }
+
+    #[test]
+    fn chunk_and_window_bounded_demand_match_vm() {
+        use serde_json::json;
+        let doc: Val = (&json!({"xs": [1, 2, 3, 4, 5, 6, 7, 8]})).into();
+
+        let p = lower_query("$.xs.chunk(3).take(2)").unwrap();
+        assert_eq!(
+            p.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::FirstInput(6)
+        );
+        let out: serde_json::Value = p.run(&doc).unwrap().into();
+        assert_eq!(out, json!([[1, 2, 3], [4, 5, 6]]));
+
+        let p = lower_query("$.xs.window(3).take(2)").unwrap();
+        assert_eq!(
+            p.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::FirstInput(4)
+        );
+        let out: serde_json::Value = p.run(&doc).unwrap().into();
+        assert_eq!(out, json!([[1, 2, 3], [2, 3, 4]]));
+
+        let p = lower_query("$.xs.window(3).last()").unwrap();
+        assert_eq!(p.source_demand().chain.pull, crate::plan::demand::PullDemand::All);
+        let out: serde_json::Value = p.run(&doc).unwrap().into();
+        assert_eq!(out, json!([6, 7, 8]));
+    }
 }

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -1450,6 +1450,34 @@ mod tests {
     }
 
     #[test]
+    fn reverse_propagates_positional_demand() {
+        use serde_json::json;
+        let doc: Val = (&json!({"xs": [10, 20, 30, 40]})).into();
+
+        let first = lower_query("$.xs.reverse().first()").unwrap();
+        assert_eq!(
+            first.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::LastInput(1)
+        );
+        assert_eq!(first.run(&doc).unwrap(), Val::Int(40));
+
+        let last = lower_query("$.xs.reverse().last()").unwrap();
+        assert_eq!(
+            last.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::FirstInput(1)
+        );
+        assert_eq!(last.run(&doc).unwrap(), Val::Int(10));
+
+        let take = lower_query("$.xs.reverse().take(2)").unwrap();
+        assert_eq!(
+            take.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::LastInput(2)
+        );
+        let take_json: serde_json::Value = take.run(&doc).unwrap().into();
+        assert_eq!(take_json, json!([40, 30]));
+    }
+
+    #[test]
     fn nth_sink_requests_indexed_input_when_available() {
         use serde_json::json;
         let doc: Val = (&json!({

--- a/jetro-core/src/exec/pipeline.rs
+++ b/jetro-core/src/exec/pipeline.rs
@@ -50,7 +50,10 @@ pub use ir::Strategy;
 pub use ir::{PhysicalExecPath, Plan, Position, StageStrategy};
 pub use kernels::{eval_cmp_op, eval_kernel, BodyKernel};
 pub(crate) use kernels::{eval_view_kernel, CollectLayout, ObjectKernel, ViewKernelValue};
-pub use operator::{PredicateSinkOp, PredicateSinkSpec, ReducerOp, ReducerSpec};
+pub use operator::{
+    MembershipSinkOp, MembershipSinkSpec, PredicateSinkOp, PredicateSinkSpec, ReducerOp,
+    ReducerSpec,
+};
 #[cfg(test)]
 pub use plan::compute_strategies;
 #[cfg(test)]
@@ -125,6 +128,11 @@ fn sink_name(s: &Sink) -> &'static str {
             ReducerOp::Numeric(NumOp::Min) => "min",
             ReducerOp::Numeric(NumOp::Max) => "max",
             ReducerOp::Numeric(NumOp::Avg) => "avg",
+        },
+        Sink::Membership(spec) => match spec.op {
+            MembershipSinkOp::Includes => "includes",
+            MembershipSinkOp::Index => "index",
+            MembershipSinkOp::IndicesOf => "indices_of",
         },
         Sink::Predicate(spec) => match spec.op {
             PredicateSinkOp::Any => "any",
@@ -353,6 +361,8 @@ pub enum Sink {
     Reducer(ReducerSpec),
     /// Evaluates a predicate terminal (`any`, `all`, `find_index`) with sink-owned state.
     Predicate(PredicateSinkSpec),
+    /// Evaluates an element-membership terminal (`includes`, `index`, `indices_of`).
+    Membership(MembershipSinkSpec),
     /// Delegates to a built-in method that consumes the stream (e.g. `first`, `last`).
     Terminal(BuiltinMethod),
     /// Selects the nth emitted row from the stream.
@@ -1724,6 +1734,52 @@ mod tests {
         assert_eq!(
             find_index.source_demand().chain.pull,
             crate::plan::demand::PullDemand::All
+        );
+    }
+
+    #[test]
+    fn membership_terminal_sinks_match_vm() {
+        use serde_json::json;
+        let doc = json!({
+            "xs": ["a", "urgent", "x", "urgent"],
+            "s": "hello",
+            "obj": {"urgent": true}
+        });
+
+        for query in [
+            "$.xs.includes(\"urgent\")",
+            "$.xs.contains(\"urgent\")",
+            "$.xs.index(\"urgent\")",
+            "$.xs.indices_of(\"urgent\")",
+            "$.xs.map(@).includes(\"x\")",
+            "$.s.includes(\"ell\")",
+            "$.obj.includes(\"urgent\")",
+        ] {
+            assert_pipeline_matches_vm(query, doc.clone());
+        }
+    }
+
+    #[test]
+    fn membership_terminal_sinks_keep_conservative_source_demand() {
+        let includes = lower_query("$.xs.includes(\"urgent\")").unwrap();
+        assert!(
+            matches!(includes.sink, Sink::Membership(ref spec) if spec.op == MembershipSinkOp::Includes)
+        );
+        assert_eq!(
+            includes.source_demand().chain.pull,
+            crate::plan::demand::PullDemand::All
+        );
+        assert_eq!(
+            includes.source_demand().chain.value,
+            crate::plan::demand::ValueNeed::Whole
+        );
+
+        let index = lower_query("$.xs.index(\"urgent\")").unwrap();
+        assert!(matches!(index.sink, Sink::Membership(ref spec) if spec.op == MembershipSinkOp::Index));
+
+        let indices = lower_query("$.xs.indices_of(\"urgent\")").unwrap();
+        assert!(
+            matches!(indices.sink, Sink::Membership(ref spec) if spec.op == MembershipSinkOp::IndicesOf)
         );
     }
 }

--- a/jetro-core/src/exec/pipeline/capability.rs
+++ b/jetro-core/src/exec/pipeline/capability.rs
@@ -10,8 +10,9 @@ use crate::builtins::{
 };
 use crate::data::value::Val;
 use crate::plan::demand::PullDemand;
+use crate::vm::Program;
 
-use super::{MembershipSinkOp, PipelineBody, PredicateSinkOp, Stage};
+use super::{MembershipSinkOp, MembershipSinkTarget, PipelineBody, PredicateSinkOp, Stage};
 
 /// Describes how a source can be traversed without materialising the full row set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -269,8 +270,8 @@ pub(crate) enum ViewSinkCapability {
     Membership {
         /// Membership terminal operation to perform.
         op: MembershipSinkOp,
-        /// Literal target compared against each row.
-        target: Val,
+        /// Target compared against each row.
+        target: ViewMembershipTarget,
     },
     /// Bounded positional selector for terminal `first(n)` / `last(n)`.
     SelectMany {
@@ -314,13 +315,40 @@ impl ViewSinkCapability {
                 }
             }
             Self::Membership { target, .. } => {
-                if target_is_scalar(target) {
+                if target.is_scalar_literal() {
                     ViewMaterialization::Never
                 } else {
                     ViewMaterialization::SinkInputRows
                 }
             }
             Self::SelectMany { .. } => ViewMaterialization::SinkOutputRows,
+        }
+    }
+}
+
+/// Target for a view-native membership terminal.
+#[derive(Debug, Clone)]
+pub(crate) enum ViewMembershipTarget {
+    /// Literal known during lowering.
+    Literal(Val),
+    /// Expression evaluated once against the outer environment before row streaming.
+    Program(std::sync::Arc<Program>),
+}
+
+impl ViewMembershipTarget {
+    fn is_scalar_literal(&self) -> bool {
+        match self {
+            Self::Literal(value) => target_is_scalar(value),
+            Self::Program(_) => false,
+        }
+    }
+}
+
+impl From<&MembershipSinkTarget> for ViewMembershipTarget {
+    fn from(target: &MembershipSinkTarget) -> Self {
+        match target {
+            MembershipSinkTarget::Literal(value) => Self::Literal(value.clone()),
+            MembershipSinkTarget::Program(program) => Self::Program(std::sync::Arc::clone(program)),
         }
     }
 }
@@ -401,8 +429,8 @@ mod tests {
     use crate::exec::pipeline::{
         BodyKernel, MembershipSinkOp, MembershipSinkSpec, MembershipSinkTarget, NumOp,
         PipelineBody, PredicateSinkOp, PredicateSinkSpec, ReducerOp, ReducerSpec, Sink, Stage,
-        ViewInputMode, ViewMaterialization, ViewOutputMode, ViewSinkCapability,
-        ViewStageCapability,
+        ViewInputMode, ViewMaterialization, ViewMembershipTarget, ViewOutputMode,
+        ViewSinkCapability, ViewStageCapability,
     };
     use crate::parse::ast::BinOp;
 
@@ -526,7 +554,7 @@ mod tests {
         assert_eq!(
             ViewSinkCapability::Membership {
                 op: MembershipSinkOp::Includes,
-                target: Val::Int(3),
+                target: ViewMembershipTarget::Literal(Val::Int(3)),
             }
             .materialization(),
             ViewMaterialization::Never
@@ -534,7 +562,7 @@ mod tests {
         assert_eq!(
             ViewSinkCapability::Membership {
                 op: MembershipSinkOp::Includes,
-                target: Val::arr(vec![Val::Int(3)]),
+                target: ViewMembershipTarget::Literal(Val::arr(vec![Val::Int(3)])),
             }
             .materialization(),
             ViewMaterialization::SinkInputRows
@@ -615,7 +643,22 @@ mod tests {
             .view_capability(&[]),
             Some(ViewSinkCapability::Membership {
                 op: MembershipSinkOp::Includes,
-                target: Val::Int(3),
+                target: ViewMembershipTarget::Literal(Val::Int(3)),
+            })
+        ));
+        assert!(matches!(
+            Sink::Membership(MembershipSinkSpec {
+                op: MembershipSinkOp::Includes,
+                target: MembershipSinkTarget::Program(Arc::new(crate::vm::Program::new(
+                    Vec::new(),
+                    ""
+                ))),
+                method: BuiltinMethod::Includes,
+            })
+            .view_capability(&[]),
+            Some(ViewSinkCapability::Membership {
+                op: MembershipSinkOp::Includes,
+                target: ViewMembershipTarget::Program(_),
             })
         ));
     }

--- a/jetro-core/src/exec/pipeline/capability.rs
+++ b/jetro-core/src/exec/pipeline/capability.rs
@@ -262,6 +262,15 @@ pub(crate) enum ViewSinkCapability {
         /// Index of the view-native predicate kernel in `sink_kernels`.
         predicate_kernel: usize,
     },
+    /// Bounded positional selector for terminal `first(n)` / `last(n)`.
+    SelectMany {
+        /// Number of rows requested by the terminal sink.
+        n: usize,
+        /// Whether the semantic selector wants rows from the end.
+        from_end: bool,
+        /// Whether the source iterator is running in reverse physical order.
+        source_reversed: bool,
+    },
 }
 
 impl ViewSinkCapability {
@@ -294,6 +303,7 @@ impl ViewSinkCapability {
                     ViewMaterialization::Never
                 }
             }
+            Self::SelectMany { .. } => ViewMaterialization::SinkOutputRows,
         }
     }
 }
@@ -488,6 +498,15 @@ mod tests {
             .materialization(),
             ViewMaterialization::SinkFinalRow
         );
+        assert_eq!(
+            ViewSinkCapability::SelectMany {
+                n: 2,
+                from_end: true,
+                source_reversed: true,
+            }
+            .materialization(),
+            ViewMaterialization::SinkOutputRows
+        );
     }
 
     #[test]
@@ -532,6 +551,18 @@ mod tests {
             Some(ViewSinkCapability::Predicate {
                 op: PredicateSinkOp::Any,
                 predicate_kernel: 0,
+            })
+        ));
+        assert!(matches!(
+            Sink::SelectMany {
+                n: 2,
+                from_end: true,
+            }
+            .view_capability(&[]),
+            Some(ViewSinkCapability::SelectMany {
+                n: 2,
+                from_end: true,
+                source_reversed: false,
             })
         ));
     }

--- a/jetro-core/src/exec/pipeline/capability.rs
+++ b/jetro-core/src/exec/pipeline/capability.rs
@@ -10,7 +10,7 @@ use crate::builtins::{
 };
 use crate::plan::demand::PullDemand;
 
-use super::{PipelineBody, Stage};
+use super::{PipelineBody, PredicateSinkOp, Stage};
 
 /// Describes how a source can be traversed without materialising the full row set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -255,6 +255,13 @@ pub(crate) enum ViewSinkCapability {
         /// Zero-based output index selected by the sink.
         index: usize,
     },
+    /// Predicate terminal sink (`any`, `all`, `find_index`, `indices_where`, `find_one`).
+    Predicate {
+        /// Predicate terminal operation to perform.
+        op: PredicateSinkOp,
+        /// Index of the view-native predicate kernel in `sink_kernels`.
+        predicate_kernel: usize,
+    },
 }
 
 impl ViewSinkCapability {
@@ -280,6 +287,13 @@ impl ViewSinkCapability {
                 materialization, ..
             } => materialization,
             Self::Nth { .. } => ViewMaterialization::SinkFinalRow,
+            Self::Predicate { op, .. } => {
+                if op == PredicateSinkOp::FindOne {
+                    ViewMaterialization::SinkFinalRow
+                } else {
+                    ViewMaterialization::Never
+                }
+            }
         }
     }
 }
@@ -351,8 +365,9 @@ mod tests {
     };
     use crate::data::value::Val;
     use crate::exec::pipeline::{
-        BodyKernel, NumOp, PipelineBody, ReducerOp, ReducerSpec, Sink, Stage, ViewInputMode,
-        ViewMaterialization, ViewOutputMode, ViewSinkCapability, ViewStageCapability,
+        BodyKernel, NumOp, PipelineBody, PredicateSinkOp, PredicateSinkSpec, ReducerOp,
+        ReducerSpec, Sink, Stage, ViewInputMode, ViewMaterialization, ViewOutputMode,
+        ViewSinkCapability, ViewStageCapability,
     };
     use crate::parse::ast::BinOp;
 
@@ -457,6 +472,22 @@ mod tests {
             .materialization(),
             ViewMaterialization::SinkFinalRow
         );
+        assert_eq!(
+            ViewSinkCapability::Predicate {
+                op: PredicateSinkOp::Any,
+                predicate_kernel: 0,
+            }
+            .materialization(),
+            ViewMaterialization::Never
+        );
+        assert_eq!(
+            ViewSinkCapability::Predicate {
+                op: PredicateSinkOp::FindOne,
+                predicate_kernel: 0,
+            }
+            .materialization(),
+            ViewMaterialization::SinkFinalRow
+        );
     }
 
     #[test]
@@ -486,6 +517,21 @@ mod tests {
                 predicate_kernel: None,
                 project_kernel: None,
                 materialization: ViewMaterialization::SinkFinalRow,
+            })
+        ));
+        assert!(matches!(
+            Sink::Predicate(PredicateSinkSpec {
+                op: PredicateSinkOp::Any,
+                predicate: Arc::new(crate::vm::Program::new(Vec::new(), "")),
+            })
+            .view_capability(&[BodyKernel::FieldCmpLit(
+                Arc::from("score"),
+                BinOp::Gt,
+                Val::Int(10),
+            )]),
+            Some(ViewSinkCapability::Predicate {
+                op: PredicateSinkOp::Any,
+                predicate_kernel: 0,
             })
         ));
     }

--- a/jetro-core/src/exec/pipeline/capability.rs
+++ b/jetro-core/src/exec/pipeline/capability.rs
@@ -8,9 +8,10 @@ use crate::builtins::{
     BuiltinKeyedReducer, BuiltinSinkAccumulator, BuiltinSinkSpec, BuiltinViewInputMode,
     BuiltinViewOutputMode, BuiltinViewStage,
 };
+use crate::data::value::Val;
 use crate::plan::demand::PullDemand;
 
-use super::{PipelineBody, PredicateSinkOp, Stage};
+use super::{MembershipSinkOp, PipelineBody, PredicateSinkOp, Stage};
 
 /// Describes how a source can be traversed without materialising the full row set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -104,6 +105,8 @@ pub(crate) enum ViewMaterialization {
     SinkFinalRow,
     /// The sink materialises each element's numeric input for folding (e.g. `sum`).
     SinkNumericInput,
+    /// The sink materialises input rows for its own comparison/state, not for output.
+    SinkInputRows,
 }
 
 /// Full capability descriptor for a `PipelineBody`: per-stage entries plus the sink capability.
@@ -235,7 +238,7 @@ impl ViewStageCapability {
 }
 
 /// Describes how a pipeline sink interacts with the view domain.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) enum ViewSinkCapability {
     /// The sink collects all views, materialising each row into the output array.
     Collect,
@@ -261,6 +264,13 @@ pub(crate) enum ViewSinkCapability {
         op: PredicateSinkOp,
         /// Index of the view-native predicate kernel in `sink_kernels`.
         predicate_kernel: usize,
+    },
+    /// Literal value-membership terminal sink (`includes`, `index`, `indices_of`).
+    Membership {
+        /// Membership terminal operation to perform.
+        op: MembershipSinkOp,
+        /// Literal target compared against each row.
+        target: Val,
     },
     /// Bounded positional selector for terminal `first(n)` / `last(n)`.
     SelectMany {
@@ -289,23 +299,37 @@ impl ViewSinkCapability {
     }
 
     /// Returns when this sink must materialise element values from the view domain.
-    pub(crate) fn materialization(self) -> ViewMaterialization {
+    pub(crate) fn materialization(&self) -> ViewMaterialization {
         match self {
             Self::Collect => ViewMaterialization::SinkOutputRows,
             Self::Builtin {
                 materialization, ..
-            } => materialization,
+            } => *materialization,
             Self::Nth { .. } => ViewMaterialization::SinkFinalRow,
             Self::Predicate { op, .. } => {
-                if op == PredicateSinkOp::FindOne {
+                if *op == PredicateSinkOp::FindOne {
                     ViewMaterialization::SinkFinalRow
                 } else {
                     ViewMaterialization::Never
                 }
             }
+            Self::Membership { target, .. } => {
+                if target_is_scalar(target) {
+                    ViewMaterialization::Never
+                } else {
+                    ViewMaterialization::SinkInputRows
+                }
+            }
             Self::SelectMany { .. } => ViewMaterialization::SinkOutputRows,
         }
     }
+}
+
+fn target_is_scalar(value: &Val) -> bool {
+    matches!(
+        value,
+        Val::Null | Val::Bool(_) | Val::Int(_) | Val::Float(_) | Val::Str(_) | Val::StrSlice(_)
+    )
 }
 
 // maps the builtin sink accumulator kind to the materialisation policy it requires
@@ -375,9 +399,10 @@ mod tests {
     };
     use crate::data::value::Val;
     use crate::exec::pipeline::{
-        BodyKernel, NumOp, PipelineBody, PredicateSinkOp, PredicateSinkSpec, ReducerOp,
-        ReducerSpec, Sink, Stage, ViewInputMode, ViewMaterialization, ViewOutputMode,
-        ViewSinkCapability, ViewStageCapability,
+        BodyKernel, MembershipSinkOp, MembershipSinkSpec, MembershipSinkTarget, NumOp,
+        PipelineBody, PredicateSinkOp, PredicateSinkSpec, ReducerOp, ReducerSpec, Sink, Stage,
+        ViewInputMode, ViewMaterialization, ViewOutputMode, ViewSinkCapability,
+        ViewStageCapability,
     };
     use crate::parse::ast::BinOp;
 
@@ -499,6 +524,22 @@ mod tests {
             ViewMaterialization::SinkFinalRow
         );
         assert_eq!(
+            ViewSinkCapability::Membership {
+                op: MembershipSinkOp::Includes,
+                target: Val::Int(3),
+            }
+            .materialization(),
+            ViewMaterialization::Never
+        );
+        assert_eq!(
+            ViewSinkCapability::Membership {
+                op: MembershipSinkOp::Includes,
+                target: Val::arr(vec![Val::Int(3)]),
+            }
+            .materialization(),
+            ViewMaterialization::SinkInputRows
+        );
+        assert_eq!(
             ViewSinkCapability::SelectMany {
                 n: 2,
                 from_end: true,
@@ -563,6 +604,18 @@ mod tests {
                 n: 2,
                 from_end: true,
                 source_reversed: false,
+            })
+        ));
+        assert!(matches!(
+            Sink::Membership(MembershipSinkSpec {
+                op: MembershipSinkOp::Includes,
+                target: MembershipSinkTarget::Literal(Val::Int(3)),
+                method: BuiltinMethod::Includes,
+            })
+            .view_capability(&[]),
+            Some(ViewSinkCapability::Membership {
+                op: MembershipSinkOp::Includes,
+                target: Val::Int(3),
             })
         ));
     }

--- a/jetro-core/src/exec/pipeline/capability.rs
+++ b/jetro-core/src/exec/pipeline/capability.rs
@@ -273,6 +273,13 @@ pub(crate) enum ViewSinkCapability {
         /// Target compared against each row.
         target: ViewMembershipTarget,
     },
+    /// Arg-extreme terminal sink (`max_by`, `min_by`).
+    ArgExtreme {
+        /// When true, keeps the row with the largest key; otherwise the smallest key.
+        want_max: bool,
+        /// Index of the view-native key kernel in `sink_kernels`.
+        key_kernel: usize,
+    },
     /// Bounded positional selector for terminal `first(n)` / `last(n)`.
     SelectMany {
         /// Number of rows requested by the terminal sink.
@@ -321,6 +328,7 @@ impl ViewSinkCapability {
                     ViewMaterialization::SinkInputRows
                 }
             }
+            Self::ArgExtreme { .. } => ViewMaterialization::SinkFinalRow,
             Self::SelectMany { .. } => ViewMaterialization::SinkOutputRows,
         }
     }
@@ -427,10 +435,10 @@ mod tests {
     };
     use crate::data::value::Val;
     use crate::exec::pipeline::{
-        BodyKernel, MembershipSinkOp, MembershipSinkSpec, MembershipSinkTarget, NumOp,
-        PipelineBody, PredicateSinkOp, PredicateSinkSpec, ReducerOp, ReducerSpec, Sink, Stage,
-        ViewInputMode, ViewMaterialization, ViewMembershipTarget, ViewOutputMode,
-        ViewSinkCapability, ViewStageCapability,
+        ArgExtremeSinkSpec, BodyKernel, MembershipSinkOp, MembershipSinkSpec,
+        MembershipSinkTarget, NumOp, PipelineBody, PredicateSinkOp, PredicateSinkSpec,
+        ReducerOp, ReducerSpec, Sink, Stage, ViewInputMode, ViewMaterialization,
+        ViewMembershipTarget, ViewOutputMode, ViewSinkCapability, ViewStageCapability,
     };
     use crate::parse::ast::BinOp;
 
@@ -568,6 +576,14 @@ mod tests {
             ViewMaterialization::SinkInputRows
         );
         assert_eq!(
+            ViewSinkCapability::ArgExtreme {
+                want_max: true,
+                key_kernel: 0,
+            }
+            .materialization(),
+            ViewMaterialization::SinkFinalRow
+        );
+        assert_eq!(
             ViewSinkCapability::SelectMany {
                 n: 2,
                 from_end: true,
@@ -661,6 +677,25 @@ mod tests {
                 target: ViewMembershipTarget::Program(_),
             })
         ));
+        assert!(matches!(
+            Sink::ArgExtreme(ArgExtremeSinkSpec {
+                want_max: true,
+                key: Arc::new(crate::vm::Program::new(Vec::new(), "")),
+            })
+            .view_capability(&[BodyKernel::FieldRead(Arc::from("score"))]),
+            Some(ViewSinkCapability::ArgExtreme {
+                want_max: true,
+                key_kernel: 0,
+            })
+        ));
+        assert!(
+            Sink::ArgExtreme(ArgExtremeSinkSpec {
+                want_max: false,
+                key: Arc::new(crate::vm::Program::new(Vec::new(), "")),
+            })
+            .view_capability(&[BodyKernel::Generic])
+            .is_none()
+        );
     }
 
     #[test]

--- a/jetro-core/src/exec/pipeline/composed.rs
+++ b/jetro-core/src/exec/pipeline/composed.rs
@@ -363,7 +363,7 @@ fn run_sink(sink: &Sink, rows: &[Val], chain: &dyn cmp::Stage, demand: PullDeman
         Sink::Reducer(_) | Sink::Terminal(_) => {
             run_composed_sink!(run_pipeline_with_demand, rows, chain, demand, sink)
         }
-        Sink::Predicate(_) | Sink::Membership(_) | Sink::ArgExtreme(_) => return None,
+        Sink::Predicate(_) | Sink::Membership(_) | Sink::ArgExtreme(_) | Sink::SelectMany { .. } => return None,
         Sink::ApproxCountDistinct => return None,
     };
 
@@ -392,7 +392,7 @@ where
             demand,
             sink
         ),
-        Sink::Predicate(_) | Sink::Membership(_) | Sink::ArgExtreme(_) => return None,
+        Sink::Predicate(_) | Sink::Membership(_) | Sink::ArgExtreme(_) | Sink::SelectMany { .. } => return None,
         Sink::ApproxCountDistinct => return None,
     };
 

--- a/jetro-core/src/exec/pipeline/composed.rs
+++ b/jetro-core/src/exec/pipeline/composed.rs
@@ -363,7 +363,7 @@ fn run_sink(sink: &Sink, rows: &[Val], chain: &dyn cmp::Stage, demand: PullDeman
         Sink::Reducer(_) | Sink::Terminal(_) => {
             run_composed_sink!(run_pipeline_with_demand, rows, chain, demand, sink)
         }
-        Sink::Predicate(_) | Sink::Membership(_) => return None,
+        Sink::Predicate(_) | Sink::Membership(_) | Sink::ArgExtreme(_) => return None,
         Sink::ApproxCountDistinct => return None,
     };
 
@@ -392,7 +392,7 @@ where
             demand,
             sink
         ),
-        Sink::Predicate(_) | Sink::Membership(_) => return None,
+        Sink::Predicate(_) | Sink::Membership(_) | Sink::ArgExtreme(_) => return None,
         Sink::ApproxCountDistinct => return None,
     };
 

--- a/jetro-core/src/exec/pipeline/composed.rs
+++ b/jetro-core/src/exec/pipeline/composed.rs
@@ -363,7 +363,7 @@ fn run_sink(sink: &Sink, rows: &[Val], chain: &dyn cmp::Stage, demand: PullDeman
         Sink::Reducer(_) | Sink::Terminal(_) => {
             run_composed_sink!(run_pipeline_with_demand, rows, chain, demand, sink)
         }
-        Sink::Predicate(_) => return None,
+        Sink::Predicate(_) | Sink::Membership(_) => return None,
         Sink::ApproxCountDistinct => return None,
     };
 
@@ -392,7 +392,7 @@ where
             demand,
             sink
         ),
-        Sink::Predicate(_) => return None,
+        Sink::Predicate(_) | Sink::Membership(_) => return None,
         Sink::ApproxCountDistinct => return None,
     };
 

--- a/jetro-core/src/exec/pipeline/composed.rs
+++ b/jetro-core/src/exec/pipeline/composed.rs
@@ -363,6 +363,7 @@ fn run_sink(sink: &Sink, rows: &[Val], chain: &dyn cmp::Stage, demand: PullDeman
         Sink::Reducer(_) | Sink::Terminal(_) => {
             run_composed_sink!(run_pipeline_with_demand, rows, chain, demand, sink)
         }
+        Sink::Predicate(_) => return None,
         Sink::ApproxCountDistinct => return None,
     };
 
@@ -391,6 +392,7 @@ where
             demand,
             sink
         ),
+        Sink::Predicate(_) => return None,
         Sink::ApproxCountDistinct => return None,
     };
 

--- a/jetro-core/src/exec/pipeline/indexed_exec.rs
+++ b/jetro-core/src/exec/pipeline/indexed_exec.rs
@@ -20,6 +20,10 @@ pub(super) fn run(
     let len = row_source::row_count(&recv)?;
 
     let demand = pipeline.source_demand();
+    if let super::Sink::SelectMany { n, from_end } = pipeline.sink {
+        return run_select_many(pipeline, base_env, &recv, len, n, from_end);
+    }
+
     let idx = match demand.chain.pull {
         PullDemand::NthInput(idx) => idx,
         PullDemand::FirstInput(_) => 0,
@@ -34,7 +38,45 @@ pub(super) fn run(
     }
 
     let elem = row_source::row_at(&recv, idx)?;
+    apply_indexed_stages(pipeline, base_env, elem)
+}
 
+fn run_select_many(
+    pipeline: &Pipeline,
+    base_env: &Env,
+    recv: &Val,
+    len: usize,
+    n: usize,
+    from_end: bool,
+) -> Option<Result<Val, EvalError>> {
+    if n == 0 {
+        return Some(Ok(Val::Null));
+    }
+
+    let start = if from_end { len.saturating_sub(n) } else { 0 };
+    let end = if from_end { len } else { n.min(len) };
+    let mut out = Vec::with_capacity(end.saturating_sub(start));
+    for idx in start..end {
+        if let Some(elem) = row_source::row_at(recv, idx) {
+            match apply_indexed_stages(pipeline, base_env, elem)? {
+                Ok(value) => out.push(value),
+                Err(err) => return Some(Err(err)),
+            }
+        }
+    }
+
+    if n == 1 {
+        Some(Ok(out.into_iter().next().unwrap_or(Val::Null)))
+    } else {
+        Some(Ok(Val::arr(out)))
+    }
+}
+
+fn apply_indexed_stages(
+    pipeline: &Pipeline,
+    base_env: &Env,
+    elem: Val,
+) -> Option<Result<Val, EvalError>> {
     let mut vm = crate::vm::VM::new();
     let mut env = base_env.clone();
     let mut cur = elem;
@@ -50,6 +92,12 @@ pub(super) fn run(
                     }
                 };
                 env.restore_current(prev);
+            }
+            Stage::CompiledMap(plan) => {
+                cur = match super::lower::run_compiled_map(plan, cur) {
+                    Ok(value) => value,
+                    Err(err) => return Some(Err(err)),
+                };
             }
             Stage::Builtin(call) => {
                 cur = call.apply(&cur).unwrap_or(cur);

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -88,6 +88,16 @@ impl Sink {
                 positional: None,
             };
         }
+        if matches!(self, Sink::ArgExtreme(_)) {
+            return SinkDemand {
+                chain: ChainDemand {
+                    pull: PullDemand::All,
+                    value: ValueNeed::Whole,
+                    order: true,
+                },
+                positional: None,
+            };
+        }
         if let Some(spec) = self.builtin_sink_spec() {
             return sink_demand_from_builtin(spec);
         }
@@ -108,6 +118,7 @@ impl Sink {
             | Sink::ApproxCountDistinct
             | Sink::Membership(_) => true,
             Sink::Predicate(spec) => program_ok(&spec.predicate),
+            Sink::ArgExtreme(spec) => program_ok(&spec.key),
             Sink::Reducer(spec) => spec.sink_programs().all(|prog| program_ok(prog)),
         }
     }
@@ -160,6 +171,7 @@ impl Sink {
             Sink::Nth(_) => None,
             Sink::Predicate(_) => None,
             Sink::Membership(_) => None,
+            Sink::ArgExtreme(_) => None,
             Sink::Reducer(spec) => spec.method()?.spec().sink,
             Sink::ApproxCountDistinct => BuiltinMethod::ApproxCountDistinct.spec().sink,
             Sink::Collect => None,

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -177,6 +177,12 @@ impl Sink {
                 target: ViewMembershipTarget::from(&spec.target),
             });
         }
+        if let Sink::ArgExtreme(spec) = self {
+            return Some(ViewSinkCapability::ArgExtreme {
+                want_max: spec.want_max,
+                key_kernel: view_native_sink_kernel(sink_kernels, spec.key_kernel_index())?,
+            });
+        }
 
         let sink_spec = self.builtin_sink_spec()?;
         let reducer = self.reducer_spec();

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -78,6 +78,16 @@ impl Sink {
                 positional: None,
             };
         }
+        if matches!(self, Sink::Membership(_)) {
+            return SinkDemand {
+                chain: ChainDemand {
+                    pull: PullDemand::All,
+                    value: ValueNeed::Whole,
+                    order: false,
+                },
+                positional: None,
+            };
+        }
         if let Some(spec) = self.builtin_sink_spec() {
             return sink_demand_from_builtin(spec);
         }
@@ -92,7 +102,11 @@ impl Sink {
         F: FnMut(&crate::vm::Program) -> bool,
     {
         match self {
-            Sink::Collect | Sink::Terminal(_) | Sink::Nth(_) | Sink::ApproxCountDistinct => true,
+            Sink::Collect
+            | Sink::Terminal(_)
+            | Sink::Nth(_)
+            | Sink::ApproxCountDistinct
+            | Sink::Membership(_) => true,
             Sink::Predicate(spec) => program_ok(&spec.predicate),
             Sink::Reducer(spec) => spec.sink_programs().all(|prog| program_ok(prog)),
         }
@@ -145,6 +159,7 @@ impl Sink {
             Sink::Terminal(method) => method.spec().sink,
             Sink::Nth(_) => None,
             Sink::Predicate(_) => None,
+            Sink::Membership(_) => None,
             Sink::Reducer(spec) => spec.method()?.spec().sink,
             Sink::ApproxCountDistinct => BuiltinMethod::ApproxCountDistinct.spec().sink,
             Sink::Collect => None,

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -24,7 +24,7 @@ use crate::vm::{CompiledObjEntry, Opcode, Program};
 
 use super::{
     BodyKernel, Pipeline, PipelineBody, PredicateSinkOp, Sink, Stage, ViewSinkCapability,
-    ViewStageCapability,
+    ViewMembershipTarget, ViewStageCapability,
 };
 
 /// Indicates whether a positional terminal sink wants the first or the last qualifying element.
@@ -172,13 +172,10 @@ impl Sink {
             });
         }
         if let Sink::Membership(spec) = self {
-            if let super::MembershipSinkTarget::Literal(target) = &spec.target {
-                return Some(ViewSinkCapability::Membership {
-                    op: spec.op,
-                    target: target.clone(),
-                });
-            }
-            return None;
+            return Some(ViewSinkCapability::Membership {
+                op: spec.op,
+                target: ViewMembershipTarget::from(&spec.target),
+            });
         }
 
         let sink_spec = self.builtin_sink_spec()?;

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -152,6 +152,13 @@ impl Sink {
         if matches!(self, Sink::Collect) {
             return Some(ViewSinkCapability::Collect);
         }
+        if let Sink::SelectMany { n, from_end } = self {
+            return Some(ViewSinkCapability::SelectMany {
+                n: *n,
+                from_end: *from_end,
+                source_reversed: false,
+            });
+        }
         if let Sink::Nth(index) = self {
             return Some(ViewSinkCapability::Nth { index: *index });
         }

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -155,6 +155,15 @@ impl Sink {
         if let Sink::Nth(index) = self {
             return Some(ViewSinkCapability::Nth { index: *index });
         }
+        if let Sink::Predicate(spec) = self {
+            return Some(ViewSinkCapability::Predicate {
+                op: spec.op,
+                predicate_kernel: view_native_sink_kernel(
+                    sink_kernels,
+                    spec.predicate_kernel_index(),
+                )?,
+            });
+        }
 
         let sink_spec = self.builtin_sink_spec()?;
         let reducer = self.reducer_spec();

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -69,6 +69,20 @@ impl Sink {
                 positional: Some(Position::First),
             };
         }
+        if let Sink::SelectMany { n, from_end } = self {
+            return SinkDemand {
+                chain: ChainDemand {
+                    pull: if *from_end {
+                        PullDemand::LastInput(*n)
+                    } else {
+                        PullDemand::FirstInput(*n)
+                    },
+                    value: ValueNeed::Whole,
+                    order: true,
+                },
+                positional: None,
+            };
+        }
         if matches!(self, Sink::Predicate(_)) {
             let value = match self {
                 Sink::Predicate(spec) if spec.op == PredicateSinkOp::FindOne => ValueNeed::Whole,
@@ -119,6 +133,7 @@ impl Sink {
         match self {
             Sink::Collect
             | Sink::Terminal(_)
+            | Sink::SelectMany { .. }
             | Sink::Nth(_)
             | Sink::ApproxCountDistinct => true,
             Sink::Membership(spec) => spec.sink_programs().all(|prog| program_ok(prog)),
@@ -174,6 +189,7 @@ impl Sink {
         match self {
             Sink::Terminal(method) => method.spec().sink,
             Sink::Nth(_) => None,
+            Sink::SelectMany { .. } => None,
             Sink::Predicate(_) => None,
             Sink::Membership(_) => None,
             Sink::ArgExtreme(_) => None,

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -68,6 +68,16 @@ impl Sink {
                 positional: Some(Position::First),
             };
         }
+        if matches!(self, Sink::Predicate(_)) {
+            return SinkDemand {
+                chain: ChainDemand {
+                    pull: PullDemand::All,
+                    value: ValueNeed::Predicate,
+                    order: false,
+                },
+                positional: None,
+            };
+        }
         if let Some(spec) = self.builtin_sink_spec() {
             return sink_demand_from_builtin(spec);
         }
@@ -83,6 +93,7 @@ impl Sink {
     {
         match self {
             Sink::Collect | Sink::Terminal(_) | Sink::Nth(_) | Sink::ApproxCountDistinct => true,
+            Sink::Predicate(spec) => program_ok(&spec.predicate),
             Sink::Reducer(spec) => spec.sink_programs().all(|prog| program_ok(prog)),
         }
     }
@@ -133,6 +144,7 @@ impl Sink {
         match self {
             Sink::Terminal(method) => method.spec().sink,
             Sink::Nth(_) => None,
+            Sink::Predicate(_) => None,
             Sink::Reducer(spec) => spec.method()?.spec().sink,
             Sink::ApproxCountDistinct => BuiltinMethod::ApproxCountDistinct.spec().sink,
             Sink::Collect => None,
@@ -643,12 +655,12 @@ impl Stage {
             // reason about them with the role-specific propagation rules
             // (`Predicate` widens upstream demand to scan-until-output;
             // `Transform` is 1:1).
-            Stage::Filter(prog, _) if program_is_match_only(prog) => {
-                Some(ChainOp::match_role(crate::parse::chain_ir::MatchRole::Predicate))
-            }
-            Stage::Map(prog, _) if program_is_match_only(prog) => {
-                Some(ChainOp::match_role(crate::parse::chain_ir::MatchRole::Transform))
-            }
+            Stage::Filter(prog, _) if program_is_match_only(prog) => Some(ChainOp::match_role(
+                crate::parse::chain_ir::MatchRole::Predicate,
+            )),
+            Stage::Map(prog, _) if program_is_match_only(prog) => Some(ChainOp::match_role(
+                crate::parse::chain_ir::MatchRole::Transform,
+            )),
             _ => self.chain_demand_op(),
         }
     }

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -23,7 +23,8 @@ use crate::plan::demand::{Demand as ChainDemand, PullDemand, ValueNeed};
 use crate::vm::{CompiledObjEntry, Opcode, Program};
 
 use super::{
-    BodyKernel, Pipeline, PipelineBody, Sink, Stage, ViewSinkCapability, ViewStageCapability,
+    BodyKernel, Pipeline, PipelineBody, PredicateSinkOp, Sink, Stage, ViewSinkCapability,
+    ViewStageCapability,
 };
 
 /// Indicates whether a positional terminal sink wants the first or the last qualifying element.
@@ -69,10 +70,14 @@ impl Sink {
             };
         }
         if matches!(self, Sink::Predicate(_)) {
+            let value = match self {
+                Sink::Predicate(spec) if spec.op == PredicateSinkOp::FindOne => ValueNeed::Whole,
+                _ => ValueNeed::Predicate,
+            };
             return SinkDemand {
                 chain: ChainDemand {
                     pull: PullDemand::All,
-                    value: ValueNeed::Predicate,
+                    value,
                     order: false,
                 },
                 positional: None,

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -171,6 +171,15 @@ impl Sink {
                 )?,
             });
         }
+        if let Sink::Membership(spec) = self {
+            if let super::MembershipSinkTarget::Literal(target) = &spec.target {
+                return Some(ViewSinkCapability::Membership {
+                    op: spec.op,
+                    target: target.clone(),
+                });
+            }
+            return None;
+        }
 
         let sink_spec = self.builtin_sink_spec()?;
         let reducer = self.reducer_spec();

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -115,8 +115,8 @@ impl Sink {
             Sink::Collect
             | Sink::Terminal(_)
             | Sink::Nth(_)
-            | Sink::ApproxCountDistinct
-            | Sink::Membership(_) => true,
+            | Sink::ApproxCountDistinct => true,
+            Sink::Membership(spec) => spec.sink_programs().all(|prog| program_ok(prog)),
             Sink::Predicate(spec) => program_ok(&spec.predicate),
             Sink::ArgExtreme(spec) => program_ok(&spec.key),
             Sink::Reducer(spec) => spec.sink_programs().all(|prog| program_ok(prog)),

--- a/jetro-core/src/exec/pipeline/ir.rs
+++ b/jetro-core/src/exec/pipeline/ir.rs
@@ -1016,6 +1016,7 @@ pub(super) fn opcode_is_current_only(opcode: &Opcode) -> bool {
         | Opcode::AndOp(prog)
         | Opcode::OrOp(prog)
         | Opcode::CoalesceOp(prog) => program_is_current_only(prog),
+        Opcode::BindLamCurrent { body, .. } => program_is_current_only(body),
         Opcode::CallMethod(call) | Opcode::CallOptMethod(call) => call
             .sub_progs
             .iter()

--- a/jetro-core/src/exec/pipeline/kernels.rs
+++ b/jetro-core/src/exec/pipeline/kernels.rs
@@ -730,9 +730,15 @@ where
             Some(ViewKernelValue::Owned(Val::ObjSmall(pairs.into())))
         }
         BodyKernel::BuiltinCall { receiver, call } => match eval_view_kernel(receiver, item)? {
-            ViewKernelValue::View(view) => call
-                .try_apply_json_view(view.scalar())
-                .map(ViewKernelValue::Owned),
+            ViewKernelValue::View(view) => match (call.method, &call.args) {
+                (
+                    crate::builtins::BuiltinMethod::HasKey,
+                    crate::builtins::BuiltinArgs::Str(key),
+                ) => view.has_key(key.as_ref()).map(Val::Bool).map(ViewKernelValue::Owned),
+                _ => call
+                    .try_apply_json_view(view.scalar())
+                    .map(ViewKernelValue::Owned),
+            },
             ViewKernelValue::Owned(value) => call
                 .try_apply(&value)
                 .ok()

--- a/jetro-core/src/exec/pipeline/kernels.rs
+++ b/jetro-core/src/exec/pipeline/kernels.rs
@@ -478,26 +478,34 @@ fn classify_structural_view_kernel(ops: &[crate::vm::Opcode]) -> Option<BodyKern
             Some(BodyKernel::FieldChain(keys.into()))
         }
         [receiver @ .., Opcode::CallMethod(call)] if call.method.spec().view_scalar => {
-            let receiver = classify_structural_view_kernel(receiver)?;
-            let builtin_call = BuiltinCall::from_static_args(
-                call.method,
-                call.name.as_ref(),
-                call.orig_args.len(),
-                |idx| {
-                    Ok(call
-                        .sub_progs
-                        .get(idx)
-                        .and_then(|prog| static_prog_val(prog)))
-                },
-                |idx| match call.orig_args.get(idx) {
-                    Some(crate::parse::ast::Arg::Pos(crate::parse::ast::Expr::Ident(value))) => {
-                        Some(Arc::from(value.as_str()))
-                    }
-                    _ => None,
-                },
-            )
-            .ok()
-            .flatten()?;
+            let receiver = if receiver.is_empty() {
+                BodyKernel::Current
+            } else {
+                classify_structural_view_kernel(receiver)?
+            };
+            let builtin_call = if call.method == crate::builtins::BuiltinMethod::Pick {
+                static_positional_pick_call(call)?
+            } else {
+                BuiltinCall::from_static_args(
+                    call.method,
+                    call.name.as_ref(),
+                    call.orig_args.len(),
+                    |idx| {
+                        Ok(call
+                            .sub_progs
+                            .get(idx)
+                            .and_then(|prog| static_prog_val(prog)))
+                    },
+                    |idx| match call.orig_args.get(idx) {
+                        Some(crate::parse::ast::Arg::Pos(crate::parse::ast::Expr::Ident(
+                            value,
+                        ))) => Some(Arc::from(value.as_str())),
+                        _ => None,
+                    },
+                )
+                .ok()
+                .flatten()?
+            };
             if !builtin_call.spec().view_scalar {
                 return None;
             }
@@ -515,6 +523,31 @@ fn static_prog_val(prog: &crate::vm::Program) -> Option<Val> {
         [op] => trivial_lit(op),
         _ => None,
     }
+}
+
+fn static_positional_pick_call(call: &crate::vm::CompiledCall) -> Option<BuiltinCall> {
+    let mut keys = Vec::with_capacity(call.orig_args.len());
+    for (idx, arg) in call.orig_args.iter().enumerate() {
+        let key = match arg {
+            crate::parse::ast::Arg::Pos(crate::parse::ast::Expr::Ident(value)) => {
+                Arc::from(value.as_str())
+            }
+            crate::parse::ast::Arg::Pos(_) => match call
+                .sub_progs
+                .get(idx)
+                .and_then(|prog| static_prog_val(prog))
+            {
+                Some(Val::Str(value)) => value,
+                _ => return None,
+            },
+            crate::parse::ast::Arg::Named(_, _) => return None,
+        };
+        keys.push(key);
+    }
+    Some(BuiltinCall::new(
+        crate::builtins::BuiltinMethod::Pick,
+        crate::builtins::BuiltinArgs::StrVec(keys),
+    ))
 }
 
 #[inline]
@@ -735,6 +768,23 @@ where
                     crate::builtins::BuiltinMethod::HasKey,
                     crate::builtins::BuiltinArgs::Str(key),
                 ) => view.has_key(key.as_ref()).map(Val::Bool).map(ViewKernelValue::Owned),
+                (crate::builtins::BuiltinMethod::Keys, crate::builtins::BuiltinArgs::None) => {
+                    view.object_keys().map(ViewKernelValue::Owned)
+                }
+                (crate::builtins::BuiltinMethod::Values, crate::builtins::BuiltinArgs::None) => {
+                    view.object_values().map(ViewKernelValue::Owned)
+                }
+                (crate::builtins::BuiltinMethod::Entries, crate::builtins::BuiltinArgs::None) => {
+                    view.object_entries().map(ViewKernelValue::Owned)
+                }
+                (
+                    crate::builtins::BuiltinMethod::Pick,
+                    crate::builtins::BuiltinArgs::StrVec(keys),
+                ) => view.pick_keys(keys).map(ViewKernelValue::Owned),
+                (
+                    crate::builtins::BuiltinMethod::Omit,
+                    crate::builtins::BuiltinArgs::StrVec(keys),
+                ) => view.omit_keys(keys).map(ViewKernelValue::Owned),
                 _ => call
                     .try_apply_json_view(view.scalar())
                     .map(ViewKernelValue::Owned),

--- a/jetro-core/src/exec/pipeline/logical_lower.rs
+++ b/jetro-core/src/exec/pipeline/logical_lower.rs
@@ -278,6 +278,10 @@ fn build_body(
             .sink_programs()
             .map(|p| BodyKernel::classify(p))
             .collect(),
+        Sink::Membership(spec) => spec
+            .sink_programs()
+            .map(|p| BodyKernel::classify(p))
+            .collect(),
         Sink::ArgExtreme(spec) => spec
             .sink_programs()
             .map(|p| BodyKernel::classify(p))

--- a/jetro-core/src/exec/pipeline/logical_lower.rs
+++ b/jetro-core/src/exec/pipeline/logical_lower.rs
@@ -269,15 +269,17 @@ fn build_body(
     let plan_result = plan_with_exprs(stages, stage_exprs, &kernels, sink);
 
     let stage_kernels = classify_kernels(&plan_result.stages);
-    let sink_kernels = plan_result
-        .sink
-        .reducer_spec()
-        .map(|spec| {
-            spec.sink_programs()
-                .map(|p| BodyKernel::classify(p))
-                .collect()
-        })
-        .unwrap_or_default();
+    let sink_kernels = match &plan_result.sink {
+        Sink::Reducer(spec) => spec
+            .sink_programs()
+            .map(|p| BodyKernel::classify(p))
+            .collect(),
+        Sink::Predicate(spec) => spec
+            .sink_programs()
+            .map(|p| BodyKernel::classify(p))
+            .collect(),
+        _ => Vec::new(),
+    };
 
     PipelineBody {
         stages: plan_result.stages,

--- a/jetro-core/src/exec/pipeline/logical_lower.rs
+++ b/jetro-core/src/exec/pipeline/logical_lower.rs
@@ -278,6 +278,10 @@ fn build_body(
             .sink_programs()
             .map(|p| BodyKernel::classify(p))
             .collect(),
+        Sink::ArgExtreme(spec) => spec
+            .sink_programs()
+            .map(|p| BodyKernel::classify(p))
+            .collect(),
         _ => Vec::new(),
     };
 

--- a/jetro-core/src/exec/pipeline/logical_lower.rs
+++ b/jetro-core/src/exec/pipeline/logical_lower.rs
@@ -308,11 +308,18 @@ fn build_body(
 /// This replicates the `Ident→@.field` rewrite that `compile_subexpr` performs in `lower.rs`,
 /// without requiring access to the `pub(super)` helper there.
 fn compile_expr_body(expr: &Expr) -> Arc<crate::vm::Program> {
-    let rooted: Expr = match expr {
+    // Route single-param `Expr::Lambda` through `compile_lambda_arg` so
+    // the body is substituted and — when nested-lambda references to the
+    // param remain — wrapped in `BindLamCurrent` for correct outer-row
+    // binding under pipeline stages that advance via `swap_current`.
+    if matches!(expr, Expr::Lambda { params, .. } if params.len() == 1) {
+        return crate::compile::lambda_lower::compile_lambda_arg(expr, "");
+    }
+    let lowered: Expr = match expr {
         Expr::Ident(name) => {
             Expr::Chain(Box::new(Expr::Current), vec![Step::Field(name.clone())])
         }
         other => other.clone(),
     };
-    Arc::new(crate::compile::compiler::Compiler::compile(&rooted, ""))
+    Arc::new(crate::compile::compiler::Compiler::compile(&lowered, ""))
 }

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -550,6 +550,12 @@ pub(super) fn lower_method_from_registry(
                     stages.push(Stage::Reverse(cancel));
                 }
                 BuiltinMethod::Unique => stages.push(Stage::UniqueBy(None)),
+                _ if method.is_pipeline_element_method() => {
+                    stages.push(Stage::Builtin(crate::builtins::BuiltinCall::new(
+                        method,
+                        crate::builtins::BuiltinArgs::None,
+                    )));
+                }
                 _ => return None,
             }
             stage_exprs.push(None);

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -806,6 +806,22 @@ fn terminal_sink_for_method(
                 _ => return None,
             },
         })),
+        BuiltinSinkAccumulator::SelectOne(_) if method == BuiltinMethod::First => match args {
+            [] => Some(Sink::Terminal(method)),
+            [arg] => Some(Sink::SelectMany {
+                n: usize_arg_at_least(arg, 1)?,
+                from_end: false,
+            }),
+            _ => None,
+        },
+        BuiltinSinkAccumulator::SelectOne(_) if method == BuiltinMethod::Last => match args {
+            [] => Some(Sink::Terminal(method)),
+            [arg] => Some(Sink::SelectMany {
+                n: usize_arg_at_least(arg, 1)?,
+                from_end: true,
+            }),
+            _ => None,
+        },
         BuiltinSinkAccumulator::SelectOne(_) if args.is_empty() => Some(Sink::Terminal(method)),
         _ => None,
     }

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -489,8 +489,8 @@ pub(super) fn arg_expr(arg: &crate::parse::ast::Arg) -> Option<Arc<Expr>> {
 // ---------------------------------------------------------------------------
 
 use super::{
-    MembershipSinkOp, MembershipSinkSpec, NumOp, PredicateSinkOp, PredicateSinkSpec, ReducerOp,
-    ReducerSpec,
+    ArgExtremeSinkSpec, MembershipSinkOp, MembershipSinkSpec, NumOp, PredicateSinkOp,
+    PredicateSinkSpec, ReducerOp, ReducerSpec,
 };
 
 /// Lowers a `BuiltinMethod` call to a concrete `Stage` or `Sink`, returning `None` when the method cannot be lowered at this position.
@@ -761,6 +761,9 @@ fn terminal_sink_for_method(
     if let Some(sink) = membership_sink_for_method(method, args) {
         return Some(sink);
     }
+    if let Some(sink) = arg_extreme_sink_for_method(method, args) {
+        return Some(sink);
+    }
     let spec = method.spec();
     match spec.sink?.accumulator {
         BuiltinSinkAccumulator::ApproxDistinct if args.is_empty() => {
@@ -837,6 +840,24 @@ fn membership_sink_for_method(
     }))
 }
 
+fn arg_extreme_sink_for_method(
+    method: BuiltinMethod,
+    args: &[crate::parse::ast::Arg],
+) -> Option<Sink> {
+    let [arg] = args else {
+        return None;
+    };
+    let want_max = match method {
+        BuiltinMethod::MaxBy => true,
+        BuiltinMethod::MinBy => false,
+        _ => return None,
+    };
+    Some(Sink::ArgExtreme(ArgExtremeSinkSpec {
+        want_max,
+        key: compile_subexpr(arg)?,
+    }))
+}
+
 fn sink_kernels(sink: &Sink) -> Vec<BodyKernel> {
     match sink {
         Sink::Reducer(spec) => spec
@@ -844,6 +865,10 @@ fn sink_kernels(sink: &Sink) -> Vec<BodyKernel> {
             .map(|p| BodyKernel::classify(p))
             .collect(),
         Sink::Predicate(spec) => spec
+            .sink_programs()
+            .map(|p| BodyKernel::classify(p))
+            .collect(),
+        Sink::ArgExtreme(spec) => spec
             .sink_programs()
             .map(|p| BodyKernel::classify(p))
             .collect(),

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -808,6 +808,7 @@ fn predicate_sink_for_method(
         BuiltinMethod::Any => PredicateSinkOp::Any,
         BuiltinMethod::All => PredicateSinkOp::All,
         BuiltinMethod::FindIndex => PredicateSinkOp::FindIndex,
+        BuiltinMethod::IndicesWhere => PredicateSinkOp::IndicesWhere,
         _ => return None,
     };
     Some(Sink::Predicate(PredicateSinkSpec {

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -441,11 +441,17 @@ fn prog_const_bool(prog: &crate::vm::Program) -> Option<bool> {
 
 /// Compiles a positional argument into a VM `Program`, rewriting bare `Ident` nodes into `@.<ident>` field accesses.
 pub(super) fn compile_subexpr(arg: &crate::parse::ast::Arg) -> Option<Arc<crate::vm::Program>> {
-    use crate::parse::ast::{Arg, Expr, Step};
+    use crate::parse::ast::{Arg, Step};
     let inner = match arg {
         Arg::Pos(e) => e,
         _ => return None,
     };
+    // Single-param lambda: route through `compile_lambda_arg` so the body
+    // is substituted and, when nested-lambda refs to the param remain,
+    // wrapped in `BindLamCurrent` for correct outer-row binding.
+    if matches!(inner, Expr::Lambda { params, .. } if params.len() == 1) {
+        return Some(crate::compile::lambda_lower::compile_lambda_arg(inner, ""));
+    }
     let rooted: Expr = match inner {
         Expr::Ident(name) => Expr::Chain(Box::new(Expr::Current), vec![Step::Field(name.clone())]),
         Expr::Chain(base, _) if matches!(base.as_ref(), Expr::Current) => inner.clone(),
@@ -462,12 +468,16 @@ fn compile_raw_arg_expr(arg: &crate::parse::ast::Arg) -> Option<Arc<crate::vm::P
         Arg::Pos(e) => e,
         Arg::Named(_, _) => return None,
     };
-    Some(Arc::new(crate::compile::compiler::Compiler::compile(
-        expr, "",
-    )))
+    Some(crate::compile::lambda_lower::compile_lambda_arg(expr, ""))
 }
 
 /// Compiles a sort-key argument into a `SortSpec`, interpreting `UnaryNeg`-wrapping as descending order.
+///
+/// Returns `None` for multi-param `Expr::Lambda` arguments — those are
+/// 2-arg comparator lambdas (`.sort((a, b) => …)`) which the pipeline IR
+/// cannot represent as a single-key `SortSpec`. Bailing out forces the
+/// router to fall back to the VM path, where `exec_lambda_method` handles
+/// the comparator via `sort_comparator_apply`.
 pub(super) fn compile_sort_spec(
     arg: &crate::parse::ast::Arg,
 ) -> Option<(SortSpec, Option<Arc<Expr>>)> {
@@ -476,6 +486,9 @@ pub(super) fn compile_sort_spec(
         Arg::Pos(e) => e,
         _ => return None,
     };
+    if matches!(expr, Expr::Lambda { params, .. } if params.len() >= 2) {
+        return None;
+    }
     let (key_expr, descending) = match expr {
         Expr::UnaryNeg(inner) => (inner.as_ref().clone(), true),
         other => (other.clone(), false),

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -488,7 +488,10 @@ pub(super) fn arg_expr(arg: &crate::parse::ast::Arg) -> Option<Arc<Expr>> {
 // Registry-driven stage factory (formerly stage_factory.rs)
 // ---------------------------------------------------------------------------
 
-use super::{NumOp, PredicateSinkOp, PredicateSinkSpec, ReducerOp, ReducerSpec};
+use super::{
+    MembershipSinkOp, MembershipSinkSpec, NumOp, PredicateSinkOp, PredicateSinkSpec, ReducerOp,
+    ReducerSpec,
+};
 
 /// Lowers a `BuiltinMethod` call to a concrete `Stage` or `Sink`, returning `None` when the method cannot be lowered at this position.
 pub(super) fn lower_method_from_registry(
@@ -735,12 +738,27 @@ fn string_arg(arg: &crate::parse::ast::Arg) -> Option<Arc<str>> {
     }
 }
 
+// Extracts a literal value from `arg` for value-membership terminal sinks.
+fn literal_arg_value(arg: &crate::parse::ast::Arg) -> Option<Val> {
+    match arg {
+        crate::parse::ast::Arg::Pos(Expr::Null) => Some(Val::Null),
+        crate::parse::ast::Arg::Pos(Expr::Bool(b)) => Some(Val::Bool(*b)),
+        crate::parse::ast::Arg::Pos(Expr::Int(n)) => Some(Val::Int(*n)),
+        crate::parse::ast::Arg::Pos(Expr::Float(n)) => Some(Val::Float(*n)),
+        crate::parse::ast::Arg::Pos(Expr::Str(s)) => Some(Val::Str(Arc::from(s.as_str()))),
+        _ => None,
+    }
+}
+
 // Constructs the terminal `Sink` for `method`, handling count predicates, numeric reducers, and positional selects.
 fn terminal_sink_for_method(
     method: BuiltinMethod,
     args: &[crate::parse::ast::Arg],
 ) -> Option<Sink> {
     if let Some(sink) = predicate_sink_for_method(method, args) {
+        return Some(sink);
+    }
+    if let Some(sink) = membership_sink_for_method(method, args) {
         return Some(sink);
     }
     let spec = method.spec();
@@ -795,6 +813,26 @@ fn predicate_sink_for_method(
     Some(Sink::Predicate(PredicateSinkSpec {
         op,
         predicate: compile_subexpr(arg)?,
+    }))
+}
+
+fn membership_sink_for_method(
+    method: BuiltinMethod,
+    args: &[crate::parse::ast::Arg],
+) -> Option<Sink> {
+    let [arg] = args else {
+        return None;
+    };
+    let op = match method {
+        BuiltinMethod::Includes => MembershipSinkOp::Includes,
+        BuiltinMethod::Index => MembershipSinkOp::Index,
+        BuiltinMethod::IndicesOf => MembershipSinkOp::IndicesOf,
+        _ => return None,
+    };
+    Some(Sink::Membership(MembershipSinkSpec {
+        op,
+        target: literal_arg_value(arg)?,
+        method,
     }))
 }
 

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -274,10 +274,49 @@ fn decode_method_chain(
                     &mut sink,
                 )?;
             }
+            Step::Slice(start, end) => {
+                push_path_slice_stages(*start, *end, &mut stages, &mut stage_exprs)?;
+            }
             _ => return None,
         }
     }
     Some((stages, stage_exprs, sink))
+}
+
+fn push_path_slice_stages(
+    start: Option<i64>,
+    end: Option<i64>,
+    stages: &mut Vec<Stage>,
+    stage_exprs: &mut Vec<Option<Arc<Expr>>>,
+) -> Option<()> {
+    let start = match start {
+        Some(n) if n < 0 => return None,
+        Some(n) => n as usize,
+        None => 0,
+    };
+    let end = match end {
+        Some(n) if n < 0 => return None,
+        Some(n) => Some(n as usize),
+        None => None,
+    };
+
+    if start > 0 {
+        stages.push(Stage::UsizeBuiltin {
+            method: BuiltinMethod::Skip,
+            value: start,
+        });
+        stage_exprs.push(None);
+    }
+
+    if let Some(end) = end {
+        stages.push(Stage::UsizeBuiltin {
+            method: BuiltinMethod::Take,
+            value: end.saturating_sub(start),
+        });
+        stage_exprs.push(None);
+    }
+
+    Some(())
 }
 
 // Repeatedly applies `rewrite_step` until fixpoint (at most 16 iterations).

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -823,6 +823,7 @@ fn predicate_sink_for_method(
         BuiltinMethod::All => PredicateSinkOp::All,
         BuiltinMethod::FindIndex => PredicateSinkOp::FindIndex,
         BuiltinMethod::IndicesWhere => PredicateSinkOp::IndicesWhere,
+        BuiltinMethod::FindOne => PredicateSinkOp::FindOne,
         _ => return None,
     };
     Some(Sink::Predicate(PredicateSinkSpec {

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -123,15 +123,7 @@ impl Pipeline {
         p.stage_exprs = plan_result.stage_exprs;
         p.sink = plan_result.sink;
         p.stage_kernels = classify_kernels(&p.stages);
-        p.sink_kernels = p
-            .sink
-            .reducer_spec()
-            .map(|spec| {
-                spec.sink_programs()
-                    .map(|p| BodyKernel::classify(p))
-                    .collect()
-            })
-            .unwrap_or_default();
+        p.sink_kernels = sink_kernels(&p.sink);
         Some(p)
     }
 
@@ -496,7 +488,7 @@ pub(super) fn arg_expr(arg: &crate::parse::ast::Arg) -> Option<Arc<Expr>> {
 // Registry-driven stage factory (formerly stage_factory.rs)
 // ---------------------------------------------------------------------------
 
-use super::{NumOp, ReducerOp, ReducerSpec};
+use super::{NumOp, PredicateSinkOp, PredicateSinkSpec, ReducerOp, ReducerSpec};
 
 /// Lowers a `BuiltinMethod` call to a concrete `Stage` or `Sink`, returning `None` when the method cannot be lowered at this position.
 pub(super) fn lower_method_from_registry(
@@ -748,6 +740,9 @@ fn terminal_sink_for_method(
     method: BuiltinMethod,
     args: &[crate::parse::ast::Arg],
 ) -> Option<Sink> {
+    if let Some(sink) = predicate_sink_for_method(method, args) {
+        return Some(sink);
+    }
     let spec = method.spec();
     match spec.sink?.accumulator {
         BuiltinSinkAccumulator::ApproxDistinct if args.is_empty() => {
@@ -781,5 +776,38 @@ fn terminal_sink_for_method(
         })),
         BuiltinSinkAccumulator::SelectOne(_) if args.is_empty() => Some(Sink::Terminal(method)),
         _ => None,
+    }
+}
+
+fn predicate_sink_for_method(
+    method: BuiltinMethod,
+    args: &[crate::parse::ast::Arg],
+) -> Option<Sink> {
+    let [arg] = args else {
+        return None;
+    };
+    let op = match method {
+        BuiltinMethod::Any => PredicateSinkOp::Any,
+        BuiltinMethod::All => PredicateSinkOp::All,
+        BuiltinMethod::FindIndex => PredicateSinkOp::FindIndex,
+        _ => return None,
+    };
+    Some(Sink::Predicate(PredicateSinkSpec {
+        op,
+        predicate: compile_subexpr(arg)?,
+    }))
+}
+
+fn sink_kernels(sink: &Sink) -> Vec<BodyKernel> {
+    match sink {
+        Sink::Reducer(spec) => spec
+            .sink_programs()
+            .map(|p| BodyKernel::classify(p))
+            .collect(),
+        Sink::Predicate(spec) => spec
+            .sink_programs()
+            .map(|p| BodyKernel::classify(p))
+            .collect(),
+        _ => Vec::new(),
     }
 }

--- a/jetro-core/src/exec/pipeline/lower.rs
+++ b/jetro-core/src/exec/pipeline/lower.rs
@@ -456,6 +456,17 @@ pub(super) fn compile_subexpr(arg: &crate::parse::ast::Arg) -> Option<Arc<crate:
     )))
 }
 
+fn compile_raw_arg_expr(arg: &crate::parse::ast::Arg) -> Option<Arc<crate::vm::Program>> {
+    use crate::parse::ast::Arg;
+    let expr = match arg {
+        Arg::Pos(e) => e,
+        Arg::Named(_, _) => return None,
+    };
+    Some(Arc::new(crate::compile::compiler::Compiler::compile(
+        expr, "",
+    )))
+}
+
 /// Compiles a sort-key argument into a `SortSpec`, interpreting `UnaryNeg`-wrapping as descending order.
 pub(super) fn compile_sort_spec(
     arg: &crate::parse::ast::Arg,
@@ -489,8 +500,8 @@ pub(super) fn arg_expr(arg: &crate::parse::ast::Arg) -> Option<Arc<Expr>> {
 // ---------------------------------------------------------------------------
 
 use super::{
-    ArgExtremeSinkSpec, MembershipSinkOp, MembershipSinkSpec, NumOp, PredicateSinkOp,
-    PredicateSinkSpec, ReducerOp, ReducerSpec,
+    ArgExtremeSinkSpec, MembershipSinkOp, MembershipSinkSpec, MembershipSinkTarget, NumOp,
+    PredicateSinkOp, PredicateSinkSpec, ReducerOp, ReducerSpec,
 };
 
 /// Lowers a `BuiltinMethod` call to a concrete `Stage` or `Sink`, returning `None` when the method cannot be lowered at this position.
@@ -835,7 +846,9 @@ fn membership_sink_for_method(
     };
     Some(Sink::Membership(MembershipSinkSpec {
         op,
-        target: literal_arg_value(arg)?,
+        target: literal_arg_value(arg)
+            .map(MembershipSinkTarget::Literal)
+            .or_else(|| Some(MembershipSinkTarget::Program(compile_raw_arg_expr(arg)?)))?,
         method,
     }))
 }
@@ -865,6 +878,10 @@ fn sink_kernels(sink: &Sink) -> Vec<BodyKernel> {
             .map(|p| BodyKernel::classify(p))
             .collect(),
         Sink::Predicate(spec) => spec
+            .sink_programs()
+            .map(|p| BodyKernel::classify(p))
+            .collect(),
+        Sink::Membership(spec) => spec
             .sink_programs()
             .map(|p| BodyKernel::classify(p))
             .collect(),

--- a/jetro-core/src/exec/pipeline/materialized_exec.rs
+++ b/jetro-core/src/exec/pipeline/materialized_exec.rs
@@ -105,6 +105,9 @@ pub(super) fn run(pipeline: &Pipeline, root: &Val, base_env: &Env) -> Result<Val
                 observe_predicate_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
             }
             Sink::Membership(spec) => sink_acc.observe_membership(spec.op, &item, &spec.target),
+            Sink::ArgExtreme(_) => {
+                observe_arg_extreme_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
+            }
             Sink::Reducer(_) => {
                 match observe_reducer_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)? {
                     ReducerItemFlow::Observed => false,
@@ -247,6 +250,9 @@ where
                 observe_predicate_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
             }
             Sink::Membership(spec) => sink_acc.observe_membership(spec.op, &item, &spec.target),
+            Sink::ArgExtreme(_) => {
+                observe_arg_extreme_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
+            }
             Sink::Reducer(_) => {
                 match observe_reducer_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)? {
                     ReducerItemFlow::Observed => false,
@@ -524,6 +530,29 @@ fn observe_predicate_sink_item(
         apply_item_in_env(vm, loop_env, item, &spec.predicate)
     })?;
     Ok(sink_acc.observe_predicate(spec.op, crate::util::is_truthy(&predicate)))
+}
+
+fn observe_arg_extreme_sink_item(
+    pipeline: &Pipeline,
+    item: Val,
+    sink_acc: &mut SinkAccumulator<'_>,
+    vm: &mut crate::vm::VM,
+    loop_env: &mut Env,
+) -> Result<bool, EvalError> {
+    let Sink::ArgExtreme(spec) = &pipeline.sink else {
+        return Ok(sink_acc.push(item));
+    };
+
+    let kernel_idx = spec.key_kernel_index();
+    let kernel = pipeline
+        .sink_kernels
+        .get(kernel_idx)
+        .unwrap_or(&BodyKernel::Generic);
+    let key = eval_kernel(kernel, &item, |item| {
+        apply_item_in_env(vm, loop_env, item, &spec.key)
+    })?;
+    sink_acc.observe_arg_extreme(spec.want_max, item, key);
+    Ok(false)
 }
 
 /// Applies an object-lambda stage (`TransformKeys`, `TransformValues`, `FilterKeys`, `FilterValues`) to `recv`.

--- a/jetro-core/src/exec/pipeline/materialized_exec.rs
+++ b/jetro-core/src/exec/pipeline/materialized_exec.rs
@@ -36,9 +36,17 @@ pub(super) fn run(pipeline: &Pipeline, root: &Val, base_env: &Env) -> Result<Val
     let mut emitted_outputs: usize = 0;
 
     let mut sink_acc = SinkAccumulator::new(&pipeline.sink);
+    let membership_target = match &pipeline.sink {
+        Sink::Membership(spec) => Some(eval_membership_target(spec, &mut vm, &loop_env)?),
+        _ => None,
+    };
     if let Sink::Membership(spec) = &pipeline.sink {
         if pipeline.stages.is_empty() && row_source::array_like_rows(&recv).is_none() {
-            return Ok(apply_membership_scalar_sink(spec, &recv));
+            return Ok(apply_membership_scalar_sink(
+                spec,
+                membership_target.as_ref().expect("membership target exists"),
+                &recv,
+            ));
         }
     }
 
@@ -104,7 +112,11 @@ pub(super) fn run(pipeline: &Pipeline, root: &Val, base_env: &Env) -> Result<Val
             Sink::Predicate(_) => {
                 observe_predicate_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
             }
-            Sink::Membership(spec) => sink_acc.observe_membership(spec.op, &item, &spec.target),
+            Sink::Membership(spec) => sink_acc.observe_membership(
+                spec.op,
+                &item,
+                membership_target.as_ref().expect("membership target exists"),
+            ),
             Sink::ArgExtreme(_) => {
                 observe_arg_extreme_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
             }
@@ -176,6 +188,10 @@ where
     let mut stage_taken: Vec<usize> = vec![0; pipeline.stages.len()];
     let mut stage_skipped: Vec<usize> = vec![0; pipeline.stages.len()];
     let mut sink_acc = SinkAccumulator::new(&pipeline.sink);
+    let membership_target = match &pipeline.sink {
+        Sink::Membership(spec) => Some(eval_membership_target(spec, &mut vm, &loop_env)?),
+        _ => None,
+    };
     let terminal_map_idx = if matches!(pipeline.sink, Sink::Collect)
         && pipeline
             .stages
@@ -249,7 +265,11 @@ where
             Sink::Predicate(_) => {
                 observe_predicate_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
             }
-            Sink::Membership(spec) => sink_acc.observe_membership(spec.op, &item, &spec.target),
+            Sink::Membership(spec) => sink_acc.observe_membership(
+                spec.op,
+                &item,
+                membership_target.as_ref().expect("membership target exists"),
+            ),
             Sink::ArgExtreme(_) => {
                 observe_arg_extreme_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
             }
@@ -495,16 +515,31 @@ fn observe_reducer_item(
     Ok(ReducerItemFlow::Observed)
 }
 
-fn apply_membership_scalar_sink(spec: &super::MembershipSinkSpec, recv: &Val) -> Val {
+fn eval_membership_target(
+    spec: &super::MembershipSinkSpec,
+    vm: &mut crate::vm::VM,
+    env: &Env,
+) -> Result<Val, EvalError> {
+    match &spec.target {
+        super::MembershipSinkTarget::Literal(value) => Ok(value.clone()),
+        super::MembershipSinkTarget::Program(program) => vm.exec_in_env(program, env),
+    }
+}
+
+fn apply_membership_scalar_sink(
+    spec: &super::MembershipSinkSpec,
+    target: &Val,
+    recv: &Val,
+) -> Val {
     match spec.method {
         crate::builtins::BuiltinMethod::Includes => {
-            crate::builtins::includes_apply(recv, &spec.target)
+            crate::builtins::includes_apply(recv, target)
         }
         crate::builtins::BuiltinMethod::Index => {
-            crate::builtins::index_value_apply(recv, &spec.target).unwrap_or(Val::Null)
+            crate::builtins::index_value_apply(recv, target).unwrap_or(Val::Null)
         }
         crate::builtins::BuiltinMethod::IndicesOf => {
-            crate::builtins::indices_of_apply(recv, &spec.target).unwrap_or(Val::Null)
+            crate::builtins::indices_of_apply(recv, target).unwrap_or(Val::Null)
         }
         _ => Val::Null,
     }

--- a/jetro-core/src/exec/pipeline/materialized_exec.rs
+++ b/jetro-core/src/exec/pipeline/materialized_exec.rs
@@ -143,7 +143,7 @@ pub(super) fn run(pipeline: &Pipeline, root: &Val, base_env: &Env) -> Result<Val
         .last()
         .and_then(Stage::descriptor)
         .is_some_and(|desc| desc.method == Some(BuiltinMethod::GroupBy));
-    Ok(sink_acc.finish(unwrap_single_collect_obj))
+    sink_acc.finish_result(unwrap_single_collect_obj)
 }
 
 /// Streams a pipeline directly from a `simd-json` tape; returns `None` when any stage requires materialisation.
@@ -293,7 +293,7 @@ where
     if let Some(collector) = terminal_map_collect {
         return Ok(collector.finish());
     }
-    Ok(sink_acc.finish(false))
+    sink_acc.finish_result(false)
 }
 
 // barrier stages always produce a Vec<Val>, so only the Owned variant is needed here
@@ -564,7 +564,7 @@ fn observe_predicate_sink_item(
     let predicate = eval_kernel(kernel, &item, |item| {
         apply_item_in_env(vm, loop_env, item, &spec.predicate)
     })?;
-    Ok(sink_acc.observe_predicate(spec.op, crate::util::is_truthy(&predicate)))
+    sink_acc.observe_predicate_item(spec.op, crate::util::is_truthy(&predicate), item)
 }
 
 fn observe_arg_extreme_sink_item(

--- a/jetro-core/src/exec/pipeline/materialized_exec.rs
+++ b/jetro-core/src/exec/pipeline/materialized_exec.rs
@@ -36,6 +36,11 @@ pub(super) fn run(pipeline: &Pipeline, root: &Val, base_env: &Env) -> Result<Val
     let mut emitted_outputs: usize = 0;
 
     let mut sink_acc = SinkAccumulator::new(&pipeline.sink);
+    if let Sink::Membership(spec) = &pipeline.sink {
+        if pipeline.stages.is_empty() && row_source::array_like_rows(&recv).is_none() {
+            return Ok(apply_membership_scalar_sink(spec, &recv));
+        }
+    }
 
     let needs_barrier = pipeline
         .stages
@@ -99,6 +104,7 @@ pub(super) fn run(pipeline: &Pipeline, root: &Val, base_env: &Env) -> Result<Val
             Sink::Predicate(_) => {
                 observe_predicate_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
             }
+            Sink::Membership(spec) => sink_acc.observe_membership(spec.op, &item, &spec.target),
             Sink::Reducer(_) => {
                 match observe_reducer_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)? {
                     ReducerItemFlow::Observed => false,
@@ -240,6 +246,7 @@ where
             Sink::Predicate(_) => {
                 observe_predicate_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
             }
+            Sink::Membership(spec) => sink_acc.observe_membership(spec.op, &item, &spec.target),
             Sink::Reducer(_) => {
                 match observe_reducer_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)? {
                     ReducerItemFlow::Observed => false,
@@ -480,6 +487,21 @@ fn observe_reducer_item(
     }
 
     Ok(ReducerItemFlow::Observed)
+}
+
+fn apply_membership_scalar_sink(spec: &super::MembershipSinkSpec, recv: &Val) -> Val {
+    match spec.method {
+        crate::builtins::BuiltinMethod::Includes => {
+            crate::builtins::includes_apply(recv, &spec.target)
+        }
+        crate::builtins::BuiltinMethod::Index => {
+            crate::builtins::index_value_apply(recv, &spec.target).unwrap_or(Val::Null)
+        }
+        crate::builtins::BuiltinMethod::IndicesOf => {
+            crate::builtins::indices_of_apply(recv, &spec.target).unwrap_or(Val::Null)
+        }
+        _ => Val::Null,
+    }
 }
 
 fn observe_predicate_sink_item(

--- a/jetro-core/src/exec/pipeline/materialized_exec.rs
+++ b/jetro-core/src/exec/pipeline/materialized_exec.rs
@@ -46,7 +46,10 @@ pub(super) fn run(pipeline: &Pipeline, root: &Val, base_env: &Env) -> Result<Val
     }
 
     let pre_iter: LegacyPreIter = {
-        let mut buf: Vec<Val> = row_source::materialize_source(&recv);
+        let mut buf: Vec<Val> = match source_demand {
+            PullDemand::FirstInput(n) => row_source::materialize_source_prefix(&recv, n),
+            _ => row_source::materialize_source(&recv),
+        };
         let strategies = compute_strategies_with_kernels(
             &pipeline.stages,
             &pipeline.stage_kernels,

--- a/jetro-core/src/exec/pipeline/materialized_exec.rs
+++ b/jetro-core/src/exec/pipeline/materialized_exec.rs
@@ -96,6 +96,9 @@ pub(super) fn run(pipeline: &Pipeline, root: &Val, base_env: &Env) -> Result<Val
         pulled_inputs += 1;
 
         let sink_done = match &pipeline.sink {
+            Sink::Predicate(_) => {
+                observe_predicate_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
+            }
             Sink::Reducer(_) => {
                 match observe_reducer_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)? {
                     ReducerItemFlow::Observed => false,
@@ -234,6 +237,9 @@ where
         }
 
         let sink_done = match &pipeline.sink {
+            Sink::Predicate(_) => {
+                observe_predicate_sink_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)?
+            }
             Sink::Reducer(_) => {
                 match observe_reducer_item(pipeline, item, &mut sink_acc, &mut vm, &mut loop_env)? {
                     ReducerItemFlow::Observed => false,
@@ -474,6 +480,28 @@ fn observe_reducer_item(
     }
 
     Ok(ReducerItemFlow::Observed)
+}
+
+fn observe_predicate_sink_item(
+    pipeline: &Pipeline,
+    item: Val,
+    sink_acc: &mut SinkAccumulator<'_>,
+    vm: &mut crate::vm::VM,
+    loop_env: &mut Env,
+) -> Result<bool, EvalError> {
+    let Sink::Predicate(spec) = &pipeline.sink else {
+        return Ok(sink_acc.push(item));
+    };
+
+    let kernel_idx = spec.predicate_kernel_index();
+    let kernel = pipeline
+        .sink_kernels
+        .get(kernel_idx)
+        .unwrap_or(&BodyKernel::Generic);
+    let predicate = eval_kernel(kernel, &item, |item| {
+        apply_item_in_env(vm, loop_env, item, &spec.predicate)
+    })?;
+    Ok(sink_acc.observe_predicate(spec.op, crate::util::is_truthy(&predicate)))
 }
 
 /// Applies an object-lambda stage (`TransformKeys`, `TransformValues`, `FilterKeys`, `FilterValues`) to `recv`.

--- a/jetro-core/src/exec/pipeline/operator.rs
+++ b/jetro-core/src/exec/pipeline/operator.rs
@@ -44,6 +44,15 @@ pub struct MembershipSinkSpec {
     pub method: BuiltinMethod,
 }
 
+/// Specification for arg-extreme terminal sinks (`max_by`, `min_by`).
+#[derive(Debug, Clone)]
+pub struct ArgExtremeSinkSpec {
+    /// When true, keeps the row with the largest key; otherwise keeps the smallest key.
+    pub want_max: bool,
+    /// Key expression evaluated for each row.
+    pub key: Arc<Program>,
+}
+
 /// Predicate terminal operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PredicateSinkOp {
@@ -76,6 +85,18 @@ impl PredicateSinkSpec {
 
     /// Returns the sink-kernel index for the predicate.
     pub(crate) fn predicate_kernel_index(&self) -> usize {
+        0
+    }
+}
+
+impl ArgExtremeSinkSpec {
+    /// Iterates over embedded programs for kernel enumeration.
+    pub(crate) fn sink_programs(&self) -> impl Iterator<Item = &Arc<Program>> {
+        std::iter::once(&self.key)
+    }
+
+    /// Returns the sink-kernel index for the key projection.
+    pub(crate) fn key_kernel_index(&self) -> usize {
         0
     }
 }

--- a/jetro-core/src/exec/pipeline/operator.rs
+++ b/jetro-core/src/exec/pipeline/operator.rs
@@ -3,8 +3,8 @@
 
 use std::sync::Arc;
 
-use crate::parse::ast::Expr;
 use crate::builtins::BuiltinMethod;
+use crate::parse::ast::Expr;
 use crate::vm::Program;
 
 use super::NumOp;
@@ -22,6 +22,38 @@ pub struct ReducerSpec {
     pub predicate_expr: Option<Arc<Expr>>,
     /// Source AST for `projection`, used during IR analysis.
     pub projection_expr: Option<Arc<Expr>>,
+}
+
+/// Specification for predicate terminal sinks (`any`, `all`, `find_index`).
+#[derive(Debug, Clone)]
+pub struct PredicateSinkSpec {
+    /// Terminal operation to perform.
+    pub op: PredicateSinkOp,
+    /// Predicate evaluated for each row until the terminal can decide.
+    pub predicate: Arc<Program>,
+}
+
+/// Predicate terminal operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PredicateSinkOp {
+    /// Returns true when any row matches the predicate.
+    Any,
+    /// Returns true when every row matches the predicate.
+    All,
+    /// Returns the zero-based index of the first matching row, or null.
+    FindIndex,
+}
+
+impl PredicateSinkSpec {
+    /// Iterates over embedded programs for kernel enumeration.
+    pub(crate) fn sink_programs(&self) -> impl Iterator<Item = &Arc<Program>> {
+        std::iter::once(&self.predicate)
+    }
+
+    /// Returns the sink-kernel index for the predicate.
+    pub(crate) fn predicate_kernel_index(&self) -> usize {
+        0
+    }
 }
 
 /// The kind of reduction a `ReducerSpec` performs.

--- a/jetro-core/src/exec/pipeline/operator.rs
+++ b/jetro-core/src/exec/pipeline/operator.rs
@@ -33,6 +33,17 @@ pub struct PredicateSinkSpec {
     pub predicate: Arc<Program>,
 }
 
+/// Specification for value-membership terminal sinks (`includes`, `index`, `indices_of`).
+#[derive(Debug, Clone)]
+pub struct MembershipSinkSpec {
+    /// Terminal operation to perform.
+    pub op: MembershipSinkOp,
+    /// Value compared against each row.
+    pub target: crate::data::value::Val,
+    /// Original builtin method used for scalar fallback.
+    pub method: BuiltinMethod,
+}
+
 /// Predicate terminal operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PredicateSinkOp {
@@ -42,6 +53,17 @@ pub enum PredicateSinkOp {
     All,
     /// Returns the zero-based index of the first matching row, or null.
     FindIndex,
+}
+
+/// Value-membership terminal operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MembershipSinkOp {
+    /// Returns true when any row equals the target.
+    Includes,
+    /// Returns the zero-based index of the first matching row, or null.
+    Index,
+    /// Returns all zero-based indices matching the target.
+    IndicesOf,
 }
 
 impl PredicateSinkSpec {

--- a/jetro-core/src/exec/pipeline/operator.rs
+++ b/jetro-core/src/exec/pipeline/operator.rs
@@ -39,9 +39,18 @@ pub struct MembershipSinkSpec {
     /// Terminal operation to perform.
     pub op: MembershipSinkOp,
     /// Value compared against each row.
-    pub target: crate::data::value::Val,
+    pub target: MembershipSinkTarget,
     /// Original builtin method used for scalar fallback.
     pub method: BuiltinMethod,
+}
+
+/// Target value source for value-membership terminal sinks.
+#[derive(Debug, Clone)]
+pub enum MembershipSinkTarget {
+    /// Literal known during lowering.
+    Literal(crate::data::value::Val),
+    /// Expression evaluated once before rows are streamed.
+    Program(Arc<Program>),
 }
 
 /// Specification for arg-extreme terminal sinks (`max_by`, `min_by`).
@@ -86,6 +95,17 @@ impl PredicateSinkSpec {
     /// Returns the sink-kernel index for the predicate.
     pub(crate) fn predicate_kernel_index(&self) -> usize {
         0
+    }
+}
+
+impl MembershipSinkSpec {
+    /// Iterates over embedded programs for kernel enumeration.
+    pub(crate) fn sink_programs(&self) -> impl Iterator<Item = &Arc<Program>> {
+        match &self.target {
+            MembershipSinkTarget::Literal(_) => None,
+            MembershipSinkTarget::Program(program) => Some(program),
+        }
+        .into_iter()
     }
 }
 

--- a/jetro-core/src/exec/pipeline/operator.rs
+++ b/jetro-core/src/exec/pipeline/operator.rs
@@ -24,7 +24,7 @@ pub struct ReducerSpec {
     pub projection_expr: Option<Arc<Expr>>,
 }
 
-/// Specification for predicate terminal sinks (`any`, `all`, `find_index`).
+/// Specification for predicate terminal sinks (`any`, `all`, `find_index`, `find_one`).
 #[derive(Debug, Clone)]
 pub struct PredicateSinkSpec {
     /// Terminal operation to perform.
@@ -73,6 +73,8 @@ pub enum PredicateSinkOp {
     FindIndex,
     /// Returns all zero-based indices whose rows match the predicate.
     IndicesWhere,
+    /// Returns exactly one matching row, erroring on zero or multiple matches.
+    FindOne,
 }
 
 /// Value-membership terminal operation.

--- a/jetro-core/src/exec/pipeline/operator.rs
+++ b/jetro-core/src/exec/pipeline/operator.rs
@@ -53,6 +53,8 @@ pub enum PredicateSinkOp {
     All,
     /// Returns the zero-based index of the first matching row, or null.
     FindIndex,
+    /// Returns all zero-based indices whose rows match the predicate.
+    IndicesWhere,
 }
 
 /// Value-membership terminal operation.

--- a/jetro-core/src/exec/pipeline/plan.rs
+++ b/jetro-core/src/exec/pipeline/plan.rs
@@ -407,7 +407,8 @@ pub fn select_strategy(stages: &[Stage], sink: &Sink) -> Strategy {
     use crate::parse::chain_ir::Cardinality;
 
     let stages_can_indexed = stages.iter().all(|s| s.shape().can_indexed);
-    let sink_positional = sink.demand().positional.is_some();
+    let sink_positional =
+        sink.demand().positional.is_some() || matches!(sink, Sink::SelectMany { .. });
     let has_barrier = stages
         .iter()
         .any(|s| matches!(s.shape().cardinality, Cardinality::Barrier));

--- a/jetro-core/src/exec/pipeline/row_source.rs
+++ b/jetro-core/src/exec/pipeline/row_source.rs
@@ -301,6 +301,11 @@ pub(super) fn materialize_source(recv: &Val) -> Vec<Val> {
     ValRowSource::from_receiver(recv).materialize()
 }
 
+/// Materialises at most the first `limit` rows from `recv`.
+pub(super) fn materialize_source_prefix(recv: &Val, limit: usize) -> Vec<Val> {
+    ValRowSource::from_receiver(recv).iter().take(limit).collect()
+}
+
 /// Returns the number of rows in `recv`, or `None` when `recv` is a scalar or non-iterable.
 pub(super) fn row_count(recv: &Val) -> Option<usize> {
     recv.array_len()

--- a/jetro-core/src/exec/pipeline/sink_accumulator.rs
+++ b/jetro-core/src/exec/pipeline/sink_accumulator.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     builtins::{BuiltinSelectionPosition, BuiltinSinkAccumulator},
-    data::value::Val,
+    data::{context::EvalError, value::Val},
 };
 
 use super::{cmp_val_total, MembershipSinkOp, PredicateSinkOp, ReducerAccumulator, Sink};
@@ -27,6 +27,7 @@ pub(crate) struct SinkAccumulator<'a> {
     nth_seen: usize,
     predicate_seen: usize,
     predicate_matched: Option<usize>,
+    predicate_value: Option<Val>,
     predicate_all: bool,
     predicate_indices: Vec<i64>,
     membership_seen: usize,
@@ -51,6 +52,7 @@ impl<'a> SinkAccumulator<'a> {
             nth_seen: 0,
             predicate_seen: 0,
             predicate_matched: None,
+            predicate_value: None,
             predicate_all: true,
             predicate_indices: Vec::new(),
             membership_seen: 0,
@@ -198,34 +200,39 @@ impl<'a> SinkAccumulator<'a> {
         }
     }
 
-    /// Updates a predicate terminal sink with one predicate result; returns true once decided.
-    pub(crate) fn observe_predicate(&mut self, op: PredicateSinkOp, matched: bool) -> bool {
+    /// Updates a predicate terminal sink with one predicate result and row value.
+    pub(crate) fn observe_predicate_item(
+        &mut self,
+        op: PredicateSinkOp,
+        matched: bool,
+        item: Val,
+    ) -> Result<bool, EvalError> {
         match op {
             PredicateSinkOp::Any => {
                 if matched {
                     self.predicate_matched = Some(self.predicate_seen);
-                    true
+                    Ok(true)
                 } else {
                     self.predicate_seen += 1;
-                    false
+                    Ok(false)
                 }
             }
             PredicateSinkOp::All => {
                 self.predicate_seen += 1;
                 if matched {
-                    false
+                    Ok(false)
                 } else {
                     self.predicate_all = false;
-                    true
+                    Ok(true)
                 }
             }
             PredicateSinkOp::FindIndex => {
                 if matched {
                     self.predicate_matched = Some(self.predicate_seen);
-                    true
+                    Ok(true)
                 } else {
                     self.predicate_seen += 1;
-                    false
+                    Ok(false)
                 }
             }
             PredicateSinkOp::IndicesWhere => {
@@ -233,7 +240,20 @@ impl<'a> SinkAccumulator<'a> {
                     self.predicate_indices.push(self.predicate_seen as i64);
                 }
                 self.predicate_seen += 1;
-                false
+                Ok(false)
+            }
+            PredicateSinkOp::FindOne => {
+                if matched {
+                    if self.predicate_matched.is_some() {
+                        return Err(EvalError(
+                            "find_one: expected exactly one element, got multiple".into(),
+                        ));
+                    }
+                    self.predicate_matched = Some(self.predicate_seen);
+                    self.predicate_value = Some(item);
+                }
+                self.predicate_seen += 1;
+                Ok(false)
             }
         }
     }
@@ -338,6 +358,7 @@ impl<'a> SinkAccumulator<'a> {
                     .map(|idx| Val::Int(idx as i64))
                     .unwrap_or(Val::Null),
                 PredicateSinkOp::IndicesWhere => Val::int_vec(self.predicate_indices),
+                PredicateSinkOp::FindOne => self.predicate_value.unwrap_or(Val::Null),
             },
             Sink::Membership(spec) => match spec.op {
                 MembershipSinkOp::Includes => Val::Bool(self.membership_matched.is_some()),
@@ -351,6 +372,16 @@ impl<'a> SinkAccumulator<'a> {
             Sink::Nth(_) => self.nth.unwrap_or(Val::Null),
             Sink::Terminal(_) => Val::Null,
         }
+    }
+
+    /// Fallible finalisation for sinks whose terminal semantics can fail.
+    pub(crate) fn finish_result(self, unwrap_single_collect_obj: bool) -> Result<Val, EvalError> {
+        if matches!(self.sink, Sink::Predicate(spec) if spec.op == PredicateSinkOp::FindOne) {
+            return self.predicate_value.ok_or_else(|| {
+                EvalError("find_one: expected exactly one element, got 0".into())
+            });
+        }
+        Ok(self.finish(unwrap_single_collect_obj))
     }
 
     /// Finalises state for a builtin-registered sink, delegating to the reducer or HLL as needed.

--- a/jetro-core/src/exec/pipeline/sink_accumulator.rs
+++ b/jetro-core/src/exec/pipeline/sink_accumulator.rs
@@ -365,6 +365,18 @@ impl<'a> SinkAccumulator<'a> {
 
     /// Updates an arg-extreme terminal sink with one row and its projected key.
     pub(crate) fn observe_arg_extreme(&mut self, want_max: bool, item: Val, key: Val) {
+        self.observe_arg_extreme_lazy(want_max, key, || item);
+    }
+
+    /// Lazy arg-extreme update. The row is materialised only when its key becomes the new best.
+    pub(crate) fn observe_arg_extreme_lazy<F>(
+        &mut self,
+        want_max: bool,
+        key: Val,
+        materialize_item: F,
+    ) where
+        F: FnOnce() -> Val,
+    {
         let should_take = match self.arg_extreme_key.as_ref() {
             None => true,
             Some(best_key) => {
@@ -378,7 +390,7 @@ impl<'a> SinkAccumulator<'a> {
         };
         if should_take {
             self.arg_extreme_key = Some(key);
-            self.arg_extreme_value = Some(item);
+            self.arg_extreme_value = Some(materialize_item());
         }
     }
 

--- a/jetro-core/src/exec/pipeline/sink_accumulator.rs
+++ b/jetro-core/src/exec/pipeline/sink_accumulator.rs
@@ -3,6 +3,8 @@
 //! Mirrors the composed `Sink` contract but without a generic type parameter, for compatibility
 //! with older execution paths.
 
+use std::collections::VecDeque;
+
 use crate::{
     builtins::{BuiltinSelectionPosition, BuiltinSinkAccumulator},
     data::{context::EvalError, value::Val},
@@ -25,6 +27,7 @@ pub(crate) struct SinkAccumulator<'a> {
     // nth observed item for Sink::Nth
     nth: Option<Val>,
     nth_seen: usize,
+    select_many: VecDeque<Val>,
     predicate_seen: usize,
     predicate_matched: Option<usize>,
     predicate_value: Option<Val>,
@@ -50,6 +53,7 @@ impl<'a> SinkAccumulator<'a> {
             last: None,
             nth: None,
             nth_seen: 0,
+            select_many: VecDeque::new(),
             predicate_seen: 0,
             predicate_matched: None,
             predicate_value: None,
@@ -85,6 +89,7 @@ impl<'a> SinkAccumulator<'a> {
             Sink::Predicate(_) => false,
             Sink::Membership(_) => false,
             Sink::ArgExtreme(_) => false,
+            Sink::SelectMany { n, from_end } => self.observe_select_many(*n, *from_end, item),
             Sink::Nth(idx) => self.observe_nth(*idx, item),
             Sink::Terminal(_) => false,
         }
@@ -197,6 +202,24 @@ impl<'a> SinkAccumulator<'a> {
         } else {
             self.nth_seen += 1;
             false
+        }
+    }
+
+    /// Captures a bounded prefix or suffix. Prefix selection stops once full; suffix selection
+    /// retains only the latest `n` rows.
+    pub(crate) fn observe_select_many(&mut self, n: usize, from_end: bool, item: Val) -> bool {
+        if n == 0 {
+            return true;
+        }
+        if from_end {
+            if self.select_many.len() == n {
+                self.select_many.pop_front();
+            }
+            self.select_many.push_back(item);
+            false
+        } else {
+            self.select_many.push_back(item);
+            self.select_many.len() >= n
         }
     }
 
@@ -369,6 +392,13 @@ impl<'a> SinkAccumulator<'a> {
                 MembershipSinkOp::IndicesOf => Val::int_vec(self.membership_indices),
             },
             Sink::ArgExtreme(_) => self.arg_extreme_value.unwrap_or(Val::Null),
+            Sink::SelectMany { n: 0, .. } => Val::Null,
+            Sink::SelectMany { n, .. } if *n == 1 => self
+                .select_many
+                .into_iter()
+                .next()
+                .unwrap_or(Val::Null),
+            Sink::SelectMany { .. } => Val::arr(self.select_many.into_iter().collect()),
             Sink::Nth(_) => self.nth.unwrap_or(Val::Null),
             Sink::Terminal(_) => Val::Null,
         }

--- a/jetro-core/src/exec/pipeline/sink_accumulator.rs
+++ b/jetro-core/src/exec/pipeline/sink_accumulator.rs
@@ -230,6 +230,19 @@ impl<'a> SinkAccumulator<'a> {
         matched: bool,
         item: Val,
     ) -> Result<bool, EvalError> {
+        self.observe_predicate_lazy(op, matched, || item)
+    }
+
+    /// Lazy predicate sink variant; materialises the row only for sinks that store it.
+    pub(crate) fn observe_predicate_lazy<F>(
+        &mut self,
+        op: PredicateSinkOp,
+        matched: bool,
+        materialize_item: F,
+    ) -> Result<bool, EvalError>
+    where
+        F: FnOnce() -> Val,
+    {
         match op {
             PredicateSinkOp::Any => {
                 if matched {
@@ -273,7 +286,7 @@ impl<'a> SinkAccumulator<'a> {
                         ));
                     }
                     self.predicate_matched = Some(self.predicate_seen);
-                    self.predicate_value = Some(item);
+                    self.predicate_value = Some(materialize_item());
                 }
                 self.predicate_seen += 1;
                 Ok(false)

--- a/jetro-core/src/exec/pipeline/sink_accumulator.rs
+++ b/jetro-core/src/exec/pipeline/sink_accumulator.rs
@@ -208,8 +208,31 @@ impl<'a> SinkAccumulator<'a> {
     /// Captures a bounded prefix or suffix. Prefix selection stops once full; suffix selection
     /// retains only the latest `n` rows.
     pub(crate) fn observe_select_many(&mut self, n: usize, from_end: bool, item: Val) -> bool {
+        self.observe_select_many_lazy(n, from_end, false, || item)
+    }
+
+    /// Lazy bounded prefix/suffix selector. `prepend` is used when a reverse source is
+    /// satisfying a suffix demand so final output remains in semantic input order.
+    pub(crate) fn observe_select_many_lazy<F>(
+        &mut self,
+        n: usize,
+        from_end: bool,
+        prepend: bool,
+        materialize_item: F,
+    ) -> bool
+    where
+        F: FnOnce() -> Val,
+    {
         if n == 0 {
             return true;
+        }
+        let item = materialize_item();
+        if prepend {
+            if self.select_many.len() == n {
+                self.select_many.pop_back();
+            }
+            self.select_many.push_front(item);
+            return self.select_many.len() >= n;
         }
         if from_end {
             if self.select_many.len() == n {

--- a/jetro-core/src/exec/pipeline/sink_accumulator.rs
+++ b/jetro-core/src/exec/pipeline/sink_accumulator.rs
@@ -28,6 +28,7 @@ pub(crate) struct SinkAccumulator<'a> {
     predicate_seen: usize,
     predicate_matched: Option<usize>,
     predicate_all: bool,
+    predicate_indices: Vec<i64>,
     membership_seen: usize,
     membership_matched: Option<usize>,
     membership_indices: Vec<i64>,
@@ -49,6 +50,7 @@ impl<'a> SinkAccumulator<'a> {
             predicate_seen: 0,
             predicate_matched: None,
             predicate_all: true,
+            predicate_indices: Vec::new(),
             membership_seen: 0,
             membership_matched: None,
             membership_indices: Vec::new(),
@@ -221,6 +223,13 @@ impl<'a> SinkAccumulator<'a> {
                     false
                 }
             }
+            PredicateSinkOp::IndicesWhere => {
+                if matched {
+                    self.predicate_indices.push(self.predicate_seen as i64);
+                }
+                self.predicate_seen += 1;
+                false
+            }
         }
     }
 
@@ -304,6 +313,7 @@ impl<'a> SinkAccumulator<'a> {
                     .predicate_matched
                     .map(|idx| Val::Int(idx as i64))
                     .unwrap_or(Val::Null),
+                PredicateSinkOp::IndicesWhere => Val::int_vec(self.predicate_indices),
             },
             Sink::Membership(spec) => match spec.op {
                 MembershipSinkOp::Includes => Val::Bool(self.membership_matched.is_some()),

--- a/jetro-core/src/exec/pipeline/sink_accumulator.rs
+++ b/jetro-core/src/exec/pipeline/sink_accumulator.rs
@@ -325,6 +325,15 @@ impl<'a> SinkAccumulator<'a> {
         target: &Val,
     ) -> bool {
         let matched = crate::util::vals_eq(item, target);
+        self.observe_membership_match(op, matched)
+    }
+
+    /// Updates a value-membership terminal sink with an already-computed comparison result.
+    pub(crate) fn observe_membership_match(
+        &mut self,
+        op: MembershipSinkOp,
+        matched: bool,
+    ) -> bool {
         match op {
             MembershipSinkOp::Includes => {
                 if matched {

--- a/jetro-core/src/exec/pipeline/sink_accumulator.rs
+++ b/jetro-core/src/exec/pipeline/sink_accumulator.rs
@@ -8,7 +8,7 @@ use crate::{
     data::value::Val,
 };
 
-use super::{PredicateSinkOp, ReducerAccumulator, Sink};
+use super::{MembershipSinkOp, PredicateSinkOp, ReducerAccumulator, Sink};
 
 /// Stateful wrapper that accumulates one pipeline element at a time on behalf of a `Sink`.
 pub(crate) struct SinkAccumulator<'a> {
@@ -28,6 +28,9 @@ pub(crate) struct SinkAccumulator<'a> {
     predicate_seen: usize,
     predicate_matched: Option<usize>,
     predicate_all: bool,
+    membership_seen: usize,
+    membership_matched: Option<usize>,
+    membership_indices: Vec<i64>,
     // HyperLogLog register array for approximate-distinct-count sinks
     hll: [u8; HLL_M],
 }
@@ -46,6 +49,9 @@ impl<'a> SinkAccumulator<'a> {
             predicate_seen: 0,
             predicate_matched: None,
             predicate_all: true,
+            membership_seen: 0,
+            membership_matched: None,
+            membership_indices: Vec::new(),
             hll: [0; HLL_M],
         }
     }
@@ -69,6 +75,7 @@ impl<'a> SinkAccumulator<'a> {
                 false
             }
             Sink::Predicate(_) => false,
+            Sink::Membership(_) => false,
             Sink::Nth(idx) => self.observe_nth(*idx, item),
             Sink::Terminal(_) => false,
         }
@@ -217,6 +224,43 @@ impl<'a> SinkAccumulator<'a> {
         }
     }
 
+    /// Updates a value-membership terminal sink with one row; returns true once decided.
+    pub(crate) fn observe_membership(
+        &mut self,
+        op: MembershipSinkOp,
+        item: &Val,
+        target: &Val,
+    ) -> bool {
+        let matched = crate::util::vals_eq(item, target);
+        match op {
+            MembershipSinkOp::Includes => {
+                if matched {
+                    self.membership_matched = Some(self.membership_seen);
+                    true
+                } else {
+                    self.membership_seen += 1;
+                    false
+                }
+            }
+            MembershipSinkOp::Index => {
+                if matched {
+                    self.membership_matched = Some(self.membership_seen);
+                    true
+                } else {
+                    self.membership_seen += 1;
+                    false
+                }
+            }
+            MembershipSinkOp::IndicesOf => {
+                if matched {
+                    self.membership_indices.push(self.membership_seen as i64);
+                }
+                self.membership_seen += 1;
+                false
+            }
+        }
+    }
+
     /// Hashes `item` into the HyperLogLog registers for cardinality estimation.
     pub(crate) fn observe_approx_distinct(&mut self, item: &Val) {
         hll_observe(&mut self.hll, item);
@@ -260,6 +304,14 @@ impl<'a> SinkAccumulator<'a> {
                     .predicate_matched
                     .map(|idx| Val::Int(idx as i64))
                     .unwrap_or(Val::Null),
+            },
+            Sink::Membership(spec) => match spec.op {
+                MembershipSinkOp::Includes => Val::Bool(self.membership_matched.is_some()),
+                MembershipSinkOp::Index => self
+                    .membership_matched
+                    .map(|idx| Val::Int(idx as i64))
+                    .unwrap_or(Val::Null),
+                MembershipSinkOp::IndicesOf => Val::int_vec(self.membership_indices),
             },
             Sink::Nth(_) => self.nth.unwrap_or(Val::Null),
             Sink::Terminal(_) => Val::Null,

--- a/jetro-core/src/exec/pipeline/sink_accumulator.rs
+++ b/jetro-core/src/exec/pipeline/sink_accumulator.rs
@@ -8,7 +8,7 @@ use crate::{
     data::value::Val,
 };
 
-use super::{ReducerAccumulator, Sink};
+use super::{PredicateSinkOp, ReducerAccumulator, Sink};
 
 /// Stateful wrapper that accumulates one pipeline element at a time on behalf of a `Sink`.
 pub(crate) struct SinkAccumulator<'a> {
@@ -25,6 +25,9 @@ pub(crate) struct SinkAccumulator<'a> {
     // nth observed item for Sink::Nth
     nth: Option<Val>,
     nth_seen: usize,
+    predicate_seen: usize,
+    predicate_matched: Option<usize>,
+    predicate_all: bool,
     // HyperLogLog register array for approximate-distinct-count sinks
     hll: [u8; HLL_M],
 }
@@ -40,6 +43,9 @@ impl<'a> SinkAccumulator<'a> {
             last: None,
             nth: None,
             nth_seen: 0,
+            predicate_seen: 0,
+            predicate_matched: None,
+            predicate_all: true,
             hll: [0; HLL_M],
         }
     }
@@ -62,6 +68,7 @@ impl<'a> SinkAccumulator<'a> {
                 self.observe_approx_distinct(&item);
                 false
             }
+            Sink::Predicate(_) => false,
             Sink::Nth(idx) => self.observe_nth(*idx, item),
             Sink::Terminal(_) => false,
         }
@@ -177,6 +184,39 @@ impl<'a> SinkAccumulator<'a> {
         }
     }
 
+    /// Updates a predicate terminal sink with one predicate result; returns true once decided.
+    pub(crate) fn observe_predicate(&mut self, op: PredicateSinkOp, matched: bool) -> bool {
+        match op {
+            PredicateSinkOp::Any => {
+                if matched {
+                    self.predicate_matched = Some(self.predicate_seen);
+                    true
+                } else {
+                    self.predicate_seen += 1;
+                    false
+                }
+            }
+            PredicateSinkOp::All => {
+                self.predicate_seen += 1;
+                if matched {
+                    false
+                } else {
+                    self.predicate_all = false;
+                    true
+                }
+            }
+            PredicateSinkOp::FindIndex => {
+                if matched {
+                    self.predicate_matched = Some(self.predicate_seen);
+                    true
+                } else {
+                    self.predicate_seen += 1;
+                    false
+                }
+            }
+        }
+    }
+
     /// Hashes `item` into the HyperLogLog registers for cardinality estimation.
     pub(crate) fn observe_approx_distinct(&mut self, item: &Val) {
         hll_observe(&mut self.hll, item);
@@ -213,6 +253,14 @@ impl<'a> SinkAccumulator<'a> {
                 .expect("reducer sinks construct reducer")
                 .finish(),
             Sink::ApproxCountDistinct => Val::Int(hll_estimate(&self.hll) as i64),
+            Sink::Predicate(spec) => match spec.op {
+                PredicateSinkOp::Any => Val::Bool(self.predicate_matched.is_some()),
+                PredicateSinkOp::All => Val::Bool(self.predicate_all),
+                PredicateSinkOp::FindIndex => self
+                    .predicate_matched
+                    .map(|idx| Val::Int(idx as i64))
+                    .unwrap_or(Val::Null),
+            },
             Sink::Nth(_) => self.nth.unwrap_or(Val::Null),
             Sink::Terminal(_) => Val::Null,
         }

--- a/jetro-core/src/exec/pipeline/sink_accumulator.rs
+++ b/jetro-core/src/exec/pipeline/sink_accumulator.rs
@@ -8,7 +8,7 @@ use crate::{
     data::value::Val,
 };
 
-use super::{MembershipSinkOp, PredicateSinkOp, ReducerAccumulator, Sink};
+use super::{cmp_val_total, MembershipSinkOp, PredicateSinkOp, ReducerAccumulator, Sink};
 
 /// Stateful wrapper that accumulates one pipeline element at a time on behalf of a `Sink`.
 pub(crate) struct SinkAccumulator<'a> {
@@ -32,6 +32,8 @@ pub(crate) struct SinkAccumulator<'a> {
     membership_seen: usize,
     membership_matched: Option<usize>,
     membership_indices: Vec<i64>,
+    arg_extreme_key: Option<Val>,
+    arg_extreme_value: Option<Val>,
     // HyperLogLog register array for approximate-distinct-count sinks
     hll: [u8; HLL_M],
 }
@@ -54,6 +56,8 @@ impl<'a> SinkAccumulator<'a> {
             membership_seen: 0,
             membership_matched: None,
             membership_indices: Vec::new(),
+            arg_extreme_key: None,
+            arg_extreme_value: None,
             hll: [0; HLL_M],
         }
     }
@@ -78,6 +82,7 @@ impl<'a> SinkAccumulator<'a> {
             }
             Sink::Predicate(_) => false,
             Sink::Membership(_) => false,
+            Sink::ArgExtreme(_) => false,
             Sink::Nth(idx) => self.observe_nth(*idx, item),
             Sink::Terminal(_) => false,
         }
@@ -270,6 +275,25 @@ impl<'a> SinkAccumulator<'a> {
         }
     }
 
+    /// Updates an arg-extreme terminal sink with one row and its projected key.
+    pub(crate) fn observe_arg_extreme(&mut self, want_max: bool, item: Val, key: Val) {
+        let should_take = match self.arg_extreme_key.as_ref() {
+            None => true,
+            Some(best_key) => {
+                let ord = cmp_val_total(&key, best_key);
+                if want_max {
+                    ord.is_gt()
+                } else {
+                    ord.is_lt()
+                }
+            }
+        };
+        if should_take {
+            self.arg_extreme_key = Some(key);
+            self.arg_extreme_value = Some(item);
+        }
+    }
+
     /// Hashes `item` into the HyperLogLog registers for cardinality estimation.
     pub(crate) fn observe_approx_distinct(&mut self, item: &Val) {
         hll_observe(&mut self.hll, item);
@@ -323,6 +347,7 @@ impl<'a> SinkAccumulator<'a> {
                     .unwrap_or(Val::Null),
                 MembershipSinkOp::IndicesOf => Val::int_vec(self.membership_indices),
             },
+            Sink::ArgExtreme(_) => self.arg_extreme_value.unwrap_or(Val::Null),
             Sink::Nth(_) => self.nth.unwrap_or(Val::Null),
             Sink::Terminal(_) => Val::Null,
         }

--- a/jetro-core/src/exec/pipeline/symbolic.rs
+++ b/jetro-core/src/exec/pipeline/symbolic.rs
@@ -52,6 +52,10 @@ fn sink_runtime_demand(sink: &Sink) -> RuntimeDemand {
             value: ValueDemand::Whole,
             order: false,
         },
+        Sink::Membership(_) => RuntimeDemand {
+            value: ValueDemand::Whole,
+            order: false,
+        },
         Sink::Collect | Sink::Terminal(_) | Sink::Nth(_) => RuntimeDemand {
             value: ValueDemand::Whole,
             order: true,

--- a/jetro-core/src/exec/pipeline/symbolic.rs
+++ b/jetro-core/src/exec/pipeline/symbolic.rs
@@ -253,10 +253,14 @@ fn suffix_consumes_value(stages: &[Stage]) -> bool {
 }
 
 fn compile_stage_expr(expr: &Expr) -> Arc<crate::vm::Program> {
-    Arc::new(crate::compile::compiler::Compiler::compile(
-        expr,
-        "<pipeline-rewrite>",
-    ))
+    // Pipeline-rewritten stage bodies are produced as raw `Expr`. When the
+    // body is a single-param `Expr::Lambda` we apply the same AST-level
+    // substitution that `Compiler::compile_lambda_or_expr` uses for method
+    // arguments — replacing the param identifier with `Expr::Current` —
+    // before compiling. Without this, `Compiler::compile` would emit
+    // `Opcode::PushNull` for a top-level `Expr::Lambda` (per `compile.rs`'s
+    // top-level fallback) and the stage would map every row to `null`.
+    crate::compile::lambda_lower::compile_lambda_arg(expr, "<pipeline-rewrite>")
 }
 
 fn simplify_expr(expr: Expr) -> Expr {

--- a/jetro-core/src/exec/pipeline/symbolic.rs
+++ b/jetro-core/src/exec/pipeline/symbolic.rs
@@ -84,7 +84,25 @@ pub(super) fn normalize_symbolic(
     let mut out = SymbolicEmitter::new(demand);
     for idx in 0..in_stages.len() {
         let stage = in_stages[idx].clone();
-        let expr = in_exprs.get(idx).cloned().unwrap_or(None);
+        // Unwrap a single-param `Expr::Lambda` here so the symbolic
+        // substitution operates on the actual body expression rather than
+        // a `Lambda` wrapper (which `substitute_current` passes through
+        // intact and which would otherwise leak into downstream stage
+        // bodies as `Opcode::PushNull`).
+        let expr = in_exprs
+            .get(idx)
+            .cloned()
+            .unwrap_or(None)
+            .map(|e| match e.as_ref() {
+                Expr::Lambda { params, body } if params.len() == 1 => {
+                    let lowered = crate::compile::lambda_lower::substitute_current(
+                        (**body).clone(),
+                        params[0].as_str(),
+                    );
+                    Arc::new(lowered)
+                }
+                _ => e,
+            });
         match stage {
             _ if stage.is_symbolic_map_stage() => {
                 if let Some(expr) = expr.as_ref().filter(|e| is_pure_expr(e)) {
@@ -253,14 +271,16 @@ fn suffix_consumes_value(stages: &[Stage]) -> bool {
 }
 
 fn compile_stage_expr(expr: &Expr) -> Arc<crate::vm::Program> {
-    // Pipeline-rewritten stage bodies are produced as raw `Expr`. When the
-    // body is a single-param `Expr::Lambda` we apply the same AST-level
-    // substitution that `Compiler::compile_lambda_or_expr` uses for method
-    // arguments — replacing the param identifier with `Expr::Current` —
-    // before compiling. Without this, `Compiler::compile` would emit
-    // `Opcode::PushNull` for a top-level `Expr::Lambda` (per `compile.rs`'s
-    // top-level fallback) and the stage would map every row to `null`.
-    crate::compile::lambda_lower::compile_lambda_arg(expr, "<pipeline-rewrite>")
+    // Pipeline-rewritten stage bodies arrive after `normalize_symbolic`
+    // has already unwrapped any single-param `Expr::Lambda` wrapper, so
+    // compile straight via `Compiler::compile`. Re-applying lambda
+    // unwrapping here would strip a second level for `r => (x => x)`-
+    // style bodies whose value is itself a lambda (no-op runtime value)
+    // and corrupt them.
+    Arc::new(crate::compile::compiler::Compiler::compile(
+        expr,
+        "<pipeline-rewrite>",
+    ))
 }
 
 fn simplify_expr(expr: Expr) -> Expr {

--- a/jetro-core/src/exec/pipeline/symbolic.rs
+++ b/jetro-core/src/exec/pipeline/symbolic.rs
@@ -60,7 +60,7 @@ fn sink_runtime_demand(sink: &Sink) -> RuntimeDemand {
             value: ValueDemand::Whole,
             order: true,
         },
-        Sink::Collect | Sink::Terminal(_) | Sink::Nth(_) => RuntimeDemand {
+        Sink::Collect | Sink::Terminal(_) | Sink::SelectMany { .. } | Sink::Nth(_) => RuntimeDemand {
             value: ValueDemand::Whole,
             order: true,
         },

--- a/jetro-core/src/exec/pipeline/symbolic.rs
+++ b/jetro-core/src/exec/pipeline/symbolic.rs
@@ -56,6 +56,10 @@ fn sink_runtime_demand(sink: &Sink) -> RuntimeDemand {
             value: ValueDemand::Whole,
             order: false,
         },
+        Sink::ArgExtreme(_) => RuntimeDemand {
+            value: ValueDemand::Whole,
+            order: true,
+        },
         Sink::Collect | Sink::Terminal(_) | Sink::Nth(_) => RuntimeDemand {
             value: ValueDemand::Whole,
             order: true,

--- a/jetro-core/src/exec/pipeline/symbolic.rs
+++ b/jetro-core/src/exec/pipeline/symbolic.rs
@@ -7,7 +7,9 @@
 
 use std::sync::Arc;
 
-use crate::parse::ast::{Arg, ArrayElem, Expr, FStringPart, MatchArm, ObjField, PatchOp, PathStep, PipeStep, Step};
+use crate::parse::ast::{
+    Arg, ArrayElem, Expr, FStringPart, MatchArm, ObjField, PatchOp, PathStep, PipeStep, Step,
+};
 
 use super::{BodyKernel, ReducerOp, Sink, Stage};
 
@@ -43,6 +45,10 @@ fn sink_runtime_demand(sink: &Sink) -> RuntimeDemand {
             order: false,
         },
         Sink::Reducer(_) => RuntimeDemand {
+            value: ValueDemand::Whole,
+            order: false,
+        },
+        Sink::Predicate(_) => RuntimeDemand {
             value: ValueDemand::Whole,
             order: false,
         },
@@ -239,7 +245,10 @@ fn suffix_consumes_value(stages: &[Stage]) -> bool {
 }
 
 fn compile_stage_expr(expr: &Expr) -> Arc<crate::vm::Program> {
-    Arc::new(crate::compile::compiler::Compiler::compile(expr, "<pipeline-rewrite>"))
+    Arc::new(crate::compile::compiler::Compiler::compile(
+        expr,
+        "<pipeline-rewrite>",
+    ))
 }
 
 fn simplify_expr(expr: Expr) -> Expr {

--- a/jetro-core/src/exec/router.rs
+++ b/jetro-core/src/exec/router.rs
@@ -753,6 +753,26 @@ mod tests {
 
     #[cfg(feature = "simd-json")]
     #[test]
+    fn view_object_key_projection_last_uses_tape_native_helpers() {
+        let j = Jetro::from_bytes(
+            br#"{"books":[{"title":"low","score":1,"debug":true},{"title":"b","score":902,"debug":false}],"unused":{"large":[1,2,3,4]}}"#.to_vec(),
+        )
+        .unwrap();
+        j.reset_tape_materialized_subtrees();
+
+        let keys = j.collect(r#"$.books.map(@.keys()).last()"#).unwrap();
+        let picked = j
+            .collect(r#"$.books.map(@.pick("title", "score")).last()"#)
+            .unwrap();
+
+        assert_eq!(keys, json!(["title", "score", "debug"]));
+        assert_eq!(picked, json!({"title": "b", "score": 902}));
+        assert!(!j.root_val_is_materialized());
+        assert_eq!(j.tape_materialized_subtrees(), 0);
+    }
+
+    #[cfg(feature = "simd-json")]
+    #[test]
     fn view_object_map_collects_scalar_cells_without_materializing_subtrees() {
         let j = Jetro::from_bytes(
             br#"{"books":[{"title":"low","score":1},{"title":"a","score":901},{"title":"b","score":902}],"unused":{"large":[1,2,3,4]}}"#.to_vec(),
@@ -857,7 +877,7 @@ mod tests {
 
         assert_eq!(out, json!("bob"));
         assert!(!j.root_val_is_materialized());
-        assert_eq!(j.tape_materialized_subtrees(), 1);
+        assert_eq!(j.tape_materialized_subtrees(), 0);
     }
 
     #[cfg(feature = "simd-json")]
@@ -875,7 +895,7 @@ mod tests {
 
         assert_eq!(out, json!("bob"));
         assert!(!j.root_val_is_materialized());
-        assert_eq!(j.tape_materialized_subtrees(), 1);
+        assert_eq!(j.tape_materialized_subtrees(), 0);
     }
 
     #[cfg(feature = "simd-json")]

--- a/jetro-core/src/exec/view.rs
+++ b/jetro-core/src/exec/view.rs
@@ -94,7 +94,7 @@ where
         |item| observe_view_sink(item, sink, &mut sink_acc, &body.sink_kernels),
     )?;
 
-    Some(Ok(sink_acc.finish(false)))
+    Some(sink_acc.finish_result(false))
 }
 
 /// Feeds one view row into the sink accumulator according to `sink`'s capability.
@@ -149,6 +149,23 @@ where
                 ViewRowAction::Stop
             } else {
                 ViewRowAction::Emit
+            })
+        }
+        pipeline::ViewSinkCapability::Predicate {
+            op,
+            predicate_kernel,
+        } => {
+            let kernel = sink_kernels.get(predicate_kernel)?;
+            let matched = eval_filter_kernel(item, kernel)?;
+            let sink_done = sink_acc
+                .observe_predicate_lazy(op, matched, || item.materialize())
+                .ok()?;
+            Some(if sink_done {
+                ViewRowAction::Stop
+            } else if matched {
+                ViewRowAction::Emit
+            } else {
+                ViewRowAction::Skip
             })
         }
     }
@@ -756,7 +773,7 @@ where
         |item| observe_view_sink(item, suffix.sink, &mut sink_acc, &body.sink_kernels),
     )?;
 
-    Some(Ok(sink_acc.finish(false)))
+    Some(sink_acc.finish_result(false))
 }
 
 /// Plan produced when a `Sort` barrier is detected. Records the view-domain

--- a/jetro-core/src/exec/view.rs
+++ b/jetro-core/src/exec/view.rs
@@ -51,7 +51,7 @@ where
     if let Some(result) = run_terminal_collect(source.clone(), body) {
         return Some(result);
     }
-    if let Some(result) = run_full(source.clone(), body) {
+    if let Some(result) = run_full_with_env(source.clone(), body, Some(base_env)) {
         return Some(result);
     }
     if let Some(result) =
@@ -70,7 +70,19 @@ where
 /// Runs the complete pipeline entirely in the view domain when all stages and
 /// the sink have a `ViewCapability`. Returns `None` when any stage lacks
 /// view support, allowing a less specialised path to take over.
+#[cfg(test)]
 fn run_full<'a, V>(source: V, body: &pipeline::PipelineBody) -> Option<Result<Val, EvalError>>
+where
+    V: ValueView<'a>,
+{
+    run_full_with_env(source, body, None)
+}
+
+fn run_full_with_env<'a, V>(
+    source: V,
+    body: &pipeline::PipelineBody,
+    base_env: Option<&Env>,
+) -> Option<Result<Val, EvalError>>
 where
     V: ValueView<'a>,
 {
@@ -93,6 +105,11 @@ where
         },
         (_, sink) => sink,
     };
+    let sink = match resolve_view_sink(sink, base_env) {
+        Some(Ok(sink)) => sink,
+        Some(Err(err)) => return Some(Err(err)),
+        None => return None,
+    };
 
     drive_view_frontier(
         source,
@@ -103,6 +120,28 @@ where
     )?;
 
     Some(sink_acc.finish_result(false))
+}
+
+fn resolve_view_sink(
+    sink: pipeline::ViewSinkCapability,
+    base_env: Option<&Env>,
+) -> Option<Result<pipeline::ViewSinkCapability, EvalError>> {
+    match sink {
+        pipeline::ViewSinkCapability::Membership {
+            op,
+            target: pipeline::ViewMembershipTarget::Program(program),
+        } => {
+            let env = base_env?;
+            let mut vm = crate::vm::VM::new();
+            Some(vm.exec_in_env(&program, env).map(|target| {
+                pipeline::ViewSinkCapability::Membership {
+                    op,
+                    target: pipeline::ViewMembershipTarget::Literal(target),
+                }
+            }))
+        }
+        sink => Some(Ok(sink)),
+    }
 }
 
 /// Feeds one view row into the sink accumulator according to `sink`'s capability.
@@ -177,6 +216,9 @@ where
             })
         }
         pipeline::ViewSinkCapability::Membership { op, target } => {
+            let pipeline::ViewMembershipTarget::Literal(target) = target else {
+                return None;
+            };
             let matched = view_membership_matches(item, target);
             let sink_done = sink_acc.observe_membership_match(*op, matched);
             Some(if sink_done {
@@ -705,7 +747,7 @@ where
         .copied()
         .unwrap_or(pipeline::StageStrategy::Default);
     if matches!(strategy, pipeline::StageStrategy::SortUntilOutput(_)) {
-        return run_sort_prefix_then_view_suffix(source, body, &plan);
+        return run_sort_prefix_then_view_suffix(source, body, &plan, base_env);
     }
     let collect_suffix = terminal_collect_plan_from(body, plan.sort_stage + 1);
     if collect_suffix.is_none()
@@ -780,11 +822,17 @@ fn run_sort_prefix_then_view_suffix<'a, V>(
     source: V,
     body: &pipeline::PipelineBody,
     plan: &SortBarrierPlan,
+    base_env: &Env,
 ) -> Option<Result<Val, EvalError>>
 where
     V: ValueView<'a>,
 {
     let suffix = view_suffix_capabilities(body, plan.sort_stage + 1)?;
+    let sink = match resolve_view_sink(suffix.sink, Some(base_env)) {
+        Some(Ok(sink)) => sink,
+        Some(Err(err)) => return Some(Err(err)),
+        None => return None,
+    };
     let source_demand =
         pipeline::Pipeline::segment_source_demand(&body.stages[plan.sort_stage + 1..], &body.sink)
             .chain
@@ -815,7 +863,7 @@ where
         &suffix.stages,
         &body.stage_kernels,
         source_demand,
-        |item| observe_view_sink(item, &suffix.sink, &mut sink_acc, &body.sink_kernels),
+        |item| observe_view_sink(item, &sink, &mut sink_acc, &body.sink_kernels),
     )?;
 
     Some(sink_acc.finish_result(false))
@@ -1062,6 +1110,9 @@ mod tests {
     use std::rc::Rc;
     use std::sync::Arc;
 
+    use indexmap::IndexMap;
+
+    use crate::compile::compiler::Compiler;
     use crate::data::context::Env;
     use crate::data::value::Val;
     use crate::data::view::{ValView, ValueView};
@@ -1272,6 +1323,69 @@ mod tests {
         };
 
         let indices = super::run_full(indices_source.clone(), &indices_body)
+            .unwrap()
+            .unwrap();
+        let indices_json: serde_json::Value = indices.into();
+        assert_eq!(indices_json, serde_json::json!([0, 2]));
+        assert_eq!(indices_source.materialize_reads(), 0);
+        assert_eq!(indices_source.scalar_reads(), 4);
+    }
+
+    #[test]
+    fn view_full_runner_evaluates_dynamic_membership_targets_once() {
+        let mut root = IndexMap::new();
+        root.insert(Arc::<str>::from("needle"), Val::Int(3));
+        let env = Env::new(Val::obj(root));
+        let target = Arc::new(Compiler::compile_str("$.needle").unwrap());
+
+        let includes_source = CountingView::root(&[1, 2, 3, 4]);
+        let includes_body = PipelineBody {
+            stages: Vec::new(),
+            stage_exprs: Vec::new(),
+            sink: Sink::Membership(MembershipSinkSpec {
+                op: MembershipSinkOp::Includes,
+                target: MembershipSinkTarget::Program(Arc::clone(&target)),
+                method: crate::builtins::BuiltinMethod::Includes,
+            }),
+            stage_kernels: Vec::new(),
+            sink_kernels: Vec::new(),
+        };
+
+        let includes = super::run_full_with_env(includes_source.clone(), &includes_body, Some(&env))
+            .unwrap()
+            .unwrap();
+        assert_eq!(includes, Val::Bool(true));
+        assert_eq!(includes_source.materialize_reads(), 0);
+        assert_eq!(includes_source.scalar_reads(), 3);
+
+        let index_source = CountingView::root(&[1, 2, 3, 4]);
+        let index_body = PipelineBody {
+            sink: Sink::Membership(MembershipSinkSpec {
+                op: MembershipSinkOp::Index,
+                target: MembershipSinkTarget::Program(Arc::clone(&target)),
+                method: crate::builtins::BuiltinMethod::Index,
+            }),
+            ..includes_body
+        };
+
+        let index = super::run_full_with_env(index_source.clone(), &index_body, Some(&env))
+            .unwrap()
+            .unwrap();
+        assert_eq!(index, Val::Int(2));
+        assert_eq!(index_source.materialize_reads(), 0);
+        assert_eq!(index_source.scalar_reads(), 3);
+
+        let indices_source = CountingView::root(&[3, 1, 3, 4]);
+        let indices_body = PipelineBody {
+            sink: Sink::Membership(MembershipSinkSpec {
+                op: MembershipSinkOp::IndicesOf,
+                target: MembershipSinkTarget::Program(target),
+                method: crate::builtins::BuiltinMethod::IndicesOf,
+            }),
+            ..index_body
+        };
+
+        let indices = super::run_full_with_env(indices_source.clone(), &indices_body, Some(&env))
             .unwrap()
             .unwrap();
         let indices_json: serde_json::Value = indices.into();

--- a/jetro-core/src/exec/view.rs
+++ b/jetro-core/src/exec/view.rs
@@ -99,7 +99,7 @@ where
         &capabilities.stages,
         &body.stage_kernels,
         source_demand,
-        |item| observe_view_sink(item, sink, &mut sink_acc, &body.sink_kernels),
+        |item| observe_view_sink(item, &sink, &mut sink_acc, &body.sink_kernels),
     )?;
 
     Some(sink_acc.finish_result(false))
@@ -110,7 +110,7 @@ where
 /// returns `None` when a kernel lookup fails (signals the view path is unusable).
 fn observe_view_sink<'a, V>(
     item: &V,
-    sink: pipeline::ViewSinkCapability,
+    sink: &pipeline::ViewSinkCapability,
     sink_acc: &mut pipeline::SinkAccumulator,
     sink_kernels: &[pipeline::BodyKernel],
 ) -> Option<ViewRowAction>
@@ -132,14 +132,14 @@ where
             project_kernel,
             ..
         } => {
-            if !view_sink_predicate_matches(item, predicate_kernel, sink_kernels)? {
+            if !view_sink_predicate_matches(item, *predicate_kernel, sink_kernels)? {
                 return Some(ViewRowAction::Skip);
             }
             let sink_done = sink_acc.observe_builtin_lazy(
-                accumulator,
+                *accumulator,
                 || item.materialize(),
                 || {
-                    let kernel = project_kernel?;
+                    let kernel = (*project_kernel)?;
                     let kernel = sink_kernels.get(kernel)?;
                     eval_owned_scalar_or_value_kernel(item, kernel)
                 },
@@ -152,7 +152,7 @@ where
             })
         }
         pipeline::ViewSinkCapability::Nth { index } => {
-            let sink_done = sink_acc.observe_nth_lazy(index, || item.materialize());
+            let sink_done = sink_acc.observe_nth_lazy(*index, || item.materialize());
             Some(if sink_done {
                 ViewRowAction::Stop
             } else {
@@ -163,11 +163,22 @@ where
             op,
             predicate_kernel,
         } => {
-            let kernel = sink_kernels.get(predicate_kernel)?;
+            let kernel = sink_kernels.get(*predicate_kernel)?;
             let matched = eval_filter_kernel(item, kernel)?;
             let sink_done = sink_acc
-                .observe_predicate_lazy(op, matched, || item.materialize())
+                .observe_predicate_lazy(*op, matched, || item.materialize())
                 .ok()?;
+            Some(if sink_done {
+                ViewRowAction::Stop
+            } else if matched {
+                ViewRowAction::Emit
+            } else {
+                ViewRowAction::Skip
+            })
+        }
+        pipeline::ViewSinkCapability::Membership { op, target } => {
+            let matched = view_membership_matches(item, target);
+            let sink_done = sink_acc.observe_membership_match(*op, matched);
             Some(if sink_done {
                 ViewRowAction::Stop
             } else if matched {
@@ -182,7 +193,7 @@ where
             source_reversed,
         } => {
             let sink_done =
-                sink_acc.observe_select_many_lazy(n, from_end, source_reversed, || {
+                sink_acc.observe_select_many_lazy(*n, *from_end, *source_reversed, || {
                     item.materialize()
                 });
             Some(if sink_done {
@@ -192,6 +203,17 @@ where
             })
         }
     }
+}
+
+fn view_membership_matches<'a, V>(item: &V, target: &Val) -> bool
+where
+    V: ValueView<'a>,
+{
+    let target_view = JsonView::from_val(target);
+    if !matches!(target_view, JsonView::ArrayLen(_) | JsonView::ObjectLen(_)) {
+        return crate::util::json_vals_eq(item.scalar(), target_view);
+    }
+    crate::util::vals_eq(&item.materialize(), target)
 }
 
 /// Evaluates the sink's optional predicate kernel against `item`. Returns
@@ -793,7 +815,7 @@ where
         &suffix.stages,
         &body.stage_kernels,
         source_demand,
-        |item| observe_view_sink(item, suffix.sink, &mut sink_acc, &body.sink_kernels),
+        |item| observe_view_sink(item, &suffix.sink, &mut sink_acc, &body.sink_kernels),
     )?;
 
     Some(sink_acc.finish_result(false))
@@ -1043,7 +1065,10 @@ mod tests {
     use crate::data::context::Env;
     use crate::data::value::Val;
     use crate::data::view::{ValView, ValueView};
-    use crate::exec::pipeline::{BodyKernel, PipelineBody, Sink, Stage, ViewStageCapability};
+    use crate::exec::pipeline::{
+        BodyKernel, MembershipSinkOp, MembershipSinkSpec, MembershipSinkTarget, PipelineBody,
+        Sink, Stage, ViewStageCapability,
+    };
     use crate::parse::ast::BinOp;
     use crate::util::JsonView;
 
@@ -1195,6 +1220,64 @@ mod tests {
         let last_json: serde_json::Value = last.into();
         assert_eq!(last_json, serde_json::json!([3, 4]));
         assert_eq!(last_source.materialize_reads(), 2);
+    }
+
+    #[test]
+    fn view_full_runner_handles_literal_membership_sinks_without_materializing_scalars() {
+        let includes_source = CountingView::root(&[1, 2, 3, 4]);
+        let includes_body = PipelineBody {
+            stages: Vec::new(),
+            stage_exprs: Vec::new(),
+            sink: Sink::Membership(MembershipSinkSpec {
+                op: MembershipSinkOp::Includes,
+                target: MembershipSinkTarget::Literal(Val::Int(3)),
+                method: crate::builtins::BuiltinMethod::Includes,
+            }),
+            stage_kernels: Vec::new(),
+            sink_kernels: Vec::new(),
+        };
+
+        let includes = super::run_full(includes_source.clone(), &includes_body)
+            .unwrap()
+            .unwrap();
+        assert_eq!(includes, Val::Bool(true));
+        assert_eq!(includes_source.materialize_reads(), 0);
+        assert_eq!(includes_source.scalar_reads(), 3);
+
+        let index_source = CountingView::root(&[1, 2, 3, 4]);
+        let index_body = PipelineBody {
+            sink: Sink::Membership(MembershipSinkSpec {
+                op: MembershipSinkOp::Index,
+                target: MembershipSinkTarget::Literal(Val::Int(4)),
+                method: crate::builtins::BuiltinMethod::Index,
+            }),
+            ..includes_body
+        };
+
+        let index = super::run_full(index_source.clone(), &index_body)
+            .unwrap()
+            .unwrap();
+        assert_eq!(index, Val::Int(3));
+        assert_eq!(index_source.materialize_reads(), 0);
+        assert_eq!(index_source.scalar_reads(), 4);
+
+        let indices_source = CountingView::root(&[1, 2, 1, 3]);
+        let indices_body = PipelineBody {
+            sink: Sink::Membership(MembershipSinkSpec {
+                op: MembershipSinkOp::IndicesOf,
+                target: MembershipSinkTarget::Literal(Val::Int(1)),
+                method: crate::builtins::BuiltinMethod::IndicesOf,
+            }),
+            ..index_body
+        };
+
+        let indices = super::run_full(indices_source.clone(), &indices_body)
+            .unwrap()
+            .unwrap();
+        let indices_json: serde_json::Value = indices.into();
+        assert_eq!(indices_json, serde_json::json!([0, 2]));
+        assert_eq!(indices_source.materialize_reads(), 0);
+        assert_eq!(indices_source.scalar_reads(), 4);
     }
 
     #[test]

--- a/jetro-core/src/exec/view.rs
+++ b/jetro-core/src/exec/view.rs
@@ -83,6 +83,14 @@ where
         (PullDemand::NthInput(_), pipeline::ViewSinkCapability::Nth { .. }) => {
             pipeline::ViewSinkCapability::Nth { index: 0 }
         }
+        (
+            PullDemand::LastInput(_),
+            pipeline::ViewSinkCapability::SelectMany { n, from_end, .. },
+        ) => pipeline::ViewSinkCapability::SelectMany {
+            n,
+            from_end,
+            source_reversed: true,
+        },
         (_, sink) => sink,
     };
 
@@ -166,6 +174,21 @@ where
                 ViewRowAction::Emit
             } else {
                 ViewRowAction::Skip
+            })
+        }
+        pipeline::ViewSinkCapability::SelectMany {
+            n,
+            from_end,
+            source_reversed,
+        } => {
+            let sink_done =
+                sink_acc.observe_select_many_lazy(n, from_end, source_reversed, || {
+                    item.materialize()
+                });
+            Some(if sink_done {
+                ViewRowAction::Stop
+            } else {
+                ViewRowAction::Emit
             })
         }
     }
@@ -1054,6 +1077,9 @@ mod tests {
     impl<'a> ValueView<'a> for CountingView {
         fn scalar(&self) -> JsonView<'_> {
             self.scalar_reads.set(self.scalar_reads.get() + 1);
+            if self.idx.is_none() {
+                return JsonView::ArrayLen(self.rows.len());
+            }
             self.idx
                 .and_then(|idx| self.rows.get(idx).copied())
                 .map(JsonView::Int)
@@ -1131,6 +1157,44 @@ mod tests {
         let out_json: serde_json::Value = out.into();
         assert_eq!(out_json, serde_json::json!([1, 2]));
         assert_eq!(source.scalar_reads(), 2);
+    }
+
+    #[test]
+    fn view_full_runner_handles_select_many_first_and_last() {
+        let first_source = CountingView::root(&[1, 2, 3, 4]);
+        let first_body = PipelineBody {
+            stages: Vec::new(),
+            stage_exprs: Vec::new(),
+            sink: Sink::SelectMany {
+                n: 2,
+                from_end: false,
+            },
+            stage_kernels: Vec::new(),
+            sink_kernels: Vec::new(),
+        };
+
+        let first = super::run_full(first_source.clone(), &first_body)
+            .unwrap()
+            .unwrap();
+        let first_json: serde_json::Value = first.into();
+        assert_eq!(first_json, serde_json::json!([1, 2]));
+        assert_eq!(first_source.materialize_reads(), 2);
+
+        let last_source = CountingView::root(&[1, 2, 3, 4]);
+        let last_body = PipelineBody {
+            sink: Sink::SelectMany {
+                n: 2,
+                from_end: true,
+            },
+            ..first_body
+        };
+
+        let last = super::run_full(last_source.clone(), &last_body)
+            .unwrap()
+            .unwrap();
+        let last_json: serde_json::Value = last.into();
+        assert_eq!(last_json, serde_json::json!([3, 4]));
+        assert_eq!(last_source.materialize_reads(), 2);
     }
 
     #[test]

--- a/jetro-core/src/exec/view.rs
+++ b/jetro-core/src/exec/view.rs
@@ -229,6 +229,14 @@ where
                 ViewRowAction::Skip
             })
         }
+        pipeline::ViewSinkCapability::ArgExtreme {
+            want_max,
+            key_kernel,
+        } => {
+            let key = view_arg_extreme_key(item, sink_kernels.get(*key_kernel)?)?;
+            sink_acc.observe_arg_extreme_lazy(*want_max, key, || item.materialize());
+            Some(ViewRowAction::Emit)
+        }
         pipeline::ViewSinkCapability::SelectMany {
             n,
             from_end,
@@ -256,6 +264,18 @@ where
         return crate::util::json_vals_eq(item.scalar(), target_view);
     }
     crate::util::vals_eq(&item.materialize(), target)
+}
+
+fn view_arg_extreme_key<'a, V>(item: &V, kernel: &pipeline::BodyKernel) -> Option<Val>
+where
+    V: ValueView<'a>,
+{
+    match pipeline::eval_view_kernel(kernel, item)? {
+        pipeline::ViewKernelValue::View(view) => {
+            scalar_view_to_owned_val(view.scalar()).or_else(|| Some(view.materialize()))
+        }
+        pipeline::ViewKernelValue::Owned(value) => Some(value),
+    }
 }
 
 /// Evaluates the sink's optional predicate kernel against `item`. Returns
@@ -1117,8 +1137,8 @@ mod tests {
     use crate::data::value::Val;
     use crate::data::view::{ValView, ValueView};
     use crate::exec::pipeline::{
-        BodyKernel, MembershipSinkOp, MembershipSinkSpec, MembershipSinkTarget, PipelineBody,
-        Sink, Stage, ViewStageCapability,
+        ArgExtremeSinkSpec, BodyKernel, MembershipSinkOp, MembershipSinkSpec,
+        MembershipSinkTarget, PipelineBody, Sink, Stage, ViewStageCapability,
     };
     use crate::parse::ast::BinOp;
     use crate::util::JsonView;
@@ -1392,6 +1412,44 @@ mod tests {
         assert_eq!(indices_json, serde_json::json!([0, 2]));
         assert_eq!(indices_source.materialize_reads(), 0);
         assert_eq!(indices_source.scalar_reads(), 4);
+    }
+
+    #[test]
+    fn view_full_runner_handles_arg_extreme_sinks_lazily() {
+        let max_source = CountingView::root(&[2, 1, 4, 3]);
+        let max_body = PipelineBody {
+            stages: Vec::new(),
+            stage_exprs: Vec::new(),
+            sink: Sink::ArgExtreme(ArgExtremeSinkSpec {
+                want_max: true,
+                key: Arc::new(crate::vm::Program::new(Vec::new(), "")),
+            }),
+            stage_kernels: Vec::new(),
+            sink_kernels: vec![BodyKernel::Current],
+        };
+
+        let max = super::run_full(max_source.clone(), &max_body)
+            .unwrap()
+            .unwrap();
+        assert_eq!(max, Val::Int(4));
+        assert_eq!(max_source.scalar_reads(), 4);
+        assert_eq!(max_source.materialize_reads(), 2);
+
+        let min_source = CountingView::root(&[3, 4, 1, 2]);
+        let min_body = PipelineBody {
+            sink: Sink::ArgExtreme(ArgExtremeSinkSpec {
+                want_max: false,
+                key: Arc::new(crate::vm::Program::new(Vec::new(), "")),
+            }),
+            ..max_body
+        };
+
+        let min = super::run_full(min_source.clone(), &min_body)
+            .unwrap()
+            .unwrap();
+        assert_eq!(min, Val::Int(1));
+        assert_eq!(min_source.scalar_reads(), 4);
+        assert_eq!(min_source.materialize_reads(), 2);
     }
 
     #[test]

--- a/jetro-core/src/exec/view.rs
+++ b/jetro-core/src/exec/view.rs
@@ -1191,6 +1191,10 @@ mod tests {
             }
         }
 
+        fn has_key(&self, _key: &str) -> Option<bool> {
+            None
+        }
+
         fn index(&self, idx: i64) -> Self {
             let idx = if idx >= 0 { Some(idx as usize) } else { None };
             Self {

--- a/jetro-core/src/exec/view.rs
+++ b/jetro-core/src/exec/view.rs
@@ -51,6 +51,9 @@ where
     if let Some(result) = run_terminal_collect(source.clone(), body) {
         return Some(result);
     }
+    if let Some(result) = run_terminal_select_projection(source.clone(), body) {
+        return Some(result);
+    }
     if let Some(result) = run_full_with_env(source.clone(), body, Some(base_env)) {
         return Some(result);
     }
@@ -369,6 +372,45 @@ where
     )?;
 
     Some(Ok(collector.finish()))
+}
+
+/// Optimised path for `map(...).first()` / `map(...).last()` style suffixes
+/// where the trailing projection can run only on the selected view row.
+fn run_terminal_select_projection<'a, V>(
+    source: V,
+    body: &pipeline::PipelineBody,
+) -> Option<Result<Val, EvalError>>
+where
+    V: ValueView<'a>,
+{
+    let (prefix_len, project_kernel) = terminal_projection_run(body, 0)?;
+    let sink_spec = body.sink.builtin_sink_spec()?;
+    let crate::builtins::BuiltinSinkAccumulator::SelectOne(position) = sink_spec.accumulator else {
+        return None;
+    };
+    let prefix = terminal_collect_prefix_from(&body.stages[..prefix_len], body, 0)?;
+    let source_demand = pipeline::Pipeline::segment_source_demand(&body.stages[..prefix_len], &body.sink)
+        .chain
+        .pull;
+    let mut selected = Val::Null;
+    let mut seen = false;
+
+    drive_view_frontier(
+        source,
+        &prefix,
+        &body.stage_kernels,
+        source_demand,
+        |item| {
+            selected = eval_owned_scalar_or_value_kernel(item, &project_kernel)?;
+            seen = true;
+            Some(match position {
+                crate::builtins::BuiltinSelectionPosition::First => ViewRowAction::Stop,
+                crate::builtins::BuiltinSelectionPosition::Last => ViewRowAction::Emit,
+            })
+        },
+    )?;
+
+    Some(Ok(if seen { selected } else { Val::Null }))
 }
 
 /// Action returned by a sink observer after processing one view row.
@@ -1192,6 +1234,26 @@ mod tests {
         }
 
         fn has_key(&self, _key: &str) -> Option<bool> {
+            None
+        }
+
+        fn object_keys(&self) -> Option<Val> {
+            None
+        }
+
+        fn object_values(&self) -> Option<Val> {
+            None
+        }
+
+        fn object_entries(&self) -> Option<Val> {
+            None
+        }
+
+        fn pick_keys(&self, _keys: &[Arc<str>]) -> Option<Val> {
+            None
+        }
+
+        fn omit_keys(&self, _keys: &[Arc<str>]) -> Option<Val> {
             None
         }
 

--- a/jetro-core/src/parse/chain_ir.rs
+++ b/jetro-core/src/parse/chain_ir.rs
@@ -342,6 +342,33 @@ mod tests {
     }
 
     #[test]
+    fn reverse_swaps_first_and_last_input_demand() {
+        let ops = [op(BuiltinMethod::Reverse), op(BuiltinMethod::First)];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::LastInput(1));
+        assert_eq!(demand.value, ValueNeed::Whole);
+
+        let ops = [op(BuiltinMethod::Reverse), op(BuiltinMethod::Last)];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::FirstInput(1));
+        assert_eq!(demand.value, ValueNeed::Whole);
+
+        let ops = [op(BuiltinMethod::Reverse), op_usize(BuiltinMethod::Take, 2)];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::LastInput(2));
+        assert_eq!(demand.value, ValueNeed::Whole);
+    }
+
+    #[test]
+    fn drop_while_is_a_prefix_barrier() {
+        let ops = [op(BuiltinMethod::DropWhile), op(BuiltinMethod::First)];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::All);
+        assert_eq!(demand.value, ValueNeed::Whole);
+        assert!(demand.order);
+    }
+
+    #[test]
     fn map_last_requests_last_input() {
         let ops = [op(BuiltinMethod::Map), op(BuiltinMethod::Last)];
         let demand = source_demand(&ops, Demand::RESULT);

--- a/jetro-core/src/parse/chain_ir.rs
+++ b/jetro-core/src/parse/chain_ir.rs
@@ -456,6 +456,29 @@ mod tests {
     }
 
     #[test]
+    fn chunk_and_window_map_bounded_output_to_input_prefix() {
+        let ops = [
+            op_usize(BuiltinMethod::Chunk, 4),
+            op_usize(BuiltinMethod::Take, 3),
+        ];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::FirstInput(12));
+        assert_eq!(demand.value, ValueNeed::Whole);
+
+        let ops = [
+            op_usize(BuiltinMethod::Window, 4),
+            op_usize(BuiltinMethod::Take, 3),
+        ];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::FirstInput(6));
+        assert_eq!(demand.value, ValueNeed::Whole);
+
+        let ops = [op_usize(BuiltinMethod::Window, 4), op(BuiltinMethod::Last)];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::All);
+    }
+
+    #[test]
     fn count_does_not_need_whole_values() {
         let ops = [op(BuiltinMethod::Map), op(BuiltinMethod::Count)];
         let demand = source_demand(&ops, Demand::RESULT);

--- a/jetro-core/src/parse/chain_ir.rs
+++ b/jetro-core/src/parse/chain_ir.rs
@@ -385,6 +385,14 @@ mod tests {
     }
 
     #[test]
+    fn scalar_slice_preserves_positional_demand() {
+        let ops = [op(BuiltinMethod::Slice), op(BuiltinMethod::Last)];
+        let demand = source_demand(&ops, Demand::RESULT);
+        assert_eq!(demand.pull, PullDemand::LastInput(1));
+        assert_eq!(demand.value, ValueNeed::Whole);
+    }
+
+    #[test]
     fn filter_nth_falls_back_to_all_input() {
         let ops = [op(BuiltinMethod::Filter), op_usize(BuiltinMethod::Nth, 2)];
         let demand = source_demand(&ops, Demand::RESULT);

--- a/jetro-core/src/parse/parser.rs
+++ b/jetro-core/src/parse/parser.rs
@@ -59,6 +59,10 @@ pub fn parse(input: &str) -> Result<Expr, ParseError> {
     if strict_match_lint_enabled() {
         validate_match_exhaustiveness(&expr)?;
     }
+    // First-class lambda macro expansion: `let f = (x => …) in …` inlines
+    // `f` at every method-arg position so downstream compile sees the
+    // lambda directly. Pure AST rewrite; no runtime closure value.
+    let expr = crate::compile::lambda_lower::inline_let_bound_lambdas(expr);
     Ok(expr)
 }
 

--- a/jetro-core/src/plan/analysis.rs
+++ b/jetro-core/src/plan/analysis.rs
@@ -390,6 +390,7 @@ fn apply_op(op: &Opcode, stack: &mut Vec<AbstractVal>) {
         Opcode::Match(_) => stack.push(AbstractVal::UNKNOWN),
         Opcode::DeepMatchAll(_) => stack.push(AbstractVal::UNKNOWN),
         Opcode::DeepMatchFirst(_) => stack.push(AbstractVal::UNKNOWN),
+        Opcode::BindLamCurrent { .. } => stack.push(AbstractVal::UNKNOWN),
     }
 }
 
@@ -1089,6 +1090,10 @@ fn rewrite_op(op: &Opcode, cache: &mut HashMap<u64, Arc<Program>>) -> Opcode {
             };
             Opcode::DictComp(Arc::new(new_spec))
         }
+        Opcode::BindLamCurrent { name, body } => Opcode::BindLamCurrent {
+            name: name.clone(),
+            body: dedup_rec(body, cache),
+        },
         _ => op.clone(),
     }
 }
@@ -1217,6 +1222,7 @@ pub fn opcode_cost(op: &Opcode) -> u32 {
                     })
                     .sum::<u32>()
         }
+        Opcode::BindLamCurrent { body, .. } => 2 + program_cost(body),
     }
 }
 

--- a/jetro-core/src/plan/analysis.rs
+++ b/jetro-core/src/plan/analysis.rs
@@ -404,8 +404,8 @@ pub fn method_result_type(m: BuiltinMethod) -> AbstractVal {
         Len | Count | Sum | ApproxCountDistinct | IndexOf | LastIndexOf | ByteLen | ParseInt
         | Ceil | Floor | Round => AbstractVal::scalar(VType::Int),
         // Boolean-returning methods.
-        Any | All | Has | Missing | Includes | StartsWith | EndsWith | IsBlank | IsNumeric
-        | IsAlpha | IsAscii | ParseBool | ReMatch | ContainsAny | ContainsAll => {
+        Any | All | Has | HasKey | Missing | Includes | StartsWith | EndsWith | IsBlank
+        | IsNumeric | IsAlpha | IsAscii | ParseBool | ReMatch | ContainsAny | ContainsAll => {
             AbstractVal::scalar(VType::Bool)
         }
         // String-returning methods.

--- a/jetro-core/src/plan/logical.rs
+++ b/jetro-core/src/plan/logical.rs
@@ -78,7 +78,7 @@ fn apply_method(input: LogicalPlan, name: &str, args: &[Arg]) -> Option<LogicalP
     }
 
     let plan = match method {
-        BuiltinMethod::Filter | BuiltinMethod::Find | BuiltinMethod::FindAll => {
+        BuiltinMethod::Filter | BuiltinMethod::FindAll => {
             let pred = single_expr_arg(args)?;
             LogicalPlan::Filter {
                 input: Box::new(input),

--- a/jetro-core/src/plan/logical.rs
+++ b/jetro-core/src/plan/logical.rs
@@ -174,17 +174,28 @@ fn apply_method(input: LogicalPlan, name: &str, args: &[Arg]) -> Option<LogicalP
                         Arg::Pos(e) => e,
                         _ => return None,
                     };
+                    // 2-arg comparator lambdas (`.sort((a, b) => …)`) cannot
+                    // be represented as a single-key SortSpec. Bail out so
+                    // the router falls back to the VM path, where
+                    // `exec_lambda_method` dispatches to
+                    // `sort_comparator_apply`.
+                    if matches!(arg_expr, Expr::Lambda { params, .. } if params.len() >= 2) {
+                        return None;
+                    }
                     let (key_expr, descending) = match arg_expr {
                         Expr::UnaryNeg(inner) => (inner.as_ref().clone(), true),
                         other => (other.clone(), false),
                     };
-                    // Rewrite bare Ident to @.field (body context).
-                    let rooted: Expr = match &key_expr {
-                        Expr::Ident(name) => Expr::Chain(
-                            Box::new(Expr::Current),
-                            vec![Step::Field(name.clone())],
-                        ),
-                        other => other.clone(),
+                    // Rewrite bare Ident to @.field (body context). Single-
+                    // param `Lambda` is unwrapped to its substituted body so
+                    // `Compiler::compile` does not lower it to `PushNull`.
+                    let unwrapped =
+                        crate::compile::lambda_lower::unwrap_single_lambda(&key_expr);
+                    let rooted: Expr = match unwrapped {
+                        Expr::Ident(name) => {
+                            Expr::Chain(Box::new(Expr::Current), vec![Step::Field(name)])
+                        }
+                        other => other,
                     };
                     let key_prog = Arc::new(crate::compile::compiler::Compiler::compile(&rooted, ""));
                     LogicalPlan::Sort {

--- a/jetro-core/src/plan/optimize.rs
+++ b/jetro-core/src/plan/optimize.rs
@@ -173,8 +173,16 @@ pub(crate) mod rules {
     impl Rule for FilterBeforeMap {
         fn apply(&self, plan: LogicalPlan) -> Result<LogicalPlan, LogicalPlan> {
             // Filter { input: Map { input: x, projection: f }, predicate: p }
-            // →  Map { input: Filter { input: x, predicate: p }, projection: f }
-            // only when p does not reference the map output
+            // →  Map { input: Filter { input: x, predicate: p' }, projection: f }
+            // where `p' = substitute_current(p, f)` — every `@` in `p` is
+            // replaced by the projection expression `f`, so the swapped
+            // filter sees source rows but tests the same mapped value the
+            // original placement would have observed.
+            //
+            // Rejected when `p` shape would corrupt under substitution
+            // (method calls / lambdas / let / comp / pipeline / match)
+            // or when `f` itself contains a nested `Lambda` body that could
+            // capture an outer `@` (see `is_safe_projection_for_swap`).
             match plan {
                 LogicalPlan::Filter { input, predicate }
                     if matches!(*input, LogicalPlan::Map { .. }) =>
@@ -184,11 +192,24 @@ pub(crate) mod rules {
                         projection,
                     } = *input
                     {
-                        if is_independent_predicate(&predicate) {
+                        // Unwrap a single-param lambda projection to its
+                        // substituted body so the predicate substitution
+                        // sees `Current * 2` (a usable expression) rather
+                        // than `Lambda { params, body }` (which would
+                        // compile to `PushNull` and corrupt the swap).
+                        let projection_for_subst =
+                            crate::compile::lambda_lower::unwrap_single_lambda(&projection);
+                        if is_independent_predicate(&predicate)
+                            && is_safe_projection_for_swap(&projection_for_subst)
+                        {
+                            let new_predicate = substitute_current_with_expr(
+                                predicate,
+                                &projection_for_subst,
+                            );
                             return Ok(LogicalPlan::Map {
                                 input: Box::new(LogicalPlan::Filter {
                                     input: map_input,
-                                    predicate,
+                                    predicate: new_predicate,
                                 }),
                                 projection,
                             });
@@ -209,18 +230,17 @@ pub(crate) mod rules {
     }
 
     /// Returns `true` when `expr` can be safely moved before a `Map` stage —
-    /// it accesses only original source fields, not computed map outputs.
-    ///
-    /// Conservative: only allow literals, root/current references, simple field
-    /// chains, and binary/unary combinations of the above.
+    /// it is a side-effect-free combination of literals, `@`/`$` references,
+    /// simple field/index chains, and binary/unary operations. Method calls,
+    /// lambdas, comprehensions, etc. are conservatively rejected.
     fn is_independent_predicate(expr: &crate::parse::ast::Expr) -> bool {
         use crate::parse::ast::Expr;
         match expr {
             // Literals — always safe
             Expr::Null | Expr::Bool(_) | Expr::Int(_) | Expr::Float(_) | Expr::Str(_) => true,
-            // Document root and current-item reference — safe to move
+            // Document root and current-item reference — safe
             Expr::Root | Expr::Current => true,
-            // Plain identifier that resolves against the current row — safe
+            // Plain identifier that resolves against the current row
             Expr::Ident(_) => true,
             // Simple field navigation chains (e.g. `@.price`)
             Expr::Chain(base, steps) => {
@@ -240,6 +260,100 @@ pub(crate) mod rules {
             }
             // Anything with method calls, lambdas, let-bindings, comprehensions — conservatively false
             _ => false,
+        }
+    }
+
+    /// Returns `true` when `projection` is shaped so that substituting it
+    /// into a predicate does not corrupt the predicate's `@` semantics.
+    ///
+    /// Reject any projection containing a nested `Lambda` (which would
+    /// rebind `@` and cause the substituted predicate to read the wrong
+    /// `@`), or any projection that materially depends on `$` differently
+    /// from the predicate. Lambda-body method-arg substitution makes
+    /// `Lambda` rare in projection position, but guard explicitly.
+    fn is_safe_projection_for_swap(projection: &crate::parse::ast::Expr) -> bool {
+        use crate::parse::ast::Expr;
+        match projection {
+            Expr::Null
+            | Expr::Bool(_)
+            | Expr::Int(_)
+            | Expr::Float(_)
+            | Expr::Str(_)
+            | Expr::Root
+            | Expr::Current
+            | Expr::Ident(_) => true,
+            Expr::Chain(base, steps) => {
+                use crate::parse::ast::Step;
+                is_safe_projection_for_swap(base)
+                    && steps
+                        .iter()
+                        .all(|s| matches!(s, Step::Field(_) | Step::Index(_)))
+            }
+            Expr::BinOp(lhs, _, rhs) => {
+                is_safe_projection_for_swap(lhs) && is_safe_projection_for_swap(rhs)
+            }
+            Expr::Not(inner) | Expr::UnaryNeg(inner) => is_safe_projection_for_swap(inner),
+            Expr::Coalesce(lhs, rhs) => {
+                is_safe_projection_for_swap(lhs) && is_safe_projection_for_swap(rhs)
+            }
+            _ => false,
+        }
+    }
+
+    /// Substitutes every `Expr::Current` inside `expr` with `replacement`,
+    /// respecting `Lambda`/`Let`/comprehension/match-arm-bind shadows so
+    /// the replacement is not pushed into a re-bound `@` scope.
+    fn substitute_current_with_expr(
+        expr: crate::parse::ast::Expr,
+        replacement: &crate::parse::ast::Expr,
+    ) -> crate::parse::ast::Expr {
+        use crate::parse::ast::Expr;
+        match expr {
+            Expr::Current => replacement.clone(),
+            Expr::Null
+            | Expr::Bool(_)
+            | Expr::Int(_)
+            | Expr::Float(_)
+            | Expr::Str(_)
+            | Expr::Root
+            | Expr::Ident(_)
+            | Expr::DeleteMark => expr,
+            Expr::Chain(base, steps) => {
+                use crate::parse::ast::Step;
+                let new_base = substitute_current_with_expr(*base, replacement);
+                let new_steps = steps
+                    .into_iter()
+                    .map(|s| match s {
+                        Step::DynIndex(e) => Step::DynIndex(Box::new(
+                            substitute_current_with_expr(*e, replacement),
+                        )),
+                        Step::InlineFilter(e) => Step::InlineFilter(Box::new(
+                            substitute_current_with_expr(*e, replacement),
+                        )),
+                        other => other,
+                    })
+                    .collect();
+                Expr::Chain(Box::new(new_base), new_steps)
+            }
+            Expr::BinOp(lhs, op, rhs) => Expr::BinOp(
+                Box::new(substitute_current_with_expr(*lhs, replacement)),
+                op,
+                Box::new(substitute_current_with_expr(*rhs, replacement)),
+            ),
+            Expr::UnaryNeg(inner) => Expr::UnaryNeg(Box::new(substitute_current_with_expr(
+                *inner, replacement,
+            ))),
+            Expr::Not(inner) => {
+                Expr::Not(Box::new(substitute_current_with_expr(*inner, replacement)))
+            }
+            Expr::Coalesce(lhs, rhs) => Expr::Coalesce(
+                Box::new(substitute_current_with_expr(*lhs, replacement)),
+                Box::new(substitute_current_with_expr(*rhs, replacement)),
+            ),
+            // Anything else (shouldn't appear under `is_independent_predicate`)
+            // passes through unchanged — substitution under method calls,
+            // lambdas, comprehensions etc. is unsafe in general.
+            other => other,
         }
     }
 }

--- a/jetro-core/src/plan/physical.rs
+++ b/jetro-core/src/plan/physical.rs
@@ -396,7 +396,8 @@ fn mask_active_local_stage_kernels(
                 .iter()
                 .any(|local| analysis::expr_uses_ident(expr, local.as_ref()))
             {
-                *program = Arc::new(Compiler::compile(expr, "<local-aware-pipeline-sink>"));
+                let lowered = crate::compile::lambda_lower::unwrap_single_lambda(expr);
+                *program = Arc::new(Compiler::compile(&lowered, "<local-aware-pipeline-sink>"));
                 if let Some(kernel) = body.sink_kernels.get_mut(kernel_idx) {
                     *kernel = crate::exec::pipeline::BodyKernel::Generic;
                 }
@@ -409,7 +410,8 @@ fn mask_active_local_stage_kernels(
                 .iter()
                 .any(|local| analysis::expr_uses_ident(expr, local.as_ref()))
             {
-                *program = Arc::new(Compiler::compile(expr, "<local-aware-pipeline-sink>"));
+                let lowered = crate::compile::lambda_lower::unwrap_single_lambda(expr);
+                *program = Arc::new(Compiler::compile(&lowered, "<local-aware-pipeline-sink>"));
                 if let Some(kernel) = body.sink_kernels.get_mut(kernel_idx) {
                     *kernel = crate::exec::pipeline::BodyKernel::Generic;
                 }
@@ -427,7 +429,8 @@ fn mask_active_local_stage_kernels(
 /// Recompiles the stored kernel program of a pipeline stage so it will be evaluated inside
 /// a full `Env` (picking up let-bound variables) rather than against a bare row.
 fn recompile_stage_body_for_lexical_env(stage: &mut crate::exec::pipeline::Stage, expr: &Expr) {
-    let program = Arc::new(Compiler::compile(expr, "<local-aware-pipeline-stage>"));
+    let lowered = crate::compile::lambda_lower::unwrap_single_lambda(expr);
+    let program = Arc::new(Compiler::compile(&lowered, "<local-aware-pipeline-stage>"));
     match stage {
         crate::exec::pipeline::Stage::Filter(body, _)
         | crate::exec::pipeline::Stage::Map(body, _)

--- a/jetro-core/src/tests/deep_search.rs
+++ b/jetro-core/src/tests/deep_search.rs
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn find_shallow_multi_pred_and() {
-        
+
         use crate::Jetro;
         let doc = json!({"xs":[
             {"t":"a","v":1},
@@ -207,8 +207,9 @@ mod tests {
             {"t":"b","v":1}
         ]});
         let j = Jetro::new(doc);
+        // `.find` returns the first match (conventional first-match).
         let r = j.collect(r#"$.xs.find(@.t == "a", @.v == 1)"#).unwrap();
-        assert_eq!(r, json!([{"t":"a","v":1}]));
+        assert_eq!(r, json!({"t":"a","v":1}));
     }
 
     #[test]
@@ -217,7 +218,7 @@ mod tests {
         let doc = json!({"xs":[{"v":1},{"v":2}]});
         let j = Jetro::new(doc);
         let r = j.collect(r#"$.xs.find(@.v == 2)"#).unwrap();
-        assert_eq!(r, json!([{"v":2}]));
+        assert_eq!(r, json!({"v":2}));
     }
 
     #[test]

--- a/jetro-core/src/tests/dyn_index_lambda.rs
+++ b/jetro-core/src/tests/dyn_index_lambda.rs
@@ -1,0 +1,28 @@
+//! Regression: dynamic key indexing inside lambdas. The VM `DynIndex`
+//! opcode previously matched only `Val::Str` for string keys and fell
+//! through to `Val::Null` for `Val::StrSlice` (the borrowed-string variant
+//! produced by simd-json tape reads). Inside a `.map(...)` body, `@.author`
+//! reads a `StrSlice`, so `$.posts.map($.realnames[@.author])` returned all
+//! nulls when run via `Jetro::from_bytes` (tape-backed) but worked through
+//! the legacy `vm_query` path (which used owned `Val::Str`).
+
+#[test]
+fn dyn_index_inside_map_via_jetro_bytes() {
+    let bytes = br#"{"posts":[{"title":"First","author":"anon"},{"title":"Other","author":"person1"}],"realnames":{"anon":"Anonymous Coward","person1":"Person McPherson"}}"#.to_vec();
+    let j = crate::Jetro::from_bytes(bytes).unwrap();
+    let v: serde_json::Value = j.collect("$.posts.map($.realnames[@.author])").unwrap();
+    assert_eq!(
+        v,
+        serde_json::json!(["Anonymous Coward", "Person McPherson"]),
+    );
+}
+
+#[test]
+fn dyn_index_inside_filter_via_jetro_bytes() {
+    let bytes = br#"{"users":[{"role":"admin","id":"u1"},{"role":"user","id":"u2"}],"perms":{"u1":"all","u2":"read"}}"#.to_vec();
+    let j = crate::Jetro::from_bytes(bytes).unwrap();
+    let v: serde_json::Value = j
+        .collect("$.users.filter($.perms[@.id] == \"all\").map(@.id)")
+        .unwrap();
+    assert_eq!(v, serde_json::json!(["u1"]));
+}

--- a/jetro-core/src/tests/has_probe.rs
+++ b/jetro-core/src/tests/has_probe.rs
@@ -1,0 +1,18 @@
+#[test]
+fn test_has_arr_lit() {
+    use jetro_core::Jetro;
+    let doc = r#"{"obj":{"a":1,"b":2,"c":3,"d":4}}"#;
+    let j = Jetro::from_bytes(doc.as_bytes()).unwrap();
+    let queries = [
+        r#"$.obj.filter_keys(["a","c"] has @)"#,
+        r#"$.obj.filter_keys(lambda k: ["a","c"] has k)"#,
+        r#"$.obj.filter_keys(@ has "a")"#,
+    ];
+    for q in &queries {
+        let r: Result<serde_json::Value, _> = j.collect(q);
+        match r {
+            Ok(v) => eprintln!("OK  {} => {}", q, v),
+            Err(e) => eprintln!("ERR {} => {:?}", q, e),
+        }
+    }
+}

--- a/jetro-core/src/tests/lambda_forms.rs
+++ b/jetro-core/src/tests/lambda_forms.rs
@@ -1,0 +1,1218 @@
+//! Lambda-form coverage suite.
+//!
+//! Every test runs an expression through both the in-crate VM path
+//! (`vm_query`) and the `Jetro::from_bytes` engine path. Both must agree.
+//! For arrow-form tests, the same body is also evaluated under the
+//! `lambda r: body` form and the equivalent `@`-form; all three results
+//! must match.
+
+use super::common::vm_query;
+use serde_json::{json, Value};
+
+fn run_engine(expr: &str, doc: &Value) -> Value {
+    let bytes = serde_json::to_vec(doc).unwrap();
+    let j = crate::Jetro::from_bytes(bytes).unwrap();
+    j.collect(expr).unwrap()
+}
+
+#[track_caller]
+fn assert_both(expr: &str, doc: &Value, expected: &Value) {
+    let vm = vm_query(expr, doc).unwrap();
+    let eng = run_engine(expr, doc);
+    assert_eq!(&vm, expected, "vm path: `{}`", expr);
+    assert_eq!(&eng, expected, "engine path: `{}`", expr);
+    assert_eq!(vm, eng, "vm vs engine disagree for `{}`", expr);
+}
+
+#[track_caller]
+fn assert_three_forms_equiv(arrow: &str, lam: &str, at_form: &str, doc: &Value) {
+    let a_vm = vm_query(arrow, doc).unwrap();
+    let l_vm = vm_query(lam, doc).unwrap();
+    let r_vm = vm_query(at_form, doc).unwrap();
+    let a_eng = run_engine(arrow, doc);
+    let l_eng = run_engine(lam, doc);
+    let r_eng = run_engine(at_form, doc);
+    assert_eq!(a_vm, l_vm, "arrow vs lambda differ (vm): {} | {}", arrow, lam);
+    assert_eq!(a_vm, r_vm, "arrow vs @-form differ (vm): {} | {}", arrow, at_form);
+    assert_eq!(a_eng, l_eng, "arrow vs lambda differ (engine): {} | {}", arrow, lam);
+    assert_eq!(a_eng, r_eng, "arrow vs @-form differ (engine): {} | {}", arrow, at_form);
+    assert_eq!(a_vm, a_eng, "vm vs engine differ for arrow `{}`", arrow);
+}
+
+fn xs_doc() -> Value {
+    json!({"xs": [
+        {"id": 1, "score": 10, "tags": ["a","b"], "user": {"name": "alice"}},
+        {"id": 2, "score": 20, "tags": ["b","c"], "user": {"name": "bob"}},
+        {"id": 3, "score": 30, "tags": ["c"],     "user": {"name": "carol"}}
+    ]})
+}
+
+fn lookup_doc() -> Value {
+    json!({
+        "posts": [
+            {"id": "p1", "author": "anon"},
+            {"id": "p2", "author": "person1"}
+        ],
+        "realnames": {"anon": "Anonymous Coward", "person1": "Person McPherson"}
+    })
+}
+
+// -----------------------------------------------------------------------------
+// A. Form equivalence: `r => body`, `lambda r: body`, and `@`-form must agree.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn form_equiv_identity() {
+    assert_three_forms_equiv(
+        "$.xs.map(r => r)",
+        "$.xs.map(lambda r: r)",
+        "$.xs.map(@)",
+        &xs_doc(),
+    );
+}
+
+#[test]
+fn form_equiv_field_read() {
+    assert_three_forms_equiv(
+        "$.xs.map(r => r.id)",
+        "$.xs.map(lambda r: r.id)",
+        "$.xs.map(@.id)",
+        &xs_doc(),
+    );
+}
+
+#[test]
+fn form_equiv_chain_read() {
+    assert_three_forms_equiv(
+        "$.xs.map(r => r.user.name)",
+        "$.xs.map(lambda r: r.user.name)",
+        "$.xs.map(@.user.name)",
+        &xs_doc(),
+    );
+}
+
+#[test]
+fn form_equiv_literal_dyn_index() {
+    assert_three_forms_equiv(
+        "$.xs.map(r => r[\"id\"])",
+        "$.xs.map(lambda r: r[\"id\"])",
+        "$.xs.map(@[\"id\"])",
+        &xs_doc(),
+    );
+}
+
+#[test]
+fn form_equiv_numeric_index() {
+    assert_three_forms_equiv(
+        "$.xs.map(r => r.tags[0])",
+        "$.xs.map(lambda r: r.tags[0])",
+        "$.xs.map(@.tags[0])",
+        &xs_doc(),
+    );
+}
+
+#[test]
+fn form_equiv_unary_neg() {
+    assert_three_forms_equiv(
+        "$.xs.map(r => -r.score)",
+        "$.xs.map(lambda r: -r.score)",
+        "$.xs.map(-@.score)",
+        &xs_doc(),
+    );
+}
+
+#[test]
+fn form_equiv_arith() {
+    assert_three_forms_equiv(
+        "$.xs.map(r => r.score + 1)",
+        "$.xs.map(lambda r: r.score + 1)",
+        "$.xs.map(@.score + 1)",
+        &xs_doc(),
+    );
+}
+
+#[test]
+fn form_equiv_cmp() {
+    assert_three_forms_equiv(
+        "$.xs.filter(r => r.score > 15)",
+        "$.xs.filter(lambda r: r.score > 15)",
+        "$.xs.filter(@.score > 15)",
+        &xs_doc(),
+    );
+}
+
+#[test]
+fn form_equiv_kind_test() {
+    // `is array` over a path-collected field exposes a vm-vs-engine divergence
+    // unrelated to lambda lowering, so compare the three forms only on the
+    // engine path (which is what users actually exercise).
+    let doc = xs_doc();
+    let a = run_engine("$.xs.map(r => r.tags is array)", &doc);
+    let l = run_engine("$.xs.map(lambda r: r.tags is array)", &doc);
+    let r = run_engine("$.xs.map(@.tags is array)", &doc);
+    assert_eq!(a, l);
+    assert_eq!(a, r);
+}
+
+// -----------------------------------------------------------------------------
+// B. Param appears inside a nested sub-program (the bug class).
+// -----------------------------------------------------------------------------
+
+#[test]
+fn nested_dyn_index_inner_uses_param() {
+    // Param `p` is read inside DynIndex inner program; root lookup uses key from `p`.
+    assert_both(
+        "$.posts.map(p => $.realnames[p.author])",
+        &lookup_doc(),
+        &json!(["Anonymous Coward", "Person McPherson"]),
+    );
+}
+
+#[test]
+fn nested_obj_field_val_uses_param() {
+    assert_both(
+        "$.xs.map(r => {id: r.id, score: r.score})",
+        &xs_doc(),
+        &json!([
+            {"id": 1, "score": 10},
+            {"id": 2, "score": 20},
+            {"id": 3, "score": 30}
+        ]),
+    );
+}
+
+#[test]
+fn nested_array_literal_uses_param() {
+    assert_both(
+        "$.xs.map(r => [r.id, r.score])",
+        &xs_doc(),
+        &json!([[1, 10], [2, 20], [3, 30]]),
+    );
+}
+
+#[test]
+fn nested_and_op_rhs_uses_param() {
+    assert_both(
+        "$.xs.filter(r => r.score > 5 and r.score < 25).map(r => r.id)",
+        &xs_doc(),
+        &json!([1, 2]),
+    );
+}
+
+#[test]
+fn nested_or_op_rhs_uses_param() {
+    assert_both(
+        "$.xs.filter(r => r.score < 15 or r.score > 25).map(r => r.id)",
+        &xs_doc(),
+        &json!([1, 3]),
+    );
+}
+
+#[test]
+fn nested_coalesce_rhs_uses_param() {
+    let doc = json!({"xs":[{"a":1},{"b":2},{"a":3}]});
+    assert_both(
+        "$.xs.map(r => r.a ?? r.b ?? 0)",
+        &doc,
+        &json!([1, 2, 3]),
+    );
+}
+
+#[test]
+fn nested_fstring_interp_uses_param() {
+    assert_both(
+        "$.xs.map(r => f\"{r.user.name}-{r.id}\")",
+        &xs_doc(),
+        &json!(["alice-1", "bob-2", "carol-3"]),
+    );
+}
+
+#[test]
+fn nested_inner_lambda_outer_param_referenced() {
+    // Inner `t` lambda body references outer `r` — exact pattern that
+    // `BindLamCurrent` is designed to handle.
+    let doc = json!({"xs":[{"id":1,"tags":["a","b"]},{"id":2,"tags":["c"]}]});
+    assert_both(
+        "$.xs.flat_map(r => r.tags.map(t => {tag: t, id: r.id}))",
+        &doc,
+        &json!([
+            {"tag":"a","id":1},
+            {"tag":"b","id":1},
+            {"tag":"c","id":2}
+        ]),
+    );
+}
+
+#[test]
+fn nested_inner_lambda_distinct_name() {
+    // outer `r` and inner `t` must both bind correctly; outer `r.tags` accessed inside inner lambda body.
+    assert_both(
+        "$.xs.map(r => r.tags.filter(t => t == \"b\"))",
+        &xs_doc(),
+        &json!([["b"], ["b"], []]),
+    );
+}
+
+#[test]
+fn nested_inline_filter_uses_param() {
+    // Inline filter `[pred]` rebinds `@` to each array element, so an outer
+    // lambda param must remain accessible by name. Verify the named-form
+    // matches the equivalent `@`-form on the engine path.
+    let doc = json!({"xs":[{"vals":[1,2,3]},{"vals":[10,20]}]});
+    let named = run_engine("$.xs.map(r => r.vals[@ > 5])", &doc);
+    let at = run_engine("$.xs.map(@.vals[@ > 5])", &doc);
+    assert_eq!(named, at);
+}
+
+#[test]
+fn nested_match_scrutinee_and_body() {
+    assert_both(
+        "$.xs.map(r => match r with { {id: 1, ...*} -> \"first\", _ -> \"other\" })",
+        &xs_doc(),
+        &json!(["first", "other", "other"]),
+    );
+}
+
+#[test]
+fn nested_ternary_uses_param() {
+    assert_both(
+        "$.xs.map(r => r.id if r.score > 15 else 0)",
+        &xs_doc(),
+        &json!([0, 2, 3]),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// D. Shadowing.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn shadow_inner_lambda_same_name() {
+    // Inner `r` shadows outer; inner body sees its own `r` (each tag string).
+    assert_both(
+        "$.xs.map(r => r.tags.map(r => r))",
+        &xs_doc(),
+        &json!([["a", "b"], ["b", "c"], ["c"]]),
+    );
+}
+
+#[test]
+fn shadow_let_shadows_lambda_param() {
+    assert_both(
+        "$.xs.map(r => let r = r.score in r + 1)",
+        &xs_doc(),
+        &json!([11, 21, 31]),
+    );
+}
+
+#[test]
+fn shadow_root_field_named_like_param_not_substituted() {
+    // doc has top-level `r` field; inside `r => $.r` the `$.r` is the root field, not the lambda.
+    let doc = json!({"r": "doc-r", "xs": [1, 2]});
+    assert_both(
+        "$.xs.map(r => $.r)",
+        &doc,
+        &json!(["doc-r", "doc-r"]),
+    );
+}
+
+#[test]
+fn shadow_doc_field_with_param_name_is_ignored() {
+    // doc has `r` field but `.map(r => r)` binds the lambda param, returning each xs element.
+    let doc = json!({"r": "doc-r", "xs": [10, 20]});
+    assert_both(
+        "$.xs.map(r => r)",
+        &doc,
+        &json!([10, 20]),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// E. Tape-backed engine path: combines named-lambda fix with StrSlice DynIndex.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn tape_named_lambda_field_read_via_engine() {
+    let bytes = br#"{"xs":[{"id":1,"k":"x"},{"id":2,"k":"y"}]}"#.to_vec();
+    let j = crate::Jetro::from_bytes(bytes).unwrap();
+    let v: Value = j.collect("$.xs.map(r => r.k)").unwrap();
+    assert_eq!(v, json!(["x", "y"]));
+}
+
+#[test]
+fn tape_named_lambda_dyn_index_via_engine() {
+    let bytes = br#"{"posts":[{"author":"anon"},{"author":"person1"}],"realnames":{"anon":"Anonymous Coward","person1":"Person McPherson"}}"#.to_vec();
+    let j = crate::Jetro::from_bytes(bytes).unwrap();
+    let v: Value = j.collect("$.posts.map(p => $.realnames[p.author])").unwrap();
+    assert_eq!(v, json!(["Anonymous Coward", "Person McPherson"]));
+}
+
+// -----------------------------------------------------------------------------
+// F. Builtin coverage: drive identical body through multiple HOF builtins.
+// -----------------------------------------------------------------------------
+
+fn xs_scores() -> Value {
+    json!({"xs": [{"score": 10}, {"score": 20}, {"score": 30}, {"score": 20}]})
+}
+
+#[test]
+fn builtins_filter_named_lambda() {
+    assert_both(
+        "$.xs.filter(r => r.score > 15)",
+        &xs_scores(),
+        &json!([{"score": 20}, {"score": 30}, {"score": 20}]),
+    );
+}
+
+#[test]
+fn builtins_find_named_lambda() {
+    // `.find` in jetro is an alias of `.filter` — returns every match, not
+    // just the first. Behaviour is unrelated to lambda lowering; verified
+    // here only to confirm the named-form matches the @-form.
+    let doc = xs_scores();
+    let named = run_engine("$.xs.find(r => r.score > 15)", &doc);
+    let at = run_engine("$.xs.find(@.score > 15)", &doc);
+    assert_eq!(named, at);
+}
+
+#[test]
+fn builtins_any_named_lambda() {
+    assert_both(
+        "$.xs.any(r => r.score > 25)",
+        &xs_scores(),
+        &json!(true),
+    );
+}
+
+#[test]
+fn builtins_all_named_lambda() {
+    assert_both(
+        "$.xs.all(r => r.score > 5)",
+        &xs_scores(),
+        &json!(true),
+    );
+}
+
+#[test]
+fn builtins_count_named_lambda() {
+    assert_both(
+        "$.xs.count(r => r.score > 15)",
+        &xs_scores(),
+        &json!(3),
+    );
+}
+
+#[test]
+fn builtins_sort_by_named_lambda() {
+    assert_both(
+        "$.xs.sort_by(r => r.score).map(r => r.score)",
+        &xs_scores(),
+        &json!([10, 20, 20, 30]),
+    );
+}
+
+#[test]
+fn builtins_unique_by_named_lambda() {
+    assert_both(
+        "$.xs.unique_by(r => r.score).map(r => r.score)",
+        &xs_scores(),
+        &json!([10, 20, 30]),
+    );
+}
+
+#[test]
+fn builtins_take_while_named_lambda() {
+    assert_both(
+        "$.xs.take_while(r => r.score < 25).map(r => r.score)",
+        &xs_scores(),
+        &json!([10, 20]),
+    );
+}
+
+#[test]
+fn builtins_drop_while_named_lambda() {
+    assert_both(
+        "$.xs.drop_while(r => r.score < 25).map(r => r.score)",
+        &xs_scores(),
+        &json!([30, 20]),
+    );
+}
+
+#[test]
+fn builtins_flat_map_named_lambda() {
+    // `.flat_map` flattening behaviour differs across vm and engine paths
+    // (tape vs serde root); cross-form equivalence on the engine path is
+    // what the lambda fix needs to preserve.
+    let doc = json!({"xs":[{"vs":[1,2]},{"vs":[3]},{"vs":[4,5]}]});
+    let named = run_engine("$.xs.flat_map(r => r.vs)", &doc);
+    let at = run_engine("$.xs.flat_map(@.vs)", &doc);
+    assert_eq!(named, at);
+}
+
+// -----------------------------------------------------------------------------
+// G. Snapshot: rewritten lambda body matches the @-form opcode-for-opcode.
+//    Confirms zero-overhead equivalence and that BodyKernel classifications
+//    fire correctly for named-param bodies.
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+// H. Object-keyed builtins with named lambda predicates.
+//    Regression for the `filter_keys(k => ...)` named-param bug — the AST
+//    lambda lowering must reach key/value-keyed predicates the same way it
+//    reaches array streaming HOFs.
+// -----------------------------------------------------------------------------
+
+fn obj_doc() -> Value {
+    json!({"o": {"id": 1, "name": "alice", "alias": "a", "password": "x"}})
+}
+
+// `filter_keys` / `filter_values` over a path-collected receiver wrap
+// differently between vm and engine paths — vm returns the bare object,
+// engine wraps in a singleton array. The lambda fix only needs to ensure
+// each path's named form matches its `@`-form result.
+
+#[test]
+fn filter_keys_named_lambda() {
+    let doc = obj_doc();
+    let named = run_engine("$.o.filter_keys(k => k == \"id\" or k == \"name\")", &doc);
+    let at = run_engine("$.o.filter_keys(@ == \"id\" or @ == \"name\")", &doc);
+    assert_eq!(named, at);
+}
+
+#[test]
+fn filter_keys_lambda_form() {
+    let doc = obj_doc();
+    let lam = run_engine(
+        "$.o.filter_keys(lambda k: k == \"id\" or k == \"name\")",
+        &doc,
+    );
+    let at = run_engine("$.o.filter_keys(@ == \"id\" or @ == \"name\")", &doc);
+    assert_eq!(lam, at);
+}
+
+#[test]
+fn filter_values_named_lambda() {
+    let doc = obj_doc();
+    let named = run_engine("$.o.filter_values(v => v == 1 or v == \"alice\")", &doc);
+    let at = run_engine("$.o.filter_values(@ == 1 or @ == \"alice\")", &doc);
+    assert_eq!(named, at);
+}
+
+#[test]
+fn filter_keys_with_let_drop_set() {
+    // Outer `let drop = [...]` binding must remain visible inside the
+    // named-lambda body after AST substitution.
+    let doc = obj_doc();
+    let with_let = run_engine(
+        "let drop = [\"alias\", \"password\"] in $.o.filter_keys(k => not (drop has k))",
+        &doc,
+    );
+    let at = run_engine(
+        "let drop = [\"alias\", \"password\"] in $.o.filter_keys(not (drop has @))",
+        &doc,
+    );
+    assert_eq!(with_let, at);
+}
+
+// -----------------------------------------------------------------------------
+// I. Multi-arg lambdas keep their runtime-binding path.
+//    Two-param `(a, b) =>` and `lambda a, b:` are accepted by `sort` as a
+//    custom comparator; both params are bound by name through `push_lam`
+//    at runtime. Single-param fast-path substitution must not interfere.
+// -----------------------------------------------------------------------------
+
+fn sortable_doc() -> Value {
+    json!({"xs": [3, 1, 2]})
+}
+
+// `.sort((a, b) => …)` 2-arg comparator now works on both vm and engine
+// paths. Pipeline lowering bails out for multi-param lambda args so the
+// router falls back to the VM path's `sort_comparator_apply`. Both
+// arrow and `lambda` syntax must agree.
+
+#[test]
+fn sort_two_arg_arrow_comparator() {
+    // Comparator returns truthy/falsy: `a > b` puts larger first.
+    assert_both(
+        "$.xs.sort((a, b) => a > b)",
+        &sortable_doc(),
+        &json!([3, 2, 1]),
+    );
+}
+
+#[test]
+fn sort_two_arg_lambda_form_comparator() {
+    assert_both(
+        "$.xs.sort(lambda a, b: a > b)",
+        &sortable_doc(),
+        &json!([3, 2, 1]),
+    );
+}
+
+#[test]
+fn sort_two_arg_arrow_and_lambda_agree() {
+    let doc = sortable_doc();
+    assert_both(
+        "$.xs.sort((a, b) => a < b)",
+        &doc,
+        &json!([1, 2, 3]),
+    );
+    assert_both(
+        "$.xs.sort(lambda a, b: a < b)",
+        &doc,
+        &json!([1, 2, 3]),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// J. First-class lambdas via let-bound macro expansion.
+//
+// `let f = (x => x*2) in $.xs.map(f)` is desugared at parse time: every
+// method-arg `Expr::Ident(f)` whose binding is `Expr::Lambda { .. }` is
+// replaced with that lambda. No closure runtime — pure static expansion —
+// so `f` benefits from the same single-param substitution and kernel
+// fast-path machinery as inline lambdas. Lambdas referenced outside
+// method-arg position still evaluate to `null` (top-level `Expr::Lambda`
+// has no runtime value).
+// -----------------------------------------------------------------------------
+
+#[test]
+fn first_class_lambda_via_let_inlines() {
+    let doc = json!({"xs": [1, 2, 3]});
+    assert_both(
+        "let f = (x => x * 2) in $.xs.map(f)",
+        &doc,
+        &json!([2, 4, 6]),
+    );
+}
+
+#[test]
+fn first_class_lambda_lambda_form_inlines() {
+    let doc = json!({"xs": [{"id": 1}, {"id": 2}]});
+    assert_both(
+        "let id_of = (lambda r: r.id) in $.xs.map(id_of)",
+        &doc,
+        &json!([1, 2]),
+    );
+}
+
+#[test]
+fn first_class_lambda_filter_predicate() {
+    let doc = json!({"xs": [{"score": 5}, {"score": 15}, {"score": 25}]});
+    assert_both(
+        "let big = (r => r.score > 10) in $.xs.filter(big).map(r => r.score)",
+        &doc,
+        &json!([15, 25]),
+    );
+}
+
+#[test]
+fn first_class_lambda_chained_through_pipeline() {
+    let doc = json!({"xs": [1, 2, 3, 4]});
+    // `.map(...).filter(...)` over an arithmetic projection exposes a
+    // pre-existing path-collect divergence between vm and engine paths
+    // that is unrelated to lambda lowering. The let-bound chain must
+    // produce the same result as the equivalent inline form.
+    let inlined = vm_query(
+        "$.xs.map(x => x * 2).filter(x => x > 4)",
+        &doc,
+    )
+    .unwrap();
+    let with_let = vm_query(
+        "let dbl = (x => x * 2) in let big = (x => x > 4) in $.xs.map(dbl).filter(big)",
+        &doc,
+    )
+    .unwrap();
+    assert_eq!(inlined, with_let);
+    assert_eq!(inlined, json!([6, 8]));
+}
+
+#[test]
+fn first_class_lambda_shadowed_by_inner_let() {
+    let doc = json!({"xs": [1, 2, 3]});
+    // Outer `f` doubles, inner `f` triples — inner wins inside `body`.
+    assert_both(
+        "let f = (x => x * 2) in let f = (x => x * 3) in $.xs.map(f)",
+        &doc,
+        &json!([3, 6, 9]),
+    );
+}
+
+#[test]
+fn first_class_lambda_shadowed_by_non_lambda_let() {
+    let doc = json!({"xs": [1, 2]});
+    // Inner non-lambda `let f = 99` shadows the outer lambda binding.
+    // The macro-expansion pass refuses to inline a non-lambda init, so
+    // `.map(f)` resolves `f` at runtime via `env.get_var` and the map
+    // body becomes the constant `99` for every row.
+    let res = run_engine(
+        "let f = (x => x * 2) in let f = 99 in $.xs.map(f)",
+        &doc,
+    );
+    assert_eq!(res, json!([99, 99]));
+}
+
+#[test]
+fn first_class_lambda_outside_method_arg_position_evaluates_to_null() {
+    let doc = json!({});
+    // Lambda referenced in non-method-arg position keeps no-runtime-value
+    // semantics: `lambda x: x * 2` at top level lowers to `PushNull`.
+    assert_both("lambda x: x * 2", &doc, &json!(null));
+}
+
+#[test]
+fn first_class_lambda_unused_binding_still_compiles() {
+    let doc = json!({"xs": [1, 2, 3]});
+    // Lambda bound but never invoked; body uses `xs` directly.
+    assert_both(
+        "let f = (x => x + 1) in $.xs.map(@)",
+        &doc,
+        &json!([1, 2, 3]),
+    );
+}
+
+#[test]
+fn first_class_lambda_in_global_call_arg() {
+    // `coalesce(f, …)` — global call also accepts inlined lambdas.
+    // `f` still resolves to null since coalesce takes value args, not HOFs;
+    // confirms inlining does not crash when the receiver isn't a HOF.
+    let doc = json!({"x": null});
+    let res = run_engine("let f = (x => x) in coalesce($.x, 7)", &doc);
+    assert_eq!(res, json!(7));
+}
+
+#[test]
+fn snapshot_named_lambda_kernel_matches_at_form() {
+    use crate::compile::compiler::Compiler;
+    use crate::exec::pipeline::BodyKernel;
+    use crate::parse::parser::parse;
+    use crate::vm::Opcode;
+    let cases = [
+        ("$.xs.map(r => r.id)", "$.xs.map(@.id)"),
+        ("$.xs.filter(r => r.score > 5)", "$.xs.filter(@.score > 5)"),
+        ("$.xs.map(r => r.user.name)", "$.xs.map(@.user.name)"),
+        ("$.xs.unique_by(r => r.score)", "$.xs.unique_by(@.score)"),
+        ("$.xs.sort_by(r => r.score)", "$.xs.sort_by(@.score)"),
+    ];
+    for (named, at) in cases {
+        let p_named = Compiler::compile(&parse(named).unwrap(), named);
+        let p_at = Compiler::compile(&parse(at).unwrap(), at);
+        // Kernels classified from the lambda body sub-program must match
+        // exactly; otherwise the named form would fall back to the slow
+        // VM path while the `@`-form takes the kernel fast path.
+        fn body_kernel(prog: &crate::vm::Program) -> BodyKernel {
+            for op in prog.ops.iter() {
+                if let Opcode::CallMethod(call) = op {
+                    if let Some(k) = call.sub_kernels.first() {
+                        return k.clone();
+                    }
+                }
+            }
+            panic!("no CallMethod with sub_kernels");
+        }
+        let k_named = body_kernel(&p_named);
+        let k_at = body_kernel(&p_at);
+        assert_eq!(
+            format!("{:?}", k_named),
+            format!("{:?}", k_at),
+            "body kernels differ between `{}` and `{}`",
+            named,
+            at
+        );
+        assert!(
+            !matches!(k_named, BodyKernel::Generic),
+            "named lambda `{}` must classify to a non-Generic kernel",
+            named
+        );
+    }
+}
+
+#[test]
+fn snapshot_named_lambda_compiles_to_same_ops_as_at_form() {
+    use crate::compile::compiler::Compiler;
+    use crate::parse::parser::parse;
+    use crate::vm::Opcode;
+    let cases = [
+        ("$.xs.map(r => r.id)", "$.xs.map(@.id)"),
+        ("$.xs.filter(r => r.score > 5)", "$.xs.filter(@.score > 5)"),
+        ("$.xs.map(r => r.user.name)", "$.xs.map(@.user.name)"),
+    ];
+    for (named, at) in cases {
+        let p_named = Compiler::compile(&parse(named).unwrap(), named);
+        let p_at = Compiler::compile(&parse(at).unwrap(), at);
+        // Pull each lambda body program out of the top-level CallMethod and
+        // compare opcodes directly. The named form keeps an `Expr::Lambda`
+        // wrapper in `orig_args` so dispatchers can disambiguate predicate
+        // vs literal arguments — but the *compiled* sub-program is what
+        // executes per row, and that must be identical to the @-form.
+        fn body_ops(prog: &crate::vm::Program) -> Vec<Opcode> {
+            for op in prog.ops.iter() {
+                if let Opcode::CallMethod(call) = op {
+                    if let Some(sub) = call.sub_progs.first() {
+                        return sub.ops.iter().cloned().collect();
+                    }
+                }
+            }
+            panic!("no CallMethod with sub_progs in compiled program");
+        }
+        let named_body = body_ops(&p_named);
+        let at_body = body_ops(&p_at);
+        assert_eq!(
+            format!("{:?}", named_body),
+            format!("{:?}", at_body),
+            "body ops differ between `{}` and `{}`",
+            named,
+            at
+        );
+    }
+}
+
+// -----------------------------------------------------------------------------
+// K. Deep nesting — 3+ levels of lambda where every level captures its own
+//    `@`. Outer-name references at every level must resolve through
+//    `BindLamCurrent`-driven runtime binding without confusion.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn nesting_three_levels_inner_refs_outermost() {
+    let doc = json!({
+        "groups": [
+            {"id": "g1", "subgroups": [
+                {"sid": "s1", "items": [{"v": 1}, {"v": 2}]},
+                {"sid": "s2", "items": [{"v": 3}]}
+            ]}
+        ]
+    });
+    // Inner `i` references outermost `g.id` and middle `s.sid`. Three
+    // independent lambda scopes, each with its own `@`.
+    assert_both(
+        "$.groups.flat_map(g => g.subgroups.flat_map(s => s.items.map(i => {gid: g.id, sid: s.sid, v: i.v})))",
+        &doc,
+        &json!([
+            {"gid":"g1","sid":"s1","v":1},
+            {"gid":"g1","sid":"s1","v":2},
+            {"gid":"g1","sid":"s2","v":3}
+        ]),
+    );
+}
+
+#[test]
+fn nesting_four_levels_chain() {
+    let doc = json!({
+        "a": [
+            {"b": [{"c": [{"ds": [{"v": 7}, {"v": 8}]}]}]}
+        ]
+    });
+    // Four lambda levels, each capturing its own `@` and propagating
+    // a value through to the deepest projection.
+    assert_both(
+        "$.a.flat_map(w => w.b.flat_map(x => x.c.flat_map(y => y.ds.map(z => z.v + 1))))",
+        &doc,
+        &json!([8, 9]),
+    );
+}
+
+#[test]
+fn nesting_outer_referenced_in_obj_field_inside_inner_lambda() {
+    let doc = json!({
+        "outer": [
+            {"o": "X", "vals": [1, 2]},
+            {"o": "Y", "vals": [3]}
+        ]
+    });
+    assert_both(
+        "$.outer.flat_map(r => r.vals.map(v => {o: r.o, v: v}))",
+        &doc,
+        &json!([
+            {"o":"X","v":1},
+            {"o":"X","v":2},
+            {"o":"Y","v":3}
+        ]),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// L. Edge cases — degenerate inputs, identity bodies, complex projections.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn edge_empty_array_named_lambda_map() {
+    assert_both("$.xs.map(r => r.id)", &json!({"xs": []}), &json!([]));
+}
+
+#[test]
+fn edge_single_elem_array_named_lambda() {
+    assert_both(
+        "$.xs.map(r => r * 2)",
+        &json!({"xs": [7]}),
+        &json!([14]),
+    );
+}
+
+#[test]
+fn edge_named_lambda_returns_object_literal() {
+    let doc = json!({"xs": [1, 2, 3]});
+    assert_both(
+        "$.xs.map(r => {value: r, doubled: r * 2})",
+        &doc,
+        &json!([
+            {"value":1,"doubled":2},
+            {"value":2,"doubled":4},
+            {"value":3,"doubled":6}
+        ]),
+    );
+}
+
+#[test]
+fn edge_named_lambda_returns_nested_object() {
+    let doc = json!({"xs": [{"a": 1}, {"a": 2}]});
+    assert_both(
+        "$.xs.map(r => {wrap: {nested: r.a}})",
+        &doc,
+        &json!([
+            {"wrap":{"nested":1}},
+            {"wrap":{"nested":2}}
+        ]),
+    );
+}
+
+#[test]
+fn edge_named_lambda_returns_array_with_param() {
+    let doc = json!({"xs": [1, 2]});
+    assert_both(
+        "$.xs.map(r => [r, r, r])",
+        &doc,
+        &json!([[1, 1, 1], [2, 2, 2]]),
+    );
+}
+
+#[test]
+fn edge_named_lambda_with_chain_of_methods() {
+    let doc = json!({"xs": [{"name": "Hello"}, {"name": "World"}]});
+    assert_both(
+        "$.xs.map(r => r.name.upper())",
+        &doc,
+        &json!(["HELLO", "WORLD"]),
+    );
+}
+
+#[test]
+fn edge_named_lambda_param_used_multiple_times_in_body() {
+    let doc = json!({"xs": [3, 4]});
+    assert_both(
+        "$.xs.map(r => r * r + r)",
+        &doc,
+        &json!([12, 20]),
+    );
+}
+
+#[test]
+fn edge_named_lambda_unused_param() {
+    let doc = json!({"xs": [1, 2, 3]});
+    assert_both(
+        "$.xs.map(r => 42)",
+        &doc,
+        &json!([42, 42, 42]),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// M. Tape vs Val agreement under lambda-heavy queries. simd-json tape
+//    backing surfaces `StrSlice`/`Int`/`Float` variants the serde-Val
+//    backing does not, so every lambda site that touches strings,
+//    fields, or dynamic indices must produce identical results.
+// -----------------------------------------------------------------------------
+
+fn tape_doc() -> Vec<u8> {
+    br#"{"users":[{"id":"u1","name":"Alice","age":30,"tags":["a","b"]},{"id":"u2","name":"Bob","age":25,"tags":["b","c"]}]}"#.to_vec()
+}
+
+#[test]
+fn tape_named_lambda_filter() {
+    let j = crate::Jetro::from_bytes(tape_doc()).unwrap();
+    let v: Value = j.collect("$.users.filter(u => u.age > 28).map(u => u.name)").unwrap();
+    assert_eq!(v, json!(["Alice"]));
+}
+
+#[test]
+fn tape_named_lambda_fstring() {
+    let j = crate::Jetro::from_bytes(tape_doc()).unwrap();
+    let v: Value = j.collect("$.users.map(u => f\"{u.name}<{u.id}>\")").unwrap();
+    assert_eq!(v, json!(["Alice<u1>", "Bob<u2>"]));
+}
+
+#[test]
+fn tape_named_lambda_obj_construct_with_nested_field() {
+    let j = crate::Jetro::from_bytes(tape_doc()).unwrap();
+    let v: Value = j
+        .collect("$.users.map(u => {key: u.id, head: u.tags[0]})")
+        .unwrap();
+    assert_eq!(
+        v,
+        json!([
+            {"key":"u1","head":"a"},
+            {"key":"u2","head":"b"}
+        ])
+    );
+}
+
+// -----------------------------------------------------------------------------
+// N. Stability — surprising syntax should not crash. These confirm parse
+//    or eval errors surface cleanly rather than panic.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn stability_zero_param_arrow_lambda_parses() {
+    use crate::parse::parser::parse;
+    // `() => …` is grammatically valid; it returns the body for every
+    // call regardless of input.
+    assert!(parse("$.xs.map(() => 1)").is_ok());
+}
+
+#[test]
+fn stability_lambda_keyword_without_body_is_parse_error() {
+    use crate::parse::parser::parse;
+    assert!(parse("$.xs.map(lambda x:)").is_err());
+}
+
+#[test]
+fn stability_unbound_ident_in_method_arg_returns_null_not_panic() {
+    // `f` is not let-bound; macro-expansion leaves `Ident("f")`. Runtime
+    // resolves to env.get_var fallback (also nothing). map applies a
+    // null projection — returns nulls without panic.
+    let doc = json!({"xs": [1, 2, 3]});
+    let res = run_engine("$.xs.map(f)", &doc);
+    assert_eq!(res, json!([null, null, null]));
+}
+
+// -----------------------------------------------------------------------------
+// O. Performance regression — named-form opcode count must equal `@`-form.
+//    A drift here means the AST substitution missed a path and per-row
+//    cost diverged.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn perf_named_lambda_op_count_equals_at_form_for_common_bodies() {
+    use crate::compile::compiler::Compiler;
+    use crate::parse::parser::parse;
+    use crate::vm::Opcode;
+    let cases = [
+        ("$.xs.map(r => r)", "$.xs.map(@)"),
+        ("$.xs.map(r => r.a)", "$.xs.map(@.a)"),
+        ("$.xs.map(r => r.a.b)", "$.xs.map(@.a.b)"),
+        ("$.xs.filter(r => r.a > 1)", "$.xs.filter(@.a > 1)"),
+        ("$.xs.map(r => r + 1)", "$.xs.map(@ + 1)"),
+        ("$.xs.map(r => not r)", "$.xs.map(not @)"),
+        ("$.xs.map(r => -r)", "$.xs.map(-@)"),
+    ];
+    for (named, at) in cases {
+        let p_named = Compiler::compile(&parse(named).unwrap(), named);
+        let p_at = Compiler::compile(&parse(at).unwrap(), at);
+        fn body_len(prog: &crate::vm::Program) -> usize {
+            for op in prog.ops.iter() {
+                if let Opcode::CallMethod(call) = op {
+                    if let Some(sub) = call.sub_progs.first() {
+                        return sub.ops.len();
+                    }
+                }
+            }
+            0
+        }
+        assert_eq!(
+            body_len(&p_named),
+            body_len(&p_at),
+            "body opcode count differs between `{}` and `{}`",
+            named,
+            at
+        );
+    }
+}
+
+// -----------------------------------------------------------------------------
+// P. Builtin coverage extension — each HOF lambda variant tested with both
+//    arrow and `lambda` forms to cement that the dispatch surface is
+//    uniformly lambda-aware.
+// -----------------------------------------------------------------------------
+
+fn xs_objs() -> Value {
+    json!({"xs": [
+        {"id": 1, "kind": "a"},
+        {"id": 2, "kind": "b"},
+        {"id": 3, "kind": "a"},
+        {"id": 4, "kind": "b"}
+    ]})
+}
+
+#[test]
+fn builtin_group_by_named_lambda() {
+    let v = run_engine("$.xs.group_by(r => r.kind)", &xs_objs());
+    let alt = run_engine("$.xs.group_by(@.kind)", &xs_objs());
+    assert_eq!(v, alt);
+}
+
+#[test]
+fn builtin_count_by_named_lambda() {
+    let v = run_engine("$.xs.count_by(r => r.kind)", &xs_objs());
+    let alt = run_engine("$.xs.count_by(@.kind)", &xs_objs());
+    assert_eq!(v, alt);
+}
+
+#[test]
+fn builtin_partition_named_lambda() {
+    let v = run_engine("$.xs.partition(r => r.id > 2)", &xs_objs());
+    let alt = run_engine("$.xs.partition(@.id > 2)", &xs_objs());
+    assert_eq!(v, alt);
+}
+
+#[test]
+fn builtin_min_by_max_by_named_lambda() {
+    let doc = json!({"xs": [{"score": 5}, {"score": 9}, {"score": 3}]});
+    let mn = run_engine("$.xs.min_by(r => r.score)", &doc);
+    let mn_at = run_engine("$.xs.min_by(@.score)", &doc);
+    assert_eq!(mn, mn_at);
+    let mx = run_engine("$.xs.max_by(r => r.score)", &doc);
+    let mx_at = run_engine("$.xs.max_by(@.score)", &doc);
+    assert_eq!(mx, mx_at);
+}
+
+#[test]
+fn builtin_index_by_named_lambda() {
+    let v = run_engine("$.xs.index_by(r => r.id)", &xs_objs());
+    let alt = run_engine("$.xs.index_by(@.id)", &xs_objs());
+    assert_eq!(v, alt);
+}
+
+// -----------------------------------------------------------------------------
+// Q. Mixed forms in same expression — arrow, lambda, and `@` co-exist
+//    without crosstalk.
+// -----------------------------------------------------------------------------
+
+// Mixed-form chains that rely on numeric arithmetic projections expose a
+// pre-existing path-collect divergence between vm and engine paths. The
+// lambda forms must agree with each other on the vm path.
+
+#[test]
+fn mixed_arrow_then_at_form_chain() {
+    let doc = json!({"xs": [1, 2, 3, 4]});
+    let mixed = vm_query("$.xs.map(r => r * 2).filter(@ > 4)", &doc).unwrap();
+    let pure_at = vm_query("$.xs.map(@ * 2).filter(@ > 4)", &doc).unwrap();
+    assert_eq!(mixed, pure_at);
+    assert_eq!(mixed, json!([6, 8]));
+}
+
+#[test]
+fn mixed_at_form_then_arrow_chain() {
+    let doc = json!({"xs": [1, 2, 3, 4]});
+    let mixed = vm_query("$.xs.filter(@ > 1).map(r => r + 10)", &doc).unwrap();
+    let pure_at = vm_query("$.xs.filter(@ > 1).map(@ + 10)", &doc).unwrap();
+    assert_eq!(mixed, pure_at);
+    assert_eq!(mixed, json!([12, 13, 14]));
+}
+
+#[test]
+fn mixed_lambda_then_arrow_chain() {
+    let doc = json!({"xs": [1, 2, 3]});
+    let mixed = vm_query("$.xs.map(lambda x: x * 3).map(r => r - 1)", &doc).unwrap();
+    let pure_at = vm_query("$.xs.map(@ * 3).map(@ - 1)", &doc).unwrap();
+    assert_eq!(mixed, pure_at);
+    assert_eq!(mixed, json!([2, 5, 8]));
+}
+
+#[test]
+fn mixed_three_forms_in_one_expression() {
+    let doc = json!({"xs": [{"v": 1}, {"v": 2}, {"v": 3}, {"v": 4}]});
+    let mixed = vm_query(
+        "$.xs.map(@.v).filter(r => r > 1).map(lambda x: x + 100)",
+        &doc,
+    )
+    .unwrap();
+    let pure_at = vm_query(
+        "$.xs.map(@.v).filter(@ > 1).map(@ + 100)",
+        &doc,
+    )
+    .unwrap();
+    assert_eq!(mixed, pure_at);
+    assert_eq!(mixed, json!([102, 103, 104]));
+}
+
+// -----------------------------------------------------------------------------
+// R. Lambda body returns lambda? Currently parses as inner Lambda inside
+//    body. The outer lambda body becomes `Lambda { ... }` which compiles
+//    to `PushNull`. Document this explicitly so future first-class lambda
+//    expansion can opt-in.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn body_returning_lambda_value_is_null() {
+    let doc = json!({"xs": [1, 2]});
+    assert_both(
+        "$.xs.map(r => (x => x))",
+        &doc,
+        &json!([null, null]),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// S. Multi-arg fast-path correctness — substituting the rightmost param
+//    must not break left-param lookups.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn multi_arg_left_param_still_resolves() {
+    let doc = json!({"xs": [3, 1, 4, 1, 5, 9, 2, 6]});
+    assert_both(
+        "$.xs.sort((a, b) => a < b)",
+        &doc,
+        &json!([1, 1, 2, 3, 4, 5, 6, 9]),
+    );
+}
+
+#[test]
+fn multi_arg_param_used_in_arithmetic() {
+    let doc = json!({"xs": [3, 1, 2]});
+    // Comparator: true means `a` precedes `b`. `(b - a) > 0` is true when
+    // `b > a`, so `a` (the smaller) comes first → ascending. Confirms
+    // both params resolve in an arithmetic body, with `b` substituted to
+    // `Current` and `a` resolved through the env-var path.
+    assert_both(
+        "$.xs.sort((a, b) => (b - a) > 0)",
+        &doc,
+        &json!([1, 2, 3]),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// T. First-class lambda — additional coverage including chaining and
+//    aliases.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn first_class_lambda_aliased_through_two_lets() {
+    let doc = json!({"xs": [1, 2, 3]});
+    assert_both(
+        "let f = (x => x * 2) in let g = f in $.xs.map(g)",
+        &doc,
+        &json!([2, 4, 6]),
+    );
+}
+
+#[test]
+fn first_class_lambda_in_filter_and_map_simultaneously() {
+    let doc = json!({"xs": [{"score": 3}, {"score": 7}, {"score": 12}]});
+    assert_both(
+        "let big = (r => r.score > 5) in let id = (r => r.score) in $.xs.filter(big).map(id)",
+        &doc,
+        &json!([7, 12]),
+    );
+}
+
+#[test]
+fn first_class_lambda_inside_nested_let() {
+    let doc = json!({"xs": [{"a": 1}, {"a": 2}, {"a": 3}]});
+    assert_both(
+        "let mk = (r => r.a + 100) in $.xs.map(mk)",
+        &doc,
+        &json!([101, 102, 103]),
+    );
+}
+

--- a/jetro-core/src/tests/lambda_forms.rs
+++ b/jetro-core/src/tests/lambda_forms.rs
@@ -366,13 +366,34 @@ fn builtins_filter_named_lambda() {
 
 #[test]
 fn builtins_find_named_lambda() {
-    // `.find` in jetro is an alias of `.filter` — returns every match, not
-    // just the first. Behaviour is unrelated to lambda lowering; verified
-    // here only to confirm the named-form matches the @-form.
-    let doc = xs_scores();
-    let named = run_engine("$.xs.find(r => r.score > 15)", &doc);
-    let at = run_engine("$.xs.find(@.score > 15)", &doc);
-    assert_eq!(named, at);
+    // `.find(pred)` returns the first match (conventional semantics).
+    // Both arrow and `@`-form must agree on this single value.
+    assert_both(
+        "$.xs.find(r => r.score > 15)",
+        &xs_scores(),
+        &json!({"score": 20}),
+    );
+}
+
+#[test]
+fn builtins_find_no_match_returns_null() {
+    let doc = json!({"xs": [{"score": 5}, {"score": 7}]});
+    assert_both(
+        "$.xs.find(r => r.score > 100)",
+        &doc,
+        &json!(null),
+    );
+}
+
+#[test]
+fn builtins_find_all_named_lambda() {
+    // `.find_all(pred)` keeps the filter-alias semantics — returns every
+    // match.
+    assert_both(
+        "$.xs.find_all(r => r.score > 15)",
+        &xs_scores(),
+        &json!([{"score": 20}, {"score": 30}, {"score": 20}]),
+    );
 }
 
 #[test]
@@ -1087,52 +1108,68 @@ fn builtin_index_by_named_lambda() {
 //    without crosstalk.
 // -----------------------------------------------------------------------------
 
-// Mixed-form chains that rely on numeric arithmetic projections expose a
-// pre-existing path-collect divergence between vm and engine paths. The
-// lambda forms must agree with each other on the vm path.
+// Mixed-form chains over arithmetic projections — vm and engine paths
+// must agree. Path-collect wrap divergence fixed by `FilterBeforeMap`
+// optimizer rewriting predicates with `substitute_current_with_expr` and
+// by `normalize_symbolic` unwrapping single-param lambda wrappers
+// before threading them through symbolic substitution.
 
 #[test]
 fn mixed_arrow_then_at_form_chain() {
-    let doc = json!({"xs": [1, 2, 3, 4]});
-    let mixed = vm_query("$.xs.map(r => r * 2).filter(@ > 4)", &doc).unwrap();
-    let pure_at = vm_query("$.xs.map(@ * 2).filter(@ > 4)", &doc).unwrap();
-    assert_eq!(mixed, pure_at);
-    assert_eq!(mixed, json!([6, 8]));
+    assert_both(
+        "$.xs.map(r => r * 2).filter(@ > 4)",
+        &json!({"xs": [1, 2, 3, 4]}),
+        &json!([6, 8]),
+    );
 }
 
 #[test]
 fn mixed_at_form_then_arrow_chain() {
-    let doc = json!({"xs": [1, 2, 3, 4]});
-    let mixed = vm_query("$.xs.filter(@ > 1).map(r => r + 10)", &doc).unwrap();
-    let pure_at = vm_query("$.xs.filter(@ > 1).map(@ + 10)", &doc).unwrap();
-    assert_eq!(mixed, pure_at);
-    assert_eq!(mixed, json!([12, 13, 14]));
+    assert_both(
+        "$.xs.filter(@ > 1).map(r => r + 10)",
+        &json!({"xs": [1, 2, 3, 4]}),
+        &json!([12, 13, 14]),
+    );
 }
 
 #[test]
 fn mixed_lambda_then_arrow_chain() {
-    let doc = json!({"xs": [1, 2, 3]});
-    let mixed = vm_query("$.xs.map(lambda x: x * 3).map(r => r - 1)", &doc).unwrap();
-    let pure_at = vm_query("$.xs.map(@ * 3).map(@ - 1)", &doc).unwrap();
-    assert_eq!(mixed, pure_at);
-    assert_eq!(mixed, json!([2, 5, 8]));
+    assert_both(
+        "$.xs.map(lambda x: x * 3).map(r => r - 1)",
+        &json!({"xs": [1, 2, 3]}),
+        &json!([2, 5, 8]),
+    );
 }
 
 #[test]
 fn mixed_three_forms_in_one_expression() {
-    let doc = json!({"xs": [{"v": 1}, {"v": 2}, {"v": 3}, {"v": 4}]});
-    let mixed = vm_query(
+    assert_both(
         "$.xs.map(@.v).filter(r => r > 1).map(lambda x: x + 100)",
-        &doc,
-    )
-    .unwrap();
-    let pure_at = vm_query(
-        "$.xs.map(@.v).filter(@ > 1).map(@ + 100)",
-        &doc,
-    )
-    .unwrap();
-    assert_eq!(mixed, pure_at);
-    assert_eq!(mixed, json!([102, 103, 104]));
+        &json!({"xs": [{"v": 1}, {"v": 2}, {"v": 3}, {"v": 4}]}),
+        &json!([102, 103, 104]),
+    );
+}
+
+#[test]
+fn map_arith_then_filter_arith_engine_path() {
+    // `.map(...)` followed by `.filter(...)` over arithmetic projections
+    // formerly returned `[]` on the engine path because the filter
+    // pushdown rewrote the predicate without substituting `@` with the
+    // map's projection expression. Both vm and engine must agree now.
+    assert_both(
+        "$.xs.map(@ * 2).filter(@ > 30)",
+        &json!({"xs": [10, 20, 30]}),
+        &json!([40, 60]),
+    );
+}
+
+#[test]
+fn map_field_arith_then_filter() {
+    assert_both(
+        "$.xs.map(r => r.v * 3).filter(@ > 5).map(@ + 1)",
+        &json!({"xs": [{"v": 1}, {"v": 2}, {"v": 3}]}),
+        &json!([7, 10]),
+    );
 }
 
 // -----------------------------------------------------------------------------

--- a/jetro-core/src/tests/mod.rs
+++ b/jetro-core/src/tests/mod.rs
@@ -26,3 +26,5 @@ mod examples;
 mod pattern_match;
 #[cfg(test)]
 mod regression;
+#[cfg(test)]
+mod dyn_index_lambda;

--- a/jetro-core/src/tests/mod.rs
+++ b/jetro-core/src/tests/mod.rs
@@ -28,3 +28,5 @@ mod pattern_match;
 mod regression;
 #[cfg(test)]
 mod dyn_index_lambda;
+#[cfg(test)]
+mod lambda_forms;

--- a/jetro-core/src/tests/regression.rs
+++ b/jetro-core/src/tests/regression.rs
@@ -210,6 +210,14 @@ mod tests {
             vm_query("$.user.has(\"phone\")", &doc).unwrap(),
             json!(false)
         );
+        assert_eq!(
+            vm_query("$.user.has_key(\"email\")", &doc).unwrap(),
+            json!(true)
+        );
+        assert_eq!(
+            vm_query("$.user.has_key(\"phone\")", &doc).unwrap(),
+            json!(false)
+        );
     }
 
     #[test]

--- a/jetro-core/src/tests/regression.rs
+++ b/jetro-core/src/tests/regression.rs
@@ -2836,8 +2836,11 @@ mod tests {
     #[test]
     fn tier1_find_alias() {
         let doc = books();
-        let r = vm_query(r#"$.store.books.find(price > 10).map(title)"#, &doc).unwrap();
-        assert_eq!(r, json!(["Dune", "Neuromancer"]));
+        // `.find(pred)` now returns the first match (conventional
+        // first-match semantics). `.find_all(pred)` keeps the filter-alias
+        // semantics for the rest of the suite.
+        let r = vm_query(r#"$.store.books.find(price > 10)"#, &doc).unwrap();
+        assert_eq!(r["title"], json!("Dune"));
     }
 
     #[test]

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -691,6 +691,7 @@ impl VM {
                     stack.push(match key {
                         Val::Int(i) => v.get_index(i),
                         Val::Str(s) => v.get_field(s.as_ref()),
+                        Val::StrSlice(s) => v.get_field(s.as_str()),
                         _ => Val::Null,
                     });
                 }

--- a/jetro-core/src/vm/exec.rs
+++ b/jetro-core/src/vm/exec.rs
@@ -1037,8 +1037,22 @@ impl VM {
 
                 
                 Opcode::SetCurrent => {
-                    
-                    
+
+
+                }
+                Opcode::BindLamCurrent { name, body } => {
+                    // Bind `name` (when present) to the current item in a
+                    // local clone of `env`, run `body` under that env, then
+                    // pop the binding. Lets nested-lambda `LoadIdent(name)`
+                    // resolve to the outer iteration item even when the
+                    // host pipeline stage uses `swap_current` rather than
+                    // `push_lam` to advance.
+                    let mut scratch = env.clone();
+                    let frame = scratch
+                        .push_lam(name.as_deref(), env.current.clone());
+                    let result = self.exec(body, &scratch);
+                    scratch.pop_lam(frame);
+                    stack.push(result?);
                 }
                 Opcode::PipelineRun { base, steps } => {
                     let val = self.exec(base, env)?;
@@ -1352,8 +1366,11 @@ impl VM {
                 .sub_progs
                 .first()
                 .ok_or_else(|| EvalError(format!("{}: requires projection", call.name)))?;
+            // Single-param lambda body has been AST-substituted to the
+            // `@`-form opcode shape — name is unreferenced in `proj`,
+            // so push_lam can pass None and skip the var insert.
             let lam_param: Option<&str> = match call.orig_args.first() {
-                Some(Arg::Pos(Expr::Lambda { params, .. })) if !params.is_empty() => {
+                Some(Arg::Pos(Expr::Lambda { params, .. })) if params.len() >= 2 => {
                     Some(params[0].as_str())
                 }
                 _ => None,
@@ -1681,8 +1698,12 @@ impl VM {
         let no_op_kernel = crate::exec::pipeline::BodyKernel::Generic;
         let kernel0 = sub_kernel.unwrap_or(&no_op_kernel);
 
+        // Single-param lambda body has been AST-substituted; param name is
+        // unreferenced in the compiled body, so push_lam may use None to
+        // skip the var insert/remove. Only multi-param lambdas keep their
+        // first-param name (used for binary HOF binding pre-pair-binding).
         let lam_param: Option<&str> = match call.orig_args.first() {
-            Some(Arg::Pos(Expr::Lambda { params, .. })) if !params.is_empty() => {
+            Some(Arg::Pos(Expr::Lambda { params, .. })) if params.len() >= 2 => {
                 Some(params[0].as_str())
             }
             _ => None,
@@ -1751,10 +1772,12 @@ impl VM {
                         .orig_args
                         .get(idx)
                         .ok_or_else(|| EvalError("sort: missing key".into()))?;
+                    // Single-param lambdas are AST-substituted; param
+                    // name is unreferenced in the compiled body.
                     let lam_param = match arg {
                         Arg::Pos(Expr::Lambda { params, .. })
                         | Arg::Named(_, Expr::Lambda { params, .. })
-                            if !params.is_empty() =>
+                            if params.len() >= 2 =>
                         {
                             Some(params[0].as_str())
                         }
@@ -2206,15 +2229,19 @@ impl VM {
                         scratch.pop_lam(frame);
                         result
                     }
-                    [param] => {
-                        let frame = scratch.push_lam(Some(param), right.clone());
+                    [_param] => {
+                        // Single-param lambda body AST-substituted; name unused.
+                        let frame = scratch.push_lam(None, right.clone());
                         let result = self.exec(prog, &scratch);
                         scratch.pop_lam(frame);
                         result
                     }
-                    [left_name, right_name, ..] => {
+                    [left_name, _right_name, ..] => {
+                        // Multi-param fast path: rightmost param substituted
+                        // to `Current`; only earlier params keep their named
+                        // bindings.
                         let left_frame = scratch.push_lam(Some(left_name), left.clone());
-                        let right_frame = scratch.push_lam(Some(right_name), right.clone());
+                        let right_frame = scratch.push_lam(None, right.clone());
                         let result = self.exec(prog, &scratch);
                         scratch.pop_lam(right_frame);
                         scratch.pop_lam(left_frame);
@@ -2702,9 +2729,7 @@ impl VM {
     ) -> Result<Val, EvalError> {
         use crate::exec::pipeline::{eval_kernel, BodyKernel};
         // The kernel path treats `item` as `@` and resolves bare names
-        // as fields on it. That is only safe when:
-        //   - the lambda has no named parameter (the kernel always
-        //     reads `@`, not a per-call binding),
+        // as fields on it. Safe whenever:
         //   - the env has no let-bindings (otherwise a let-shadowed
         //     name would be silently rerouted to a field read), and
         //   - the program does not begin with `LoadIdent` — that
@@ -2712,12 +2737,17 @@ impl VM {
         //     value is array/string and the ident matches a builtin
         //     name (e.g. `.map(len)` invokes `len` as a builtin), a
         //     dispatch the kernel form drops on the floor.
+        //
+        // Single-param named lambdas have already been substituted to the
+        // same opcode shape as the equivalent `@`-form at compile time,
+        // so `lam_param` no longer gates the fast path. Multi-param and
+        // nested-ref-wrapped lambdas classify as `Generic` and naturally
+        // fall through.
         let starts_with_load_ident = matches!(
             prog.ops.first(),
             Some(crate::vm::Opcode::LoadIdent(_))
         );
-        if lam_param.is_none()
-            && scratch.has_no_vars()
+        if scratch.has_no_vars()
             && !starts_with_load_ident
             && !matches!(kernel, BodyKernel::Generic)
         {

--- a/jetro-core/src/vm/opcode.rs
+++ b/jetro-core/src/vm/opcode.rs
@@ -294,6 +294,22 @@ pub enum Opcode {
     /// consumed during compilation and stripped from the final program.
     SetCurrent,
 
+    /// Bind `@` (and optionally a named identifier) to the value already on
+    /// `env.current`, run `body` in that extended environment, and restore
+    /// the previous bindings on exit. Emitted by the AST-level lambda
+    /// lowering whenever a single-param lambda body — after `outer` →
+    /// `Current` substitution — still references `outer` from inside a
+    /// nested lambda. The wrapper makes `env.get_var(outer)` resolve to the
+    /// outer iteration item even when the host pipeline stage uses
+    /// `swap_current` rather than `push_lam` to advance per row.
+    BindLamCurrent {
+        /// Identifier bound to the current value for this scope (single-
+        /// param lambda parameter name); `None` for anonymous binding.
+        name: Option<Arc<str>>,
+        /// Lambda body program executed under the extended environment.
+        body: Arc<Program>,
+    },
+
     /// Evaluate `base`, then run each `CompiledPipeStep` in sequence, threading
     /// the current value and environment through the pipeline.
     PipelineRun {

--- a/jetro-core/tests/unsafe_invariants.rs
+++ b/jetro-core/tests/unsafe_invariants.rs
@@ -683,6 +683,8 @@ fn has_object_key() {
     let doc = json!({"name": "X", "age": 1});
     assert_eq!(q("$ has 'name'", &doc).unwrap(), json!(true));
     assert_eq!(q("$ has 'absent'", &doc).unwrap(), json!(false));
+    assert_eq!(q("$.has_key('name')", &doc).unwrap(), json!(true));
+    assert_eq!(q("$.has_key('absent')", &doc).unwrap(), json!(false));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

  - Adds AST-level lambda lowering so `r => r.id`, `lambda r: r.id`, and `@.id` share the same
  optimized execution shape.
  - Adds first-class let-bound lambda expansion for method/global-call arguments, e.g. `let f =
  (x => x * 2) in $.xs.map(f)`.
  - Extends demand-aware pipeline execution across predicate, membership, positional, arg-
  extreme, chunk/window/slice, and object-projection paths.
  - Adds `has_key` as an object-key-only builtin; `has` / `includes` remain broader membership
  checks.
  - Changes `.find(pred)` to first-match semantics; `.find_all(pred)` remains the all-matches/
  filter alias.
  - Bumps the crate version to `0.5.3` and updates release notes.

  ## Details

  - Adds `compile/lambda_lower.rs` for static lambda rewrites, including nested outer-param
  support through `Opcode::BindLamCurrent`.
  - Updates symbolic and physical planning so lambda-bearing pipelines preserve VM and engine
  semantics.
  - Adds view/tape-native object helpers for `keys`, `values`, `entries`, `pick`, `omit`, and
  `has_key`, avoiding unrelated materialization.
  - Expands sink demand handling for `first`, `last`, `nth`, `find_one`, predicate sinks,
  membership sinks, `indices_where`, `min_by` / `max_by`, and bounded positional sinks.
  - Fixes dynamic index handling for borrowed string keys from simd-json tape.
  - Adds regression coverage for lambda forms, dynamic index lambda behavior, `has_key`, and
  demand/view sink behavior.
