### PR TITLE
[feature] Impl opt-in query introspection APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.12
+
+### Release focus
+
+- _Unreleased._
+
 ## 0.5.11
 
 ### Release focus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,34 @@
 
 ### Release focus
 
-- _Unreleased._
+- **Opt-in query introspection**. Added explicit developer inspection APIs for
+  tracing how a query parses, lowers, plans, and selects execution metadata
+  without adding instrumentation to normal execution.
+
+### Introspection
+
+- Added `jetro_core::introspect` report types with structured, serde-friendly
+  output for summaries, logical shape, physical plans, pipeline stages, NDJSON
+  routing, row-stream plans, and direct execution hints.
+- Added `JetroEngine::inspect_query(...)` for static value/bytes inspection.
+- Added `JetroEngine::inspect_ndjson_query_with_options(...)` for static
+  NDJSON reader/file inspection with explicit source capabilities.
+- Physical plan inspection exports node ids, node kinds, child edges,
+  execution facts, backend preference order, selected first preference, and VM
+  fallback markers.
+- Pipeline inspection exports source, stages, sink, source demand, selected
+  physical execution path, and fallback/materialization boundary.
+- NDJSON inspection reuses the existing route and row-stream planners to report
+  route kind, source capabilities, writer path, row-stream direction, demand,
+  file strategy, stages, and sink.
+- Added `QueryInspection::format_tree()` for compact developer-facing output
+  while preserving structured report data as the primary API.
+
+### Maintenance
+
+- Kept introspection read-only and opt-in. Normal query execution does not
+  allocate or populate inspection reports.
+- Re-exported `introspect` from the facade crate.
 
 ## 0.5.11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "jetro"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "jetro-core",
  "serde_json",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "jetro-core"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["jetro-core/fuzz"]
 
 [package]
 name = "jetro"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 authors = ["Milad (Mike) Taghavi <mitghi.at.me.com>"]
 license = "MIT"
@@ -18,5 +18,5 @@ keywords = ["json-search", "json-query", "json-path", "jmespath", "serde"]
 categories = ["algorithms", "encoding"]
 
 [dependencies]
-jetro-core   = { path = "jetro-core", version = "0.5.11" }
+jetro-core   = { path = "jetro-core", version = "0.5.12" }
 serde_json   = "1.0.102"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ let report = jetro.collect(r#"
 
 ```toml
 [dependencies]
-jetro = "0.5.11"
+jetro = "0.5.12"
 ```
 
 ## Why Jetro?

--- a/jetro-core/Cargo.toml
+++ b/jetro-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jetro-core"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 authors = ["Milad (Mike) Taghavi <mitghi.at.me.com>"]
 license = "MIT"

--- a/jetro-core/src/introspect/inspect.rs
+++ b/jetro-core/src/introspect/inspect.rs
@@ -1,0 +1,176 @@
+use super::report::{
+    InspectContext, InspectLevel, InspectOptions, InspectionSummary, LogicalInspection,
+    QueryInspection,
+};
+use crate::io::{NdjsonOptions, NdjsonSourceMode};
+use crate::parse::ast::Expr;
+use crate::plan::physical::PlanningContext;
+use crate::{JetroEngine, JetroEngineError};
+
+pub(crate) fn inspect_query(
+    engine: &JetroEngine,
+    query: &str,
+    options: InspectOptions,
+    ndjson_options: NdjsonOptions,
+) -> Result<QueryInspection, JetroEngineError> {
+    let plan = engine.cached_plan(query, planning_context(options.context));
+    let (summary, physical) = super::physical::inspect_physical_plan(&plan);
+    let logical = (options.level != InspectLevel::Summary).then(|| inspect_logical(query));
+    let physical = matches!(options.level, InspectLevel::Plan | InspectLevel::Detailed)
+        .then_some(physical);
+    let pipeline = (options.level == InspectLevel::Detailed)
+        .then(|| super::pipeline::inspect_first_pipeline(&plan))
+        .flatten();
+    let ndjson = match options.context {
+        InspectContext::NdjsonReader if options.level == InspectLevel::Detailed => Some(
+            super::ndjson::inspect_ndjson_query(
+                engine,
+                query,
+                NdjsonSourceMode::Reader,
+                ndjson_options,
+            )?,
+        ),
+        InspectContext::NdjsonFile if options.level == InspectLevel::Detailed => Some(
+            super::ndjson::inspect_ndjson_query(
+                engine,
+                query,
+                NdjsonSourceMode::File,
+                ndjson_options,
+            )?,
+        ),
+        _ => None,
+    };
+
+    Ok(QueryInspection {
+        query: query.to_string(),
+        context: options.context,
+        level: options.level,
+        summary: summary_with_context(summary, options.context),
+        logical,
+        physical,
+        pipeline,
+        ndjson,
+        warnings: Vec::new(),
+    })
+}
+
+fn planning_context(context: InspectContext) -> PlanningContext {
+    match context {
+        InspectContext::Value => PlanningContext::val(),
+        InspectContext::Bytes | InspectContext::NdjsonReader | InspectContext::NdjsonFile => {
+            PlanningContext::bytes()
+        }
+    }
+}
+
+fn summary_with_context(
+    mut summary: InspectionSummary,
+    context: InspectContext,
+) -> InspectionSummary {
+    if matches!(context, InspectContext::NdjsonReader | InspectContext::NdjsonFile) {
+        summary.materializes_root = false;
+    }
+    summary
+}
+
+fn inspect_logical(query: &str) -> LogicalInspection {
+    match crate::parse::parser::parse(query) {
+        Ok(expr) => LogicalInspection {
+            ast_root: expr_label(&expr).to_string(),
+            root_shape: root_shape(&expr),
+            notes: Vec::new(),
+        },
+        Err(err) => LogicalInspection {
+            ast_root: "parse-error".to_string(),
+            root_shape: "source-vm".to_string(),
+            notes: vec![err.to_string()],
+        },
+    }
+}
+
+fn expr_label(expr: &Expr) -> &'static str {
+    match expr {
+        Expr::Null => "null",
+        Expr::Bool(_) => "bool",
+        Expr::Int(_) => "int",
+        Expr::Float(_) => "float",
+        Expr::Str(_) => "string",
+        Expr::FString(_) => "f-string",
+        Expr::Root => "root",
+        Expr::Current => "current",
+        Expr::Ident(_) => "ident",
+        Expr::Chain(_, _) => "chain",
+        Expr::BinOp(_, _, _) => "binary",
+        Expr::UnaryNeg(_) => "unary-neg",
+        Expr::Not(_) => "not",
+        Expr::Kind { .. } => "kind",
+        Expr::Coalesce(_, _) => "coalesce",
+        Expr::Object(_) => "object",
+        Expr::Array(_) => "array",
+        Expr::Pipeline { .. } => "pipeline",
+        Expr::ListComp { .. } => "list-comp",
+        Expr::DictComp { .. } => "dict-comp",
+        Expr::SetComp { .. } => "set-comp",
+        Expr::GenComp { .. } => "gen-comp",
+        Expr::Lambda { .. } => "lambda",
+        Expr::Let { .. } => "let",
+        Expr::IfElse { .. } => "if-else",
+        Expr::Try { .. } => "try",
+        Expr::GlobalCall { .. } => "global-call",
+        Expr::Cast { .. } => "cast",
+        Expr::Patch { .. } => "patch",
+        Expr::UpdateBatch { .. } => "update-batch",
+        Expr::DeleteMark => "delete-mark",
+        Expr::Match { .. } => "match",
+    }
+}
+
+fn root_shape(expr: &Expr) -> String {
+    match expr {
+        Expr::Chain(base, steps) => format!("{}+{} steps", expr_label(base), steps.len()),
+        Expr::Object(fields) => format!("object({} fields)", fields.len()),
+        Expr::Array(items) => format!("array({} items)", items.len()),
+        other => expr_label(other).to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::introspect::{InspectContext, InspectLevel, InspectOptions};
+
+    #[test]
+    fn inspect_query_assembles_static_plan_report() {
+        let engine = crate::JetroEngine::new();
+        let report = engine
+            .inspect_query(
+                "$.books.filter(price > 10).map(title)",
+                InspectOptions::detailed(InspectContext::Bytes),
+            )
+            .expect("inspection");
+
+        assert_eq!(report.level, InspectLevel::Detailed);
+        assert!(report.physical.is_some());
+        assert!(report.pipeline.is_some());
+        assert!(report.ndjson.is_none());
+    }
+
+    #[test]
+    fn public_ndjson_inspection_reports_rows_route() {
+        let engine = crate::JetroEngine::new();
+        let report = engine
+            .inspect_ndjson_query_with_options(
+                r#"$.rows().reverse().find(@.custom_attributes.find(@.value == "z"))"#,
+                crate::io::NdjsonSourceMode::File,
+                crate::io::NdjsonOptions::default(),
+                InspectLevel::Detailed,
+            )
+            .expect("inspection");
+
+        assert!(report.physical.is_some());
+        assert_eq!(
+            report.ndjson.as_ref().map(|ndjson| ndjson.route_kind.as_str()),
+            Some("rows-stream")
+        );
+        assert!(report.format_tree().contains("ordered-partition-search"));
+    }
+}

--- a/jetro-core/src/introspect/inspect.rs
+++ b/jetro-core/src/introspect/inspect.rs
@@ -16,28 +16,28 @@ pub(crate) fn inspect_query(
     let plan = engine.cached_plan(query, planning_context(options.context));
     let (summary, physical) = super::physical::inspect_physical_plan(&plan);
     let logical = (options.level != InspectLevel::Summary).then(|| inspect_logical(query));
-    let physical = matches!(options.level, InspectLevel::Plan | InspectLevel::Detailed)
-        .then_some(physical);
+    let physical =
+        matches!(options.level, InspectLevel::Plan | InspectLevel::Detailed).then_some(physical);
     let pipeline = (options.level == InspectLevel::Detailed)
         .then(|| super::pipeline::inspect_first_pipeline(&plan))
         .flatten();
     let ndjson = match options.context {
-        InspectContext::NdjsonReader if options.level == InspectLevel::Detailed => Some(
-            super::ndjson::inspect_ndjson_query(
+        InspectContext::NdjsonReader if options.level == InspectLevel::Detailed => {
+            Some(super::ndjson::inspect_ndjson_query(
                 engine,
                 query,
                 NdjsonSourceMode::Reader,
                 ndjson_options,
-            )?,
-        ),
-        InspectContext::NdjsonFile if options.level == InspectLevel::Detailed => Some(
-            super::ndjson::inspect_ndjson_query(
+            )?)
+        }
+        InspectContext::NdjsonFile if options.level == InspectLevel::Detailed => {
+            Some(super::ndjson::inspect_ndjson_query(
                 engine,
                 query,
                 NdjsonSourceMode::File,
                 ndjson_options,
-            )?,
-        ),
+            )?)
+        }
         _ => None,
     };
 
@@ -67,7 +67,10 @@ fn summary_with_context(
     mut summary: InspectionSummary,
     context: InspectContext,
 ) -> InspectionSummary {
-    if matches!(context, InspectContext::NdjsonReader | InspectContext::NdjsonFile) {
+    if matches!(
+        context,
+        InspectContext::NdjsonReader | InspectContext::NdjsonFile
+    ) {
         summary.materializes_root = false;
     }
     summary
@@ -168,7 +171,10 @@ mod tests {
 
         assert!(report.physical.is_some());
         assert_eq!(
-            report.ndjson.as_ref().map(|ndjson| ndjson.route_kind.as_str()),
+            report
+                .ndjson
+                .as_ref()
+                .map(|ndjson| ndjson.route_kind.as_str()),
             Some("rows-stream")
         );
         assert!(report.format_tree().contains("ordered-partition-search"));

--- a/jetro-core/src/introspect/mod.rs
+++ b/jetro-core/src/introspect/mod.rs
@@ -9,6 +9,8 @@ mod report;
 pub(crate) mod physical;
 #[allow(dead_code)]
 pub(crate) mod pipeline;
+#[allow(dead_code)]
+pub(crate) mod ndjson;
 
 pub use report::{
     BackendInspection, BackendKind, BackendStatus, DirectPlanInspection, ExecutionFactsInspection,

--- a/jetro-core/src/introspect/mod.rs
+++ b/jetro-core/src/introspect/mod.rs
@@ -5,6 +5,8 @@
 //! explicit inspection APIs.
 
 mod report;
+#[allow(dead_code)]
+pub(crate) mod physical;
 
 pub use report::{
     BackendInspection, BackendKind, BackendStatus, DirectPlanInspection, ExecutionFactsInspection,

--- a/jetro-core/src/introspect/mod.rs
+++ b/jetro-core/src/introspect/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod physical;
 pub(crate) mod pipeline;
 #[allow(dead_code)]
 pub(crate) mod ndjson;
+mod render;
 
 pub use report::{
     BackendInspection, BackendKind, BackendStatus, DirectPlanInspection, ExecutionFactsInspection,

--- a/jetro-core/src/introspect/mod.rs
+++ b/jetro-core/src/introspect/mod.rs
@@ -1,0 +1,14 @@
+//! Opt-in query introspection.
+//!
+//! This module is deliberately read-only. Normal query execution does not
+//! allocate or populate these structures; callers receive them only through
+//! explicit inspection APIs.
+
+mod report;
+
+pub use report::{
+    BackendInspection, BackendKind, BackendStatus, DirectPlanInspection, ExecutionFactsInspection,
+    InspectContext, InspectLevel, InspectOptions, InspectionSummary, LogicalInspection,
+    NdjsonInspection, PhysicalInspection, PhysicalNodeInspection, PipelineInspection,
+    PipelineStageInspection, QueryInspection, RowStreamInspection,
+};

--- a/jetro-core/src/introspect/mod.rs
+++ b/jetro-core/src/introspect/mod.rs
@@ -7,6 +7,8 @@
 mod report;
 #[allow(dead_code)]
 pub(crate) mod physical;
+#[allow(dead_code)]
+pub(crate) mod pipeline;
 
 pub use report::{
     BackendInspection, BackendKind, BackendStatus, DirectPlanInspection, ExecutionFactsInspection,

--- a/jetro-core/src/introspect/mod.rs
+++ b/jetro-core/src/introspect/mod.rs
@@ -4,15 +4,14 @@
 //! allocate or populate these structures; callers receive them only through
 //! explicit inspection APIs.
 
+mod inspect;
 mod report;
-#[allow(dead_code)]
 pub(crate) mod physical;
-#[allow(dead_code)]
 pub(crate) mod pipeline;
-#[allow(dead_code)]
 pub(crate) mod ndjson;
 mod render;
 
+pub(crate) use inspect::inspect_query;
 pub use report::{
     BackendInspection, BackendKind, BackendStatus, DirectPlanInspection, ExecutionFactsInspection,
     InspectContext, InspectLevel, InspectOptions, InspectionSummary, LogicalInspection,

--- a/jetro-core/src/introspect/mod.rs
+++ b/jetro-core/src/introspect/mod.rs
@@ -5,11 +5,11 @@
 //! explicit inspection APIs.
 
 mod inspect;
-mod report;
+pub(crate) mod ndjson;
 pub(crate) mod physical;
 pub(crate) mod pipeline;
-pub(crate) mod ndjson;
 mod render;
+mod report;
 
 pub(crate) use inspect::inspect_query;
 pub use report::{

--- a/jetro-core/src/introspect/ndjson.rs
+++ b/jetro-core/src/introspect/ndjson.rs
@@ -1,0 +1,178 @@
+use super::report::{DirectPlanInspection, NdjsonInspection, RowStreamInspection};
+use crate::io::{
+    ndjson_route_plan, ndjson_writer_path_kind, NdjsonOptions, NdjsonRoutePlan, NdjsonSourceMode,
+};
+use crate::{JetroEngine, JetroEngineError};
+
+pub(crate) fn inspect_ndjson_query(
+    engine: &JetroEngine,
+    query: &str,
+    source: NdjsonSourceMode,
+    options: NdjsonOptions,
+) -> Result<NdjsonInspection, JetroEngineError> {
+    let route = ndjson_route_plan(engine, source, query, options)?;
+    let explain = route.explain().clone();
+    let rows = match &route {
+        NdjsonRoutePlan::Rows {
+            plan: crate::io::NdjsonRowsFilePlan::Stream(plan),
+            ..
+        } => Some(inspect_row_stream(plan, explain.source.partitionable)),
+        _ => None,
+    };
+    let mut direct_plans = Vec::new();
+    if let Some(kind) = ndjson_writer_path_kind(engine, query) {
+        direct_plans.push(DirectPlanInspection {
+            kind: format!("writer:{kind}"),
+            detail: None,
+        });
+    }
+
+    Ok(NdjsonInspection {
+        route_kind: explain.kind.to_string(),
+        source: explain.source.to_string(),
+        fallback_reason: explain.fallback_reason.map(|reason| reason.to_string()),
+        writer_path: explain.writer_path.map(|kind| kind.to_string()),
+        rows,
+        direct_plans,
+    })
+}
+
+fn inspect_row_stream(
+    plan: &crate::io::RowStreamPlan,
+    partition_available: bool,
+) -> RowStreamInspection {
+    RowStreamInspection {
+        plan_kind: "stream".to_string(),
+        source: row_source_label(plan.source).to_string(),
+        direction: row_direction_label(plan.direction).to_string(),
+        demand: row_demand_label(&plan.demand),
+        file_strategy: Some(file_strategy_label(plan.file_strategy(partition_available))),
+        stages: plan
+            .stages
+            .iter()
+            .enumerate()
+            .map(|(index, stage)| row_stage_inspection(index, stage))
+            .collect(),
+        sink: row_sink_label(&plan.stages).to_string(),
+    }
+}
+
+fn row_stage_inspection(
+    index: usize,
+    stage: &crate::io::RowStreamStage,
+) -> super::report::PipelineStageInspection {
+    let (kind, detail) = match stage {
+        crate::io::RowStreamStage::Filter(_) => ("filter", None),
+        crate::io::RowStreamStage::DistinctBy(_) => ("distinct-by", None),
+        crate::io::RowStreamStage::Take(n) => ("take", Some(n.to_string())),
+        crate::io::RowStreamStage::Map(_) => ("map", None),
+        crate::io::RowStreamStage::Last => ("last", None),
+        crate::io::RowStreamStage::Count => ("count", None),
+        crate::io::RowStreamStage::Sum => ("sum", None),
+        crate::io::RowStreamStage::Avg => ("avg", None),
+        crate::io::RowStreamStage::Min => ("min", None),
+        crate::io::RowStreamStage::Max => ("max", None),
+        crate::io::RowStreamStage::Any(_) => ("any", None),
+        crate::io::RowStreamStage::All(_) => ("all", None),
+    };
+    super::report::PipelineStageInspection {
+        index,
+        kind: kind.to_string(),
+        detail,
+    }
+}
+
+fn row_source_label(source: crate::io::RowStreamSourceKind) -> &'static str {
+    match source {
+        crate::io::RowStreamSourceKind::DocumentRows => "document-rows",
+        crate::io::RowStreamSourceKind::NdjsonRows => "ndjson-rows",
+    }
+}
+
+fn row_direction_label(direction: crate::io::RowStreamDirection) -> &'static str {
+    match direction {
+        crate::io::RowStreamDirection::Forward => "forward",
+        crate::io::RowStreamDirection::Reverse => "reverse",
+    }
+}
+
+fn row_demand_label(demand: &crate::io::RowStreamDemand) -> String {
+    format!(
+        "retained={:?}, scalar={}, predicates={}, keys={}, projectors={}, ordered_early_stop={}, parallel={}",
+        demand.retained_limit,
+        demand.scalar_output,
+        demand.predicate_count,
+        demand.key_count,
+        demand.projector_count,
+        demand.ordered_early_stop,
+        row_parallel_label(demand.parallel),
+    )
+}
+
+fn row_parallel_label(parallel: crate::io::RowStreamParallelism) -> String {
+    match parallel {
+        crate::io::RowStreamParallelism::Sequential => "sequential".to_string(),
+        crate::io::RowStreamParallelism::PartitionFilter {
+            retained_limit,
+            direction,
+        } => format!(
+            "partition-filter(retained={retained_limit:?}, direction={})",
+            row_direction_label(direction)
+        ),
+    }
+}
+
+fn file_strategy_label(strategy: crate::io::RowStreamFileStrategy) -> String {
+    match strategy {
+        crate::io::RowStreamFileStrategy::Sequential => "sequential".to_string(),
+        crate::io::RowStreamFileStrategy::Partitioned { retained_limit } => {
+            format!("partitioned(retained={retained_limit})")
+        }
+        crate::io::RowStreamFileStrategy::OrderedPartitionSearch {
+            direction,
+            retained_limit,
+        } => format!(
+            "ordered-partition-search(direction={}, retained={retained_limit})",
+            row_direction_label(direction)
+        ),
+    }
+}
+
+fn row_sink_label(stages: &[crate::io::RowStreamStage]) -> &'static str {
+    match stages.last() {
+        Some(crate::io::RowStreamStage::Take(_)) => "take",
+        Some(crate::io::RowStreamStage::Map(_)) => "collect",
+        Some(crate::io::RowStreamStage::Last) => "last",
+        Some(crate::io::RowStreamStage::Count) => "count",
+        Some(crate::io::RowStreamStage::Sum) => "sum",
+        Some(crate::io::RowStreamStage::Avg) => "avg",
+        Some(crate::io::RowStreamStage::Min) => "min",
+        Some(crate::io::RowStreamStage::Max) => "max",
+        Some(crate::io::RowStreamStage::Any(_)) => "any",
+        Some(crate::io::RowStreamStage::All(_)) => "all",
+        _ => "collect",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ndjson_inspection_exports_ordered_reverse_row_stream() {
+        let engine = crate::JetroEngine::new();
+        let inspection = super::inspect_ndjson_query(
+            &engine,
+            r#"$.rows().reverse().find(@.custom_attributes.find(@.value == "z"))"#,
+            crate::io::NdjsonSourceMode::File,
+            crate::io::NdjsonOptions::default(),
+        )
+        .expect("inspect");
+
+        assert_eq!(inspection.route_kind, "rows-stream");
+        let rows = inspection.rows.expect("row stream");
+        assert_eq!(rows.direction, "reverse");
+        assert_eq!(
+            rows.file_strategy,
+            Some("ordered-partition-search(direction=reverse, retained=1)".to_string())
+        );
+    }
+}

--- a/jetro-core/src/introspect/physical.rs
+++ b/jetro-core/src/introspect/physical.rs
@@ -1,0 +1,248 @@
+use super::report::{
+    BackendInspection, BackendKind, BackendStatus, ExecutionFactsInspection, InspectionSummary,
+    PhysicalInspection, PhysicalNodeInspection,
+};
+use crate::ir::physical::{
+    BackendPreference, ExecutionFacts, NodeId, PhysicalArrayElem, PhysicalObjField, PlanNode,
+    QueryPlan, QueryRoot,
+};
+
+pub(crate) fn inspect_physical_plan(plan: &QueryPlan) -> (InspectionSummary, PhysicalInspection) {
+    let root = root_label(plan.root());
+    let summary_facts = root_facts(plan);
+    let selected_executor = match plan.root() {
+        QueryRoot::Node(root) => plan
+            .backend_preferences(*root)
+            .first()
+            .copied()
+            .map(backend_kind),
+        QueryRoot::SourceVm(_) => Some(BackendKind::Vm),
+    };
+    let summary = InspectionSummary {
+        root: root.clone(),
+        selected_executor,
+        materializes_root: !summary_facts.can_avoid_root_materialization,
+        contains_vm_fallback: summary_facts.contains_vm_fallback,
+        can_run_byte_native: summary_facts.is_byte_native(),
+    };
+    let nodes = plan
+        .node_ids()
+        .map(|id| inspect_node(plan, id))
+        .collect::<Vec<_>>();
+    (summary, PhysicalInspection { root, nodes })
+}
+
+fn root_label(root: &QueryRoot) -> String {
+    match root {
+        QueryRoot::Node(id) => format!("node:{}", id.0),
+        QueryRoot::SourceVm(_) => "source-vm".to_string(),
+    }
+}
+
+fn root_facts(plan: &QueryPlan) -> ExecutionFacts {
+    match plan.root() {
+        QueryRoot::Node(root) => plan.execution_facts(*root),
+        QueryRoot::SourceVm(_) => ExecutionFacts {
+            contains_vm_fallback: true,
+            ..ExecutionFacts::default()
+        },
+    }
+}
+
+fn inspect_node(plan: &QueryPlan, id: NodeId) -> PhysicalNodeInspection {
+    let node = plan.node(id);
+    PhysicalNodeInspection {
+        id: id.0,
+        kind: node_kind(node).to_string(),
+        children: node_children(node).into_iter().map(|id| id.0).collect(),
+        facts: facts_inspection(plan.execution_facts(id)),
+        backends: inspect_backends(plan.backend_preferences(id)),
+        detail: node_detail(node),
+    }
+}
+
+fn facts_inspection(facts: ExecutionFacts) -> ExecutionFactsInspection {
+    ExecutionFactsInspection {
+        can_avoid_root_materialization: facts.can_avoid_root_materialization,
+        contains_vm_fallback: facts.contains_vm_fallback,
+        can_run_byte_native: facts.is_byte_native(),
+    }
+}
+
+fn inspect_backends(backends: &[BackendPreference]) -> Vec<BackendInspection> {
+    backends
+        .iter()
+        .enumerate()
+        .map(|(index, backend)| BackendInspection {
+            backend: backend_kind(*backend),
+            status: if index == 0 {
+                BackendStatus::Selected
+            } else if *backend == BackendPreference::Interpreted {
+                BackendStatus::Fallback
+            } else {
+                BackendStatus::Planned
+            },
+            reason: None,
+        })
+        .collect()
+}
+
+fn backend_kind(backend: BackendPreference) -> BackendKind {
+    match backend {
+        BackendPreference::Structural => BackendKind::StructuralIndex,
+        BackendPreference::TapeView => BackendKind::ViewPipeline,
+        BackendPreference::TapeRows => BackendKind::TapeRows,
+        BackendPreference::TapePath => BackendKind::TapePath,
+        BackendPreference::ValView => BackendKind::ValView,
+        BackendPreference::MaterializedSource => BackendKind::MaterializedSource,
+        BackendPreference::FastChildren => BackendKind::FastChildren,
+        BackendPreference::Interpreted => BackendKind::Interpreted,
+    }
+}
+
+fn node_kind(node: &PlanNode) -> &'static str {
+    match node {
+        PlanNode::Literal(_) => "literal",
+        PlanNode::Root => "root",
+        PlanNode::Current => "current",
+        PlanNode::Ident(_) => "ident",
+        PlanNode::Local(_) => "local",
+        PlanNode::Pipeline { .. } => "pipeline",
+        PlanNode::Structural { .. } => "structural",
+        PlanNode::RootPath(_) => "root-path",
+        PlanNode::Chain { .. } => "chain",
+        PlanNode::Call { .. } => "call",
+        PlanNode::UnaryNeg(_) => "unary-neg",
+        PlanNode::Not(_) => "not",
+        PlanNode::Binary { .. } => "binary",
+        PlanNode::Kind { .. } => "kind",
+        PlanNode::Coalesce { .. } => "coalesce",
+        PlanNode::IfElse { .. } => "if-else",
+        PlanNode::Try { .. } => "try",
+        PlanNode::Object(_) => "object",
+        PlanNode::Array(_) => "array",
+        PlanNode::Let { .. } => "let",
+        PlanNode::UpdateBatch { .. } => "update-batch",
+        PlanNode::Vm(_) => "vm",
+    }
+}
+
+fn node_detail(node: &PlanNode) -> Option<String> {
+    match node {
+        PlanNode::Ident(name) | PlanNode::Local(name) => Some(name.to_string()),
+        PlanNode::Pipeline { source, body } => Some(format!(
+            "source={}, stages={}, sink={}",
+            pipeline_source_label(source),
+            body.stages.len(),
+            pipeline_sink_label(&body.sink)
+        )),
+        PlanNode::RootPath(steps) => Some(format!("steps={}", steps.len())),
+        PlanNode::Chain { steps, .. } => Some(format!("steps={}", steps.len())),
+        PlanNode::Call { call, optional, .. } => {
+            Some(format!("method={:?}, optional={optional}", call.method))
+        }
+        PlanNode::Binary { op, .. } => Some(format!("op={op:?}")),
+        PlanNode::Kind { ty, negate, .. } => Some(format!("kind={ty:?}, negate={negate}")),
+        PlanNode::Object(fields) => Some(format!("fields={}", fields.len())),
+        PlanNode::Array(items) => Some(format!("items={}", items.len())),
+        PlanNode::Let { name, .. } => Some(format!("name={name}")),
+        PlanNode::UpdateBatch { selector, ops, .. } => {
+            Some(format!("selector_steps={}, ops={}", selector.len(), ops.len()))
+        }
+        _ => None,
+    }
+}
+
+fn pipeline_source_label(source: &crate::ir::physical::PipelinePlanSource) -> String {
+    match source {
+        crate::ir::physical::PipelinePlanSource::FieldChain { keys } => {
+            format!("field-chain({})", keys.len())
+        }
+        crate::ir::physical::PipelinePlanSource::Expr(id) => format!("expr:{}", id.0),
+    }
+}
+
+fn pipeline_sink_label(sink: &crate::exec::pipeline::Sink) -> &'static str {
+    match sink {
+        crate::exec::pipeline::Sink::Collect => "collect",
+        crate::exec::pipeline::Sink::Nth(_) => "nth",
+        crate::exec::pipeline::Sink::Reducer(_) => "reducer",
+        crate::exec::pipeline::Sink::Terminal(_) => "terminal",
+        crate::exec::pipeline::Sink::SelectMany { .. } => "select-many",
+        crate::exec::pipeline::Sink::Membership(_) => "membership",
+        crate::exec::pipeline::Sink::ArgExtreme(_) => "arg-extreme",
+        crate::exec::pipeline::Sink::Predicate(_) => "predicate",
+        crate::exec::pipeline::Sink::ApproxCountDistinct => "approx-count-distinct",
+    }
+}
+
+fn node_children(node: &PlanNode) -> Vec<NodeId> {
+    match node {
+        PlanNode::Chain { base, .. } => vec![*base],
+        PlanNode::Call { receiver, .. } => vec![*receiver],
+        PlanNode::UnaryNeg(inner) | PlanNode::Not(inner) | PlanNode::Kind { expr: inner, .. } => {
+            vec![*inner]
+        }
+        PlanNode::Binary { lhs, rhs, .. } | PlanNode::Coalesce { lhs, rhs } => vec![*lhs, *rhs],
+        PlanNode::IfElse { cond, then_, else_ } => vec![*cond, *then_, *else_],
+        PlanNode::Try { body, default } => vec![*body, *default],
+        PlanNode::Object(fields) => object_children(fields),
+        PlanNode::Array(items) => array_children(items),
+        PlanNode::Let { init, body, .. } => vec![*init, *body],
+        PlanNode::Pipeline {
+            source: crate::ir::physical::PipelinePlanSource::Expr(source),
+            ..
+        } => vec![*source],
+        PlanNode::UpdateBatch { root, .. } => vec![*root],
+        _ => Vec::new(),
+    }
+}
+
+fn object_children(fields: &[PhysicalObjField]) -> Vec<NodeId> {
+    let mut out = Vec::new();
+    for field in fields {
+        match field {
+            PhysicalObjField::Kv { val, cond, .. } => {
+                out.push(*val);
+                if let Some(cond) = cond {
+                    out.push(*cond);
+                }
+            }
+            PhysicalObjField::Short(_) => {}
+            PhysicalObjField::Dynamic { key, val } => {
+                out.push(*key);
+                out.push(*val);
+            }
+            PhysicalObjField::Spread(expr) => out.push(*expr),
+            PhysicalObjField::SpreadDeep(expr) => out.push(*expr),
+        }
+    }
+    out
+}
+
+fn array_children(items: &[PhysicalArrayElem]) -> Vec<NodeId> {
+    items
+        .iter()
+        .map(|item| match item {
+            PhysicalArrayElem::Expr(id) | PhysicalArrayElem::Spread(id) => *id,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn physical_inspection_exports_nodes_and_backend_preferences() {
+        let plan = crate::plan::physical::plan_query_with_context(
+            "$.books.filter(price > 10).map(title)",
+            crate::plan::physical::PlanningContext::bytes(),
+        );
+
+        let (summary, physical) = super::inspect_physical_plan(&plan);
+
+        assert!(!physical.nodes.is_empty());
+        assert!(physical.nodes.iter().any(|node| node.kind == "pipeline"));
+        assert!(physical.nodes.iter().any(|node| !node.backends.is_empty()));
+        assert!(summary.selected_executor.is_some());
+    }
+}

--- a/jetro-core/src/introspect/physical.rs
+++ b/jetro-core/src/introspect/physical.rs
@@ -146,9 +146,11 @@ fn node_detail(node: &PlanNode) -> Option<String> {
         PlanNode::Object(fields) => Some(format!("fields={}", fields.len())),
         PlanNode::Array(items) => Some(format!("items={}", items.len())),
         PlanNode::Let { name, .. } => Some(format!("name={name}")),
-        PlanNode::UpdateBatch { selector, ops, .. } => {
-            Some(format!("selector_steps={}, ops={}", selector.len(), ops.len()))
-        }
+        PlanNode::UpdateBatch { selector, ops, .. } => Some(format!(
+            "selector_steps={}, ops={}",
+            selector.len(),
+            ops.len()
+        )),
         _ => None,
     }
 }

--- a/jetro-core/src/introspect/pipeline.rs
+++ b/jetro-core/src/introspect/pipeline.rs
@@ -1,5 +1,5 @@
 use super::report::{PipelineInspection, PipelineStageInspection};
-use crate::exec::pipeline::{FallbackBoundary, PipelineBody, PhysicalExecPath, Sink, Stage};
+use crate::exec::pipeline::{FallbackBoundary, PhysicalExecPath, PipelineBody, Sink, Stage};
 use crate::ir::physical::{PipelinePlanSource, PlanNode, QueryPlan};
 
 pub(crate) fn inspect_first_pipeline(plan: &QueryPlan) -> Option<PipelineInspection> {
@@ -115,10 +115,9 @@ fn stage_label(stage: &Stage) -> (&'static str, Option<String>) {
         Stage::UsizeBuiltin { method, value } => {
             ("builtin-usize", Some(format!("{method:?}({value})")))
         }
-        Stage::StringBuiltin { method, value } => (
-            "builtin-string",
-            Some(format!("{method:?}({value:?})")),
-        ),
+        Stage::StringBuiltin { method, value } => {
+            ("builtin-string", Some(format!("{method:?}({value:?})")))
+        }
         Stage::StringPairBuiltin {
             method,
             first,

--- a/jetro-core/src/introspect/pipeline.rs
+++ b/jetro-core/src/introspect/pipeline.rs
@@ -1,0 +1,174 @@
+use super::report::{PipelineInspection, PipelineStageInspection};
+use crate::exec::pipeline::{FallbackBoundary, PipelineBody, PhysicalExecPath, Sink, Stage};
+use crate::ir::physical::{PipelinePlanSource, PlanNode, QueryPlan};
+
+pub(crate) fn inspect_first_pipeline(plan: &QueryPlan) -> Option<PipelineInspection> {
+    plan.node_ids().find_map(|id| {
+        let PlanNode::Pipeline { source, body } = plan.node(id) else {
+            return None;
+        };
+        Some(inspect_pipeline(source, body))
+    })
+}
+
+pub(crate) fn inspect_pipeline(
+    source: &PipelinePlanSource,
+    body: &PipelineBody,
+) -> PipelineInspection {
+    let exec_path = crate::exec::pipeline::select_exec_path(&body.stages, &body.sink);
+    let fallback_boundary =
+        crate::exec::pipeline::Pipeline::fallback_boundary_for(&body.stages, exec_path);
+    PipelineInspection {
+        source: source_label(source),
+        stages: body
+            .stages
+            .iter()
+            .enumerate()
+            .map(|(index, stage)| inspect_stage(index, stage))
+            .collect(),
+        sink: sink_label(&body.sink).to_string(),
+        source_demand: format!("{:?}", body.source_demand().chain.pull),
+        fallback_boundary: fallback_boundary_label(fallback_boundary),
+        execution_path: Some(exec_path_label(exec_path).to_string()),
+    }
+}
+
+pub(crate) fn source_label(source: &PipelinePlanSource) -> String {
+    match source {
+        PipelinePlanSource::FieldChain { keys } => {
+            let joined = keys
+                .iter()
+                .map(|key| key.as_ref())
+                .collect::<Vec<_>>()
+                .join(".");
+            if joined.is_empty() {
+                "field-chain:$".to_string()
+            } else {
+                format!("field-chain:$.{joined}")
+            }
+        }
+        PipelinePlanSource::Expr(id) => format!("expr:{}", id.0),
+    }
+}
+
+pub(crate) fn inspect_stage(index: usize, stage: &Stage) -> PipelineStageInspection {
+    let (kind, detail) = stage_label(stage);
+    PipelineStageInspection {
+        index,
+        kind: kind.to_string(),
+        detail,
+    }
+}
+
+pub(crate) fn sink_label(sink: &Sink) -> &'static str {
+    match sink {
+        Sink::Collect => "collect",
+        Sink::Reducer(spec) => match spec.op {
+            crate::exec::pipeline::ReducerOp::Count => "count",
+            crate::exec::pipeline::ReducerOp::Numeric(crate::exec::pipeline::NumOp::Sum) => "sum",
+            crate::exec::pipeline::ReducerOp::Numeric(crate::exec::pipeline::NumOp::Min) => "min",
+            crate::exec::pipeline::ReducerOp::Numeric(crate::exec::pipeline::NumOp::Max) => "max",
+            crate::exec::pipeline::ReducerOp::Numeric(crate::exec::pipeline::NumOp::Avg) => "avg",
+        },
+        Sink::Predicate(spec) => match spec.op {
+            crate::exec::pipeline::PredicateSinkOp::Any => "any",
+            crate::exec::pipeline::PredicateSinkOp::All => "all",
+            crate::exec::pipeline::PredicateSinkOp::FindIndex => "find-index",
+            crate::exec::pipeline::PredicateSinkOp::IndicesWhere => "indices-where",
+            crate::exec::pipeline::PredicateSinkOp::FindOne => "find-one",
+        },
+        Sink::Membership(_) => "membership",
+        Sink::ArgExtreme(spec) => {
+            if spec.want_max {
+                "max-by"
+            } else {
+                "min-by"
+            }
+        }
+        Sink::Terminal(_) => "terminal",
+        Sink::SelectMany { from_end: true, .. } => "take-last",
+        Sink::SelectMany {
+            from_end: false, ..
+        } => "take",
+        Sink::Nth(_) => "nth",
+        Sink::ApproxCountDistinct => "approx-count-distinct",
+    }
+}
+
+fn stage_label(stage: &Stage) -> (&'static str, Option<String>) {
+    match stage {
+        Stage::Filter(_, view) => ("filter", Some(format!("view={view:?}"))),
+        Stage::Map(_, view) => ("map", Some(format!("view={view:?}"))),
+        Stage::FlatMap(_, view) => ("flat-map", Some(format!("view={view:?}"))),
+        Stage::Reverse(_) => ("reverse", None),
+        Stage::UniqueBy(Some(_)) => ("unique-by", Some("keyed".to_string())),
+        Stage::UniqueBy(None) => ("unique", None),
+        Stage::Sort(spec) => (
+            "sort",
+            Some(format!(
+                "descending={}, keyed={}",
+                spec.descending,
+                spec.key.is_some()
+            )),
+        ),
+        Stage::Builtin(call) => ("builtin", Some(format!("{:?}", call.method))),
+        Stage::UsizeBuiltin { method, value } => {
+            ("builtin-usize", Some(format!("{method:?}({value})")))
+        }
+        Stage::StringBuiltin { method, value } => (
+            "builtin-string",
+            Some(format!("{method:?}({value:?})")),
+        ),
+        Stage::StringPairBuiltin {
+            method,
+            first,
+            second,
+        } => (
+            "builtin-string-pair",
+            Some(format!("{method:?}({first:?}, {second:?})")),
+        ),
+        Stage::IntRangeBuiltin { method, start, end } => (
+            "builtin-range",
+            Some(format!("{method:?}({start}, {end:?})")),
+        ),
+        Stage::CompiledMap(_) => ("compiled-map", None),
+        Stage::ExprBuiltin { method, .. } => ("expr-builtin", Some(format!("{method:?}"))),
+        Stage::SortedDedup(Some(_)) => ("sorted-dedup", Some("keyed".to_string())),
+        Stage::SortedDedup(None) => ("sorted-dedup", None),
+    }
+}
+
+fn fallback_boundary_label(boundary: FallbackBoundary) -> Option<String> {
+    match boundary {
+        FallbackBoundary::None => None,
+        FallbackBoundary::LegacyStage { index } => Some(format!("legacy-stage:{index}")),
+        FallbackBoundary::MaterializedExecution => Some("materialized-execution".to_string()),
+    }
+}
+
+fn exec_path_label(path: PhysicalExecPath) -> &'static str {
+    match path {
+        PhysicalExecPath::Indexed => "indexed",
+        PhysicalExecPath::Columnar => "columnar",
+        PhysicalExecPath::Composed => "composed",
+        PhysicalExecPath::Legacy => "legacy",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn pipeline_inspection_exports_stage_sink_and_demand() {
+        let plan = crate::plan::physical::plan_query_with_context(
+            "$.books.filter(price > 10).take(2).map(title)",
+            crate::plan::physical::PlanningContext::bytes(),
+        );
+
+        let pipeline = super::inspect_first_pipeline(&plan).expect("pipeline");
+
+        assert_eq!(pipeline.source, "field-chain:$.books");
+        assert!(!pipeline.stages.is_empty());
+        assert!(!pipeline.sink.is_empty());
+        assert!(!pipeline.source_demand.is_empty());
+    }
+}

--- a/jetro-core/src/introspect/render.rs
+++ b/jetro-core/src/introspect/render.rs
@@ -1,0 +1,173 @@
+use super::report::QueryInspection;
+use std::fmt::Write;
+
+impl QueryInspection {
+    /// Renders the inspection as a compact tree for humans.
+    pub fn format_tree(&self) -> String {
+        let mut out = String::new();
+        let _ = writeln!(out, "query:");
+        let _ = writeln!(out, "  {}", self.query);
+        let _ = writeln!(out, "context:");
+        let _ = writeln!(out, "  {:?} / {:?}", self.context, self.level);
+        let _ = writeln!(out, "summary:");
+        let _ = writeln!(out, "  root: {}", self.summary.root);
+        let _ = writeln!(
+            out,
+            "  selected executor: {}",
+            self.summary
+                .selected_executor
+                .map(|backend| format!("{backend:?}"))
+                .unwrap_or_else(|| "unknown".to_string())
+        );
+        let _ = writeln!(
+            out,
+            "  materializes root: {}",
+            self.summary.materializes_root
+        );
+        let _ = writeln!(
+            out,
+            "  contains vm fallback: {}",
+            self.summary.contains_vm_fallback
+        );
+        let _ = writeln!(
+            out,
+            "  byte native: {}",
+            self.summary.can_run_byte_native
+        );
+
+        if let Some(logical) = &self.logical {
+            let _ = writeln!(out, "logical:");
+            let _ = writeln!(out, "  ast root: {}", logical.ast_root);
+            let _ = writeln!(out, "  root shape: {}", logical.root_shape);
+            for note in &logical.notes {
+                let _ = writeln!(out, "  note: {note}");
+            }
+        }
+
+        if let Some(physical) = &self.physical {
+            let _ = writeln!(out, "physical:");
+            let _ = writeln!(out, "  root: {}", physical.root);
+            for node in &physical.nodes {
+                let _ = writeln!(out, "  node {}: {}", node.id, node.kind);
+                if !node.children.is_empty() {
+                    let _ = writeln!(out, "    children: {:?}", node.children);
+                }
+                if let Some(detail) = &node.detail {
+                    let _ = writeln!(out, "    detail: {detail}");
+                }
+                let _ = writeln!(
+                    out,
+                    "    facts: byte_native={}, avoid_root_materialization={}, vm_fallback={}",
+                    node.facts.can_run_byte_native,
+                    node.facts.can_avoid_root_materialization,
+                    node.facts.contains_vm_fallback
+                );
+                if !node.backends.is_empty() {
+                    let backends = node
+                        .backends
+                        .iter()
+                        .map(|backend| format!("{:?}:{:?}", backend.backend, backend.status))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let _ = writeln!(out, "    backends: {backends}");
+                }
+            }
+        }
+
+        if let Some(pipeline) = &self.pipeline {
+            let _ = writeln!(out, "pipeline:");
+            let _ = writeln!(out, "  source: {}", pipeline.source);
+            let _ = writeln!(out, "  demand: {}", pipeline.source_demand);
+            let _ = writeln!(out, "  sink: {}", pipeline.sink);
+            if let Some(path) = &pipeline.execution_path {
+                let _ = writeln!(out, "  execution path: {path}");
+            }
+            if let Some(boundary) = &pipeline.fallback_boundary {
+                let _ = writeln!(out, "  fallback boundary: {boundary}");
+            }
+            for stage in &pipeline.stages {
+                let _ = writeln!(out, "  stage {}: {}", stage.index, stage.kind);
+                if let Some(detail) = &stage.detail {
+                    let _ = writeln!(out, "    {detail}");
+                }
+            }
+        }
+
+        if let Some(ndjson) = &self.ndjson {
+            let _ = writeln!(out, "ndjson:");
+            let _ = writeln!(out, "  route: {}", ndjson.route_kind);
+            let _ = writeln!(out, "  source: {}", ndjson.source);
+            if let Some(reason) = &ndjson.fallback_reason {
+                let _ = writeln!(out, "  fallback: {reason}");
+            }
+            if let Some(path) = &ndjson.writer_path {
+                let _ = writeln!(out, "  writer path: {path}");
+            }
+            if let Some(rows) = &ndjson.rows {
+                let _ = writeln!(out, "  rows:");
+                let _ = writeln!(out, "    plan: {}", rows.plan_kind);
+                let _ = writeln!(out, "    source: {}", rows.source);
+                let _ = writeln!(out, "    direction: {}", rows.direction);
+                let _ = writeln!(out, "    demand: {}", rows.demand);
+                if let Some(strategy) = &rows.file_strategy {
+                    let _ = writeln!(out, "    file strategy: {strategy}");
+                }
+                let _ = writeln!(out, "    sink: {}", rows.sink);
+                for stage in &rows.stages {
+                    let _ = writeln!(out, "    stage {}: {}", stage.index, stage.kind);
+                    if let Some(detail) = &stage.detail {
+                        let _ = writeln!(out, "      {detail}");
+                    }
+                }
+            }
+            for plan in &ndjson.direct_plans {
+                let _ = writeln!(out, "  direct: {}", plan.kind);
+                if let Some(detail) = &plan.detail {
+                    let _ = writeln!(out, "    {detail}");
+                }
+            }
+        }
+
+        if !self.warnings.is_empty() {
+            let _ = writeln!(out, "warnings:");
+            for warning in &self.warnings {
+                let _ = writeln!(out, "  {warning}");
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::introspect::{
+        BackendKind, InspectContext, InspectLevel, InspectionSummary, QueryInspection,
+    };
+
+    #[test]
+    fn tree_renderer_includes_key_sections() {
+        let report = QueryInspection {
+            query: "$.a".to_string(),
+            context: InspectContext::Bytes,
+            level: InspectLevel::Plan,
+            summary: InspectionSummary {
+                root: "node:0".to_string(),
+                selected_executor: Some(BackendKind::TapePath),
+                materializes_root: false,
+                contains_vm_fallback: false,
+                can_run_byte_native: true,
+            },
+            logical: None,
+            physical: None,
+            pipeline: None,
+            ndjson: None,
+            warnings: Vec::new(),
+        };
+
+        let text = report.format_tree();
+
+        assert!(text.contains("query:"));
+        assert!(text.contains("summary:"));
+        assert!(text.contains("TapePath"));
+    }
+}

--- a/jetro-core/src/introspect/render.rs
+++ b/jetro-core/src/introspect/render.rs
@@ -29,11 +29,7 @@ impl QueryInspection {
             "  contains vm fallback: {}",
             self.summary.contains_vm_fallback
         );
-        let _ = writeln!(
-            out,
-            "  byte native: {}",
-            self.summary.can_run_byte_native
-        );
+        let _ = writeln!(out, "  byte native: {}", self.summary.can_run_byte_native);
 
         if let Some(logical) = &self.logical {
             let _ = writeln!(out, "logical:");

--- a/jetro-core/src/introspect/report.rs
+++ b/jetro-core/src/introspect/report.rs
@@ -154,6 +154,7 @@ pub struct PipelineInspection {
     pub source: String,
     pub stages: Vec<PipelineStageInspection>,
     pub sink: String,
+    pub source_demand: String,
     pub fallback_boundary: Option<String>,
     pub execution_path: Option<String>,
 }

--- a/jetro-core/src/introspect/report.rs
+++ b/jetro-core/src/introspect/report.rs
@@ -1,0 +1,189 @@
+use serde::{Deserialize, Serialize};
+
+/// How much data an explicit inspection call should collect.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum InspectLevel {
+    /// Cheap high-level labels.
+    Summary,
+    /// Adds the physical plan DAG and execution facts.
+    Plan,
+    /// Adds lowering, pipeline, NDJSON, and direct-plan details.
+    Detailed,
+}
+
+/// Planning context used for static inspection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum InspectContext {
+    /// Normal value-domain planning.
+    Value,
+    /// Byte/tape-domain planning for byte-backed documents.
+    Bytes,
+    /// NDJSON reader capabilities.
+    NdjsonReader,
+    /// NDJSON file capabilities.
+    NdjsonFile,
+}
+
+/// Options for explicit query inspection.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct InspectOptions {
+    pub level: InspectLevel,
+    pub context: InspectContext,
+}
+
+impl InspectOptions {
+    pub fn summary(context: InspectContext) -> Self {
+        Self {
+            level: InspectLevel::Summary,
+            context,
+        }
+    }
+
+    pub fn plan(context: InspectContext) -> Self {
+        Self {
+            level: InspectLevel::Plan,
+            context,
+        }
+    }
+
+    pub fn detailed(context: InspectContext) -> Self {
+        Self {
+            level: InspectLevel::Detailed,
+            context,
+        }
+    }
+}
+
+impl Default for InspectOptions {
+    fn default() -> Self {
+        Self::plan(InspectContext::Value)
+    }
+}
+
+/// Complete static inspection report for a query.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct QueryInspection {
+    pub query: String,
+    pub context: InspectContext,
+    pub level: InspectLevel,
+    pub summary: InspectionSummary,
+    pub logical: Option<LogicalInspection>,
+    pub physical: Option<PhysicalInspection>,
+    pub pipeline: Option<PipelineInspection>,
+    pub ndjson: Option<NdjsonInspection>,
+    pub warnings: Vec<String>,
+}
+
+/// One-screen summary for quick developer checks.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct InspectionSummary {
+    pub root: String,
+    pub selected_executor: Option<BackendKind>,
+    pub materializes_root: bool,
+    pub contains_vm_fallback: bool,
+    pub can_run_byte_native: bool,
+}
+
+/// Logical/lowering details that are useful before physical execution.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LogicalInspection {
+    pub ast_root: String,
+    pub root_shape: String,
+    pub notes: Vec<String>,
+}
+
+/// Physical DAG exported from the real `QueryPlan`.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PhysicalInspection {
+    pub root: String,
+    pub nodes: Vec<PhysicalNodeInspection>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PhysicalNodeInspection {
+    pub id: usize,
+    pub kind: String,
+    pub children: Vec<usize>,
+    pub facts: ExecutionFactsInspection,
+    pub backends: Vec<BackendInspection>,
+    pub detail: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionFactsInspection {
+    pub can_avoid_root_materialization: bool,
+    pub contains_vm_fallback: bool,
+    pub can_run_byte_native: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BackendInspection {
+    pub backend: BackendKind,
+    pub status: BackendStatus,
+    pub reason: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum BackendKind {
+    ByteNative,
+    StructuralIndex,
+    ViewPipeline,
+    Pipeline,
+    Interpreted,
+    Vm,
+    NdjsonRows,
+    NdjsonRowLocal,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum BackendStatus {
+    Planned,
+    Selected,
+    Fallback,
+    Rejected,
+}
+
+/// Pipeline lowering summary.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PipelineInspection {
+    pub source: String,
+    pub stages: Vec<PipelineStageInspection>,
+    pub sink: String,
+    pub fallback_boundary: Option<String>,
+    pub execution_path: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PipelineStageInspection {
+    pub index: usize,
+    pub kind: String,
+    pub detail: Option<String>,
+}
+
+/// NDJSON-specific static route and row-stream details.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NdjsonInspection {
+    pub route_kind: String,
+    pub source: String,
+    pub fallback_reason: Option<String>,
+    pub writer_path: Option<String>,
+    pub rows: Option<RowStreamInspection>,
+    pub direct_plans: Vec<DirectPlanInspection>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RowStreamInspection {
+    pub plan_kind: String,
+    pub source: String,
+    pub direction: String,
+    pub demand: String,
+    pub file_strategy: Option<String>,
+    pub stages: Vec<PipelineStageInspection>,
+    pub sink: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DirectPlanInspection {
+    pub kind: String,
+    pub detail: Option<String>,
+}

--- a/jetro-core/src/introspect/report.rs
+++ b/jetro-core/src/introspect/report.rs
@@ -127,7 +127,12 @@ pub struct BackendInspection {
 pub enum BackendKind {
     ByteNative,
     StructuralIndex,
+    TapePath,
     ViewPipeline,
+    TapeRows,
+    ValView,
+    MaterializedSource,
+    FastChildren,
     Pipeline,
     Interpreted,
     Vm,

--- a/jetro-core/src/io/mod.rs
+++ b/jetro-core/src/io/mod.rs
@@ -75,8 +75,14 @@ pub use ndjson_route::{
     ndjson_explain, NdjsonExecutionReport, NdjsonExecutionStats, NdjsonFallbackReason,
     NdjsonRouteExplain, NdjsonRouteKind, NdjsonSourceCaps, NdjsonSourceMode,
 };
+pub(crate) use ndjson_route::{ndjson_route_plan, NdjsonRoutePlan};
 pub use ndjson_rows::{ndjson_rows_plan_kind, NdjsonRowsPlanKind};
+pub(crate) use ndjson_rows::NdjsonRowsFilePlan;
 pub use source::NdjsonSource;
+pub(crate) use stream_plan::{
+    RowStreamDemand, RowStreamDirection, RowStreamFileStrategy, RowStreamParallelism,
+    RowStreamPlan, RowStreamSourceKind, RowStreamStage,
+};
 use std::fmt;
 
 /// Error with enough row context for users to find malformed input quickly.

--- a/jetro-core/src/io/mod.rs
+++ b/jetro-core/src/io/mod.rs
@@ -8,8 +8,8 @@ mod mapped_bytes;
 mod ndjson;
 mod ndjson_byte;
 mod ndjson_direct;
-mod ndjson_driver;
 mod ndjson_distinct;
+mod ndjson_driver;
 mod ndjson_frame;
 mod ndjson_hint;
 mod ndjson_parallel;
@@ -40,8 +40,8 @@ pub use ndjson::{
     for_each_ndjson_source_until, for_each_ndjson_source_until_with_options,
     for_each_ndjson_source_with_options, for_each_ndjson_until, for_each_ndjson_until_with_options,
     for_each_ndjson_with_options, ndjson_writer_path_kind, run_ndjson, run_ndjson_file,
-    run_ndjson_file_limit, run_ndjson_file_limit_with_options, run_ndjson_file_with_options,
-    run_ndjson_file_limit_with_report, run_ndjson_file_limit_with_report_and_options,
+    run_ndjson_file_limit, run_ndjson_file_limit_with_options, run_ndjson_file_limit_with_report,
+    run_ndjson_file_limit_with_report_and_options, run_ndjson_file_with_options,
     run_ndjson_file_with_report, run_ndjson_file_with_report_and_options, run_ndjson_limit,
     run_ndjson_limit_with_options, run_ndjson_limit_with_report,
     run_ndjson_limit_with_report_and_options, run_ndjson_matches, run_ndjson_matches_file,
@@ -49,16 +49,16 @@ pub use ndjson::{
     run_ndjson_matches_file_with_report_and_options, run_ndjson_matches_source,
     run_ndjson_matches_source_with_options, run_ndjson_matches_source_with_report,
     run_ndjson_matches_source_with_report_and_options, run_ndjson_matches_with_options,
-    run_ndjson_source,
-    run_ndjson_matches_with_report, run_ndjson_matches_with_report_and_options,
-    run_ndjson_source_limit, run_ndjson_source_limit_with_options, run_ndjson_source_with_options,
+    run_ndjson_matches_with_report, run_ndjson_matches_with_report_and_options, run_ndjson_source,
+    run_ndjson_source_limit, run_ndjson_source_limit_with_options,
     run_ndjson_source_limit_with_report, run_ndjson_source_limit_with_report_and_options,
-    run_ndjson_source_with_report, run_ndjson_source_with_report_and_options,
-    run_ndjson_with_options, run_ndjson_with_report, run_ndjson_with_report_and_options,
-    NdjsonControl, NdjsonNullOutput, NdjsonOptions, NdjsonParallelism, NdjsonWriterPathKind,
+    run_ndjson_source_with_options, run_ndjson_source_with_report,
+    run_ndjson_source_with_report_and_options, run_ndjson_with_options, run_ndjson_with_report,
+    run_ndjson_with_report_and_options, NdjsonControl, NdjsonNullOutput, NdjsonOptions,
+    NdjsonParallelism, NdjsonWriterPathKind,
 };
-pub use ndjson_driver::NdjsonPerRowDriver;
 pub use ndjson_distinct::DistinctFrontFilterKind;
+pub use ndjson_driver::NdjsonPerRowDriver;
 pub use ndjson_frame::{NdjsonRowFrame, NullPayload};
 pub use ndjson_rev::{
     collect_ndjson_rev, collect_ndjson_rev_matches, collect_ndjson_rev_matches_with_options,
@@ -76,14 +76,14 @@ pub use ndjson_route::{
     NdjsonRouteExplain, NdjsonRouteKind, NdjsonSourceCaps, NdjsonSourceMode,
 };
 pub(crate) use ndjson_route::{ndjson_route_plan, NdjsonRoutePlan};
-pub use ndjson_rows::{ndjson_rows_plan_kind, NdjsonRowsPlanKind};
 pub(crate) use ndjson_rows::NdjsonRowsFilePlan;
+pub use ndjson_rows::{ndjson_rows_plan_kind, NdjsonRowsPlanKind};
 pub use source::NdjsonSource;
+use std::fmt;
 pub(crate) use stream_plan::{
     RowStreamDemand, RowStreamDirection, RowStreamFileStrategy, RowStreamParallelism,
     RowStreamPlan, RowStreamSourceKind, RowStreamStage,
 };
-use std::fmt;
 
 /// Error with enough row context for users to find malformed input quickly.
 #[derive(Debug)]

--- a/jetro-core/src/io/ndjson_route.rs
+++ b/jetro-core/src/io/ndjson_route.rs
@@ -210,7 +210,6 @@ impl NdjsonRoutePlan {
             | Self::Unsupported { explain } => explain,
         }
     }
-
 }
 
 impl NdjsonRouteExplain {
@@ -367,8 +366,7 @@ mod tests {
     #[test]
     fn route_explain_marks_reader_rows_fanout_unsupported() {
         let engine = JetroEngine::new();
-        let query =
-            r#"let stream = $.rows(), a = stream.take(1), b = stream.count() in {a, b}"#;
+        let query = r#"let stream = $.rows(), a = stream.take(1), b = stream.count() in {a, b}"#;
 
         let reader = ndjson_explain(
             &engine,

--- a/jetro-core/src/io/ndjson_route.rs
+++ b/jetro-core/src/io/ndjson_route.rs
@@ -189,7 +189,7 @@ impl NdjsonExecutionReport {
     }
 }
 
-pub(super) enum NdjsonRoutePlan {
+pub(crate) enum NdjsonRoutePlan {
     RowLocal {
         explain: NdjsonRouteExplain,
     },
@@ -203,7 +203,7 @@ pub(super) enum NdjsonRoutePlan {
 }
 
 impl NdjsonRoutePlan {
-    pub(super) fn explain(&self) -> &NdjsonRouteExplain {
+    pub(crate) fn explain(&self) -> &NdjsonRouteExplain {
         match self {
             Self::RowLocal { explain }
             | Self::Rows { explain, .. }
@@ -244,7 +244,7 @@ impl NdjsonRouteExplain {
     }
 }
 
-pub(super) fn ndjson_route_plan(
+pub(crate) fn ndjson_route_plan(
     engine: &JetroEngine,
     source: NdjsonSourceMode,
     query: &str,

--- a/jetro-core/src/io/ndjson_rows.rs
+++ b/jetro-core/src/io/ndjson_rows.rs
@@ -3,14 +3,14 @@ use super::stream_plan::{lower_root_rows_query, RowStreamPlan, RowStreamSourceKi
 use super::stream_subquery::{lower_single_rows_subquery, RowStreamSubqueryPlan};
 use crate::{EvalError, JetroEngineError};
 
-pub(super) enum NdjsonRowsFilePlan {
+pub(crate) enum NdjsonRowsFilePlan {
     Stream(RowStreamPlan),
     Fanout(RowStreamFanoutPlan),
     Subquery(RowStreamSubqueryPlan),
 }
 
 impl NdjsonRowsFilePlan {
-    pub(super) fn kind(&self) -> NdjsonRowsPlanKind {
+    pub(crate) fn kind(&self) -> NdjsonRowsPlanKind {
         match self {
             Self::Stream(_) => NdjsonRowsPlanKind::Stream,
             Self::Fanout(_) => NdjsonRowsPlanKind::Fanout,
@@ -18,7 +18,7 @@ impl NdjsonRowsFilePlan {
         }
     }
 
-    pub(super) fn requires_file_backed_source(&self) -> bool {
+    pub(crate) fn requires_file_backed_source(&self) -> bool {
         matches!(self, Self::Fanout(_) | Self::Subquery(_))
     }
 }
@@ -44,14 +44,14 @@ pub fn ndjson_rows_plan_kind(query: &str) -> Result<Option<NdjsonRowsPlanKind>, 
     Ok(ndjson_rows_file_plan(query)?.map(|plan| plan.kind()))
 }
 
-pub(super) fn ndjson_rows_stream_plan(
+pub(crate) fn ndjson_rows_stream_plan(
     query: &str,
 ) -> Result<Option<RowStreamPlan>, JetroEngineError> {
     lower_root_rows_query(query, RowStreamSourceKind::NdjsonRows)
         .map_err(|err| JetroEngineError::Eval(EvalError(err.to_string())))
 }
 
-pub(super) fn ndjson_rows_file_plan(
+pub(crate) fn ndjson_rows_file_plan(
     query: &str,
 ) -> Result<Option<NdjsonRowsFilePlan>, JetroEngineError> {
     if let Some(plan) = ndjson_rows_stream_plan(query)? {

--- a/jetro-core/src/io/stream_fanout.rs
+++ b/jetro-core/src/io/stream_fanout.rs
@@ -469,7 +469,8 @@ where
     P: AsRef<std::path::Path>,
     W: Write,
 {
-    let (value, mut stats) = collect_ndjson_rows_fanout_file_with_stats(engine, path, plan, options)?;
+    let (value, mut stats) =
+        collect_ndjson_rows_fanout_file_with_stats(engine, path, plan, options)?;
     let mut writer = ndjson_writer_with_options(writer, options);
     let emitted = write_val_line_with_options(&mut writer, &value, options)? as usize;
     stats.rows_emitted = emitted;

--- a/jetro-core/src/io/stream_fanout.rs
+++ b/jetro-core/src/io/stream_fanout.rs
@@ -33,7 +33,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
-pub(super) struct RowStreamFanoutPlan {
+pub(crate) struct RowStreamFanoutPlan {
     pub source: RowStreamPlan,
     consumers: Vec<RowStreamFanoutConsumer>,
     body: Expr,

--- a/jetro-core/src/io/stream_plan.rs
+++ b/jetro-core/src/io/stream_plan.rs
@@ -119,7 +119,9 @@ pub(crate) enum RowStreamParallelism {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RowStreamFileStrategy {
     Sequential,
-    Partitioned { retained_limit: usize },
+    Partitioned {
+        retained_limit: usize,
+    },
     OrderedPartitionSearch {
         direction: RowStreamDirection,
         retained_limit: usize,

--- a/jetro-core/src/io/stream_plan.rs
+++ b/jetro-core/src/io/stream_plan.rs
@@ -10,13 +10,13 @@ use crate::parse::ast::{Arg, Expr, Step};
 use std::fmt;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum RowStreamSourceKind {
+pub(crate) enum RowStreamSourceKind {
     DocumentRows,
     NdjsonRows,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum RowStreamDirection {
+pub(crate) enum RowStreamDirection {
     Forward,
     Reverse,
 }
@@ -28,7 +28,7 @@ impl Default for RowStreamDirection {
 }
 
 #[derive(Clone, Debug)]
-pub(super) struct RowStreamPlan {
+pub(crate) struct RowStreamPlan {
     pub source: RowStreamSourceKind,
     pub direction: RowStreamDirection,
     pub stages: Vec<RowStreamStage>,
@@ -51,7 +51,7 @@ impl RowStreamPlan {
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub(super) struct RowStreamDemand {
+pub(crate) struct RowStreamDemand {
     pub retained_limit: Option<usize>,
     pub scalar_output: bool,
     pub predicate_count: usize,
@@ -63,7 +63,7 @@ pub(super) struct RowStreamDemand {
 }
 
 #[derive(Clone, Debug)]
-pub(super) enum RowStreamStage {
+pub(crate) enum RowStreamStage {
     Filter(Expr),
     DistinctBy(Expr),
     Take(usize),
@@ -107,7 +107,7 @@ impl RowStreamStage {
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) enum RowStreamParallelism {
+pub(crate) enum RowStreamParallelism {
     #[default]
     Sequential,
     PartitionFilter {
@@ -117,7 +117,7 @@ pub(super) enum RowStreamParallelism {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum RowStreamFileStrategy {
+pub(crate) enum RowStreamFileStrategy {
     Sequential,
     Partitioned { retained_limit: usize },
     OrderedPartitionSearch {
@@ -127,7 +127,7 @@ pub(super) enum RowStreamFileStrategy {
 }
 
 impl RowStreamPlan {
-    pub(super) fn file_strategy(&self, partition_available: bool) -> RowStreamFileStrategy {
+    pub(crate) fn file_strategy(&self, partition_available: bool) -> RowStreamFileStrategy {
         if partition_available {
             if let Some(retained_limit) = self.ordered_partition_retained_limit() {
                 return RowStreamFileStrategy::OrderedPartitionSearch {

--- a/jetro-core/src/io/stream_subquery.rs
+++ b/jetro-core/src/io/stream_subquery.rs
@@ -7,7 +7,7 @@ use crate::parse::ast::{
 pub(super) const STREAM_BINDING: &str = "__jetro_rows_stream_0";
 
 #[derive(Clone, Debug)]
-pub(super) struct RowStreamSubqueryPlan {
+pub(crate) struct RowStreamSubqueryPlan {
     pub stream: RowStreamPlan,
     pub wrapper: Expr,
 }

--- a/jetro-core/src/io/stream_subquery.rs
+++ b/jetro-core/src/io/stream_subquery.rs
@@ -1,8 +1,8 @@
-use super::stream_plan::{lower_root_rows_expr, RowStreamPlan, RowStreamPlanError, RowStreamSourceKind};
-use crate::builtins::BuiltinMethod;
-use crate::parse::ast::{
-    Arg, ArrayElem, Expr, FStringPart, MatchArm, ObjField, Step,
+use super::stream_plan::{
+    lower_root_rows_expr, RowStreamPlan, RowStreamPlanError, RowStreamSourceKind,
 };
+use crate::builtins::BuiltinMethod;
+use crate::parse::ast::{Arg, ArrayElem, Expr, FStringPart, MatchArm, ObjField, Step};
 
 pub(super) const STREAM_BINDING: &str = "__jetro_rows_stream_0";
 
@@ -185,21 +185,23 @@ fn replace_steps(
         .iter()
         .map(|step| {
             Ok(match step {
-                crate::parse::ast::Step::DynIndex(expr) => {
-                    crate::parse::ast::Step::DynIndex(Box::new(replace_rows_expr(
-                        expr, source, lifted,
-                    )?))
-                }
+                crate::parse::ast::Step::DynIndex(expr) => crate::parse::ast::Step::DynIndex(
+                    Box::new(replace_rows_expr(expr, source, lifted)?),
+                ),
                 crate::parse::ast::Step::InlineFilter(expr) => {
                     crate::parse::ast::Step::InlineFilter(Box::new(replace_rows_expr(
                         expr, source, lifted,
                     )?))
                 }
-                crate::parse::ast::Step::Method(name, args) => {
-                    crate::parse::ast::Step::Method(name.clone(), replace_args(args, source, lifted)?)
-                }
+                crate::parse::ast::Step::Method(name, args) => crate::parse::ast::Step::Method(
+                    name.clone(),
+                    replace_args(args, source, lifted)?,
+                ),
                 crate::parse::ast::Step::OptMethod(name, args) => {
-                    crate::parse::ast::Step::OptMethod(name.clone(), replace_args(args, source, lifted)?)
+                    crate::parse::ast::Step::OptMethod(
+                        name.clone(),
+                        replace_args(args, source, lifted)?,
+                    )
                 }
                 _ => step.clone(),
             })

--- a/jetro-core/src/ir/physical.rs
+++ b/jetro-core/src/ir/physical.rs
@@ -65,6 +65,13 @@ impl QueryPlan {
         &self.nodes[id.0].kind
     }
 
+    /// Returns every physical node id in arena order.
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn node_ids(&self) -> impl Iterator<Item = NodeId> + '_ {
+        (0..self.nodes.len()).map(NodeId)
+    }
+
     /// Returns the ordered backend preference slice for node `id` as set by the planner.
     #[inline]
     pub(crate) fn backend_preferences(&self, id: NodeId) -> &[BackendPreference] {

--- a/jetro-core/src/ir/physical.rs
+++ b/jetro-core/src/ir/physical.rs
@@ -67,7 +67,6 @@ impl QueryPlan {
 
     /// Returns every physical node id in arena order.
     #[inline]
-    #[allow(dead_code)]
     pub(crate) fn node_ids(&self) -> impl Iterator<Item = NodeId> + '_ {
         (0..self.nodes.len()).map(NodeId)
     }

--- a/jetro-core/src/ir/physical.rs
+++ b/jetro-core/src/ir/physical.rs
@@ -101,7 +101,6 @@ impl QueryPlan {
             },
         }
     }
-
 }
 
 /// Selects the execution entry point for a `QueryPlan`.

--- a/jetro-core/src/lib.rs
+++ b/jetro-core/src/lib.rs
@@ -800,9 +800,7 @@ impl JetroEngine {
         P: AsRef<std::path::Path>,
         W: std::io::Write,
     {
-        io::run_ndjson_rev_distinct_by_with_report(
-            self, path, key_query, query, limit, writer,
-        )
+        io::run_ndjson_rev_distinct_by_with_report(self, path, key_query, query, limit, writer)
     }
 
     /// Like [`JetroEngine::run_ndjson_rev_distinct_by_with_report`] with explicit options.

--- a/jetro-core/src/lib.rs
+++ b/jetro-core/src/lib.rs
@@ -246,6 +246,38 @@ impl JetroEngine {
     /// Default maximum plan-cache size; the cache is cleared wholesale when reached.
     const DEFAULT_PLAN_CACHE_LIMIT: usize = 256;
 
+    /// Inspect how a query parses, plans, and selects execution metadata.
+    ///
+    /// This is an explicit developer API. Normal query execution does not
+    /// allocate or populate introspection reports.
+    pub fn inspect_query(
+        &self,
+        query: &str,
+        options: introspect::InspectOptions,
+    ) -> std::result::Result<introspect::QueryInspection, JetroEngineError> {
+        introspect::inspect_query(self, query, options, io::NdjsonOptions::default())
+    }
+
+    /// Inspect an NDJSON query with explicit NDJSON source options.
+    pub fn inspect_ndjson_query_with_options(
+        &self,
+        query: &str,
+        source: io::NdjsonSourceMode,
+        ndjson_options: io::NdjsonOptions,
+        level: introspect::InspectLevel,
+    ) -> std::result::Result<introspect::QueryInspection, JetroEngineError> {
+        let context = match source {
+            io::NdjsonSourceMode::Reader => introspect::InspectContext::NdjsonReader,
+            io::NdjsonSourceMode::File => introspect::InspectContext::NdjsonFile,
+        };
+        introspect::inspect_query(
+            self,
+            query,
+            introspect::InspectOptions { level, context },
+            ndjson_options,
+        )
+    }
+
     /// Create a `JetroEngine` with the default plan-cache limit of 256 entries.
     pub fn new() -> Self {
         Self::with_plan_cache_limit(Self::DEFAULT_PLAN_CACHE_LIMIT)

--- a/jetro-core/src/lib.rs
+++ b/jetro-core/src/lib.rs
@@ -57,6 +57,7 @@ pub(crate) mod builtins;
 pub(crate) mod compile;
 pub(crate) mod data;
 pub(crate) mod exec;
+pub mod introspect;
 pub mod io;
 pub(crate) mod ir;
 pub(crate) mod parse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! provides the byte-oriented `Jetro` handle plus `JetroEngine` for long-lived
 //! plan/VM reuse and NDJSON processing.
 
-pub use jetro_core::{io, EvalError, JetroEngine, JetroEngineError};
+pub use jetro_core::{introspect, io, EvalError, JetroEngine, JetroEngineError};
 
 /// Byte-oriented query handle. Wraps `jetro_core::Jetro` and exposes document
 /// parsing plus query collection.

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,8 +1,9 @@
 use jetro::{
+    introspect::{InspectContext, InspectOptions},
     io::{
         ndjson_explain, ndjson_rows_plan_kind, ndjson_writer_path_kind, DistinctFrontFilterKind,
-        NdjsonFallbackReason, NdjsonRouteKind, NdjsonRowsPlanKind, NdjsonSource,
-        NdjsonSourceMode, NdjsonWriterPathKind, NdjsonOptions, NdjsonRowFrame, NullPayload,
+        NdjsonFallbackReason, NdjsonOptions, NdjsonRouteKind, NdjsonRowFrame, NdjsonRowsPlanKind,
+        NdjsonSource, NdjsonSourceMode, NdjsonWriterPathKind, NullPayload,
     },
     JetroEngine,
 };
@@ -55,6 +56,21 @@ fn facade_exposes_ndjson_route_observability() {
     .unwrap();
     assert!(framed.source.framed_payload);
     assert!(framed.source.to_string().contains("framed-payload"));
+}
+
+#[test]
+fn facade_exposes_query_introspection_api() {
+    let engine = JetroEngine::new();
+    let report = engine
+        .inspect_query(
+            "$.items.filter(price > 10).map(name)",
+            InspectOptions::detailed(InspectContext::Bytes),
+        )
+        .expect("facade introspection API should run");
+
+    assert!(report.physical.is_some());
+    assert!(report.pipeline.is_some());
+    assert!(report.format_tree().contains("pipeline:"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

  Implements opt-in query introspection to Jetro 0.5.12 so developers can inspect how a
  query lowers, plans, and selects executors without adding overhead to normal execution.

  ## Changes

  - Bumped Jetro and `jetro-core` to `0.5.12`.
  - Added the `jetro_core::introspect` module with structured inspection report types.
  - Added `JetroEngine::inspect_query(...)` for normal value/byte-backed query inspection.
  - Added `JetroEngine::inspect_ndjson_query_with_options(...)` for NDJSON route inspection.
  - Re-exported `introspect` from the public `jetro` facade.
  - Added physical-plan inspection with node ids, children, execution facts, and backend
  preferences.
  - Added pipeline inspection with source, stages, sink, demand, fallback boundary, and execution
  path.
  - Added NDJSON inspection with route kind, source mode, row-stream plan, demand, file strategy,
  stages, sink, and direct writer path details.
  - Added `QueryInspection::format_tree()` for compact human-readable diagnostics.
  - Updated the changelog under the new `0.5.12` section.

  ## Notes

  Inspection is explicit only. Normal query execution does not allocate or populate inspection
  reports.